### PR TITLE
ci: add pytest-asyncio dependency for async tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           python-version: "3.14"
 
       - name: Install dependencies
-        run: pip install ruff pytest
+        run: pip install ruff pytest pytest-asyncio
 
       - name: Lint
         run: ruff check .
@@ -47,7 +47,7 @@ jobs:
           python-version: "3.14"
 
       - name: Install dependencies
-        run: pip install ruff pytest
+        run: pip install ruff pytest pytest-asyncio
 
       - name: Lint
         run: ruff check .


### PR DESCRIPTION
Tests fail on CI because pytest-asyncio is not installed. Fixes 20 failing async tests.