### PR TITLE
fix(sensor): HA 2026.7.3 validation + dead code cleanup

### DIFF
--- a/custom_components/vaillant_ebus/backend/entity_factory.py
+++ b/custom_components/vaillant_ebus/backend/entity_factory.py
@@ -135,9 +135,6 @@ def _classify_register(
         if register.writable:
             return "switch"
         return "binary_sensor"
-    if not _is_numeric(raw_value) and ";" not in raw_value:
-        pass
-
     if register.writable and _is_numeric(raw_value):
         meta_min = meta.min_value
         meta_max = meta.max_value

--- a/custom_components/vaillant_ebus/sensor.py
+++ b/custom_components/vaillant_ebus/sensor.py
@@ -71,7 +71,7 @@ class EbusdSensor(CoordinatorEntity[VaillantCoordinator], SensorEntity):
         try:
             return float(raw)
         except (ValueError, TypeError):
-            if self._attr_native_unit_of_measurement:
+            if getattr(self, '_attr_native_unit_of_measurement', None):
                 return None
             return str(raw)
 

--- a/custom_components/vaillant_ebus/sensor.py
+++ b/custom_components/vaillant_ebus/sensor.py
@@ -64,7 +64,6 @@ class EbusdSensor(CoordinatorEntity[VaillantCoordinator], SensorEntity):
 
     @property
     def native_value(self) -> float | str | None:
-        # Return parsed numeric or string value, None for empty/unavailable
         data = self.coordinator.data.get("ebusd", {})
         raw = data.get(self._desc.key)
         if raw is None or raw in ("-", "no data stored", "empty"):
@@ -72,6 +71,8 @@ class EbusdSensor(CoordinatorEntity[VaillantCoordinator], SensorEntity):
         try:
             return float(raw)
         except (ValueError, TypeError):
+            if self._attr_native_unit_of_measurement:
+                return None
             return str(raw)
 
     @property


### PR DESCRIPTION
## Summary

Missed by previous squash merge — sensor.py fixes for HA 2026.7.3 strict validation and dead code removal.

## Changes

- **sensor.py**: Return `None` for non-numeric string values when unit is set; safe `getattr` for optional `_attr_native_unit_of_measurement`
- **entity_factory.py**: Remove dead `pass` block in `_classify_register`

The zone circuit + name suffix/prefix fixes in `entity_factory.py` from the same commits were already applied by the earlier squash merge.
