### PR TITLE
v1.1.1: ;ok suffix fix + BASV2 support + dynamic circuit type detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.1.1 - 2026-07-28
+
+- Fix: register values with ebusd status suffix (`;ok`, `;err`, etc.)
+  now strip the suffix instead of showing as unavailable. Affects
+  ebusd 26.x where read/find responses include a `;ok` status marker.
+  Stripped at TCP input boundary (`_parse_find_line`, `async_read`)
+  with safety net in `_values_from_registers`.
+
 ## 1.1.0 - 2026-07-28
 
 ### Config flow — major rewrite

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,42 @@
 
 ## 1.1.1 - 2026-07-28
 
-- Fix: register values with ebusd status suffix (`;ok`, `;err`, etc.)
-  now strip the suffix instead of showing as unavailable. Affects
-  ebusd 26.x where read/find responses include a `;ok` status marker.
-  Stripped at TCP input boundary (`_parse_find_line`, `async_read`)
-  with safety net in `_values_from_registers`.
+### Fix: ebusd status suffix on register values
+
+- Register values with ebusd status suffix (`;ok`, `;err`, `;inv`, `;too_small`,
+  `;too_big`, `;nan`, `;unknown`) now strip the suffix at the TCP input boundary
+  (`_parse_find_line`, `async_read`) before they reach entity data. Previously
+  `float("23.50;ok")` would raise `ValueError`, causing all sensors with status
+  suffixes to show as `unavailable`. Affects ebusd 26.x (found on v32 ventilation
+  units by @szflo). Safety net in `_values_from_registers` handles cached values
+  from previous versions.
+
+### Refactor: dynamic circuit type detection (removes hardcoded circuit names)
+
+- **Device type detection from eBUS scan metadata**: `_parse_find_line` now
+  captures scan model lines (`scan.15 = Vaillant;BASV2;0507;1704`). The TYPE
+  field (BASV2, CTLV2, HMU00, etc.) is extracted in `_parse_scan_metadata` and
+  used to classify each circuit by function (`heating_controller`, `heat_pump`,
+  `ventilation`, `diagnostic`, `zone`, `dhw`).
+- **Three-priority fallback chain**: (1) scan TYPE → circuit via model prefix
+  matching (any numeric variant: basv1-9, ctlv1-9, z1-9). (2) circuit name
+  prefix heuristic. (3) Z1OpMode register detection (existing behavior).
+- **New coordinator API**: `circuits_by_type("heating_controller")` returns all
+  matching circuits. `heating_circuit` property preserved as backward-compat
+  wrapper around the first result.
+- **All platforms use `coordinator.heating_circuit`** instead of hardcoded
+  `"ctlv2"`. Climate, water heater, switch, calendar, datetime, binary_sensor
+  — zero hardcoded circuit names remaining.
+- **`_infer_device_circuit`**: removed `circuit == "ctlv2"` guard. Name
+  patterns (Hwc*, Z1*, Hc1*) are heating-controller-specific enough to work on
+  any circuit.
+- **`get_meta` fallback**: unknown circuits (e.g. `basv`) fall back to
+  `ctlv2.*` REGISTER_MAP entries for metadata.
+- **Services YAML**: circuit dropdowns replaced with text input (accepts any
+  discovered circuit name).
+- **`PARENT_CIRCUITS` and `CIRCUIT_TO_DEVICE_ID`**: `basv` added alongside
+  `ctlv2` for device ID 15.
+- **`CIRCUIT_NAMES`**: `"basv": "Vaillant BASV2 (Heating Control)"` added.
 
 ## 1.1.0 - 2026-07-28
 

--- a/custom_components/vaillant_ebus/backend/entity_factory.py
+++ b/custom_components/vaillant_ebus/backend/entity_factory.py
@@ -18,11 +18,11 @@ ALWAYS_HIDDEN = {"memory"}
 def _infer_device_circuit(circuit: str, name: str) -> str | None:
     if circuit == "Broadcast":
         return "hmu"
-    if circuit == "ctlv2":
-        if name.startswith(("Hwc", "Cylinder", "MaxCylinder", "DHW", "Solar")):
-            return "dhw"
-        if name.startswith(("Z1", "Hc1")):
-            return "z1"
+    # ponytail: no circuit guard — name patterns are heating-controller-specific enough
+    if name.startswith(("Hwc", "Cylinder", "MaxCylinder", "DHW", "Solar")):
+        return "dhw"
+    if name.startswith(("Z1", "Hc1")):
+        return "z1"
     return None
 
 

--- a/custom_components/vaillant_ebus/backend/mapping.py
+++ b/custom_components/vaillant_ebus/backend/mapping.py
@@ -1154,4 +1154,11 @@ def get_meta(circuit: str, name: str, field: str = "value") -> RegisterMeta:
     key = f"{circuit}.{name}"
     if field != "value":
         key += f".{field}"
-    return REGISTER_MAP.get(key, RegisterMeta())
+    meta = REGISTER_MAP.get(key)
+    # ponytail: fallback for heating controller variants (basv → ctlv2). Add if new variants appear.
+    if meta is None and circuit != "ctlv2":
+        alt = f"ctlv2.{name}"
+        if field != "value":
+            alt += f".{field}"
+        meta = REGISTER_MAP.get(alt)
+    return meta or RegisterMeta()

--- a/custom_components/vaillant_ebus/backend/models.py
+++ b/custom_components/vaillant_ebus/backend/models.py
@@ -158,6 +158,7 @@ def zero_idle_registers(registers: Mapping[str, EbusdRegister]) -> None:
 CIRCUIT_NAMES: dict[str, str] = {
     "hmu": "Vaillant aroTHERM (Heat Pump)",
     "ctlv2": "Vaillant CTLV2 (Heating Control)",
+    "basv": "Vaillant BASV2 (Heating Control)",
     "z1": "Woonkamer (Z1)",
     "dhw": "Boiler (DHW)",
     "Broadcast": "Vaillant eBUS (Diagnostic)",

--- a/custom_components/vaillant_ebus/backend/tcp.py
+++ b/custom_components/vaillant_ebus/backend/tcp.py
@@ -20,6 +20,16 @@ INITIAL_RECONNECT_DELAY = 1
 READ_TIMEOUT = 10
 DONE_STR = "done"
 
+EBUSD_STATUS_SUFFIXES = (";ok", ";err", ";inv", ";too_small", ";too_big", ";nan", ";unknown")
+
+
+# Strip ebusd read status suffix from value (e.g. "23.50;ok" -> "23.50")
+def _strip_suffix(value: str) -> str:
+    for suffix in EBUSD_STATUS_SUFFIXES:
+        if value.endswith(suffix):
+            return value[:-len(suffix)]
+    return value
+
 
 class EbusdTcpBackend:
     # Initialize TCP backend with host and port
@@ -195,7 +205,7 @@ class EbusdTcpBackend:
             reg_name = parts[1].strip()
             if rhs in ("-", "no data stored", "") or rhs.startswith(("(empty ", "(ERR")):
                 return circuit_name, reg_name, ["value"], {"value": None}, "", ""
-            return circuit_name, reg_name, ["value"], {"value": rhs}, "", ""
+            return circuit_name, reg_name, ["value"], {"value": _strip_suffix(rhs)}, "", ""
         # Multi-field register: "circuit type name QQ:ZZ:MSG:FIELDS: field=val field=val"
         if line.startswith("#"):
             return None
@@ -219,7 +229,7 @@ class EbusdTcpBackend:
                 continue
             fname, fval = pair.split("=", 1)
             fields.append(fname)
-            values[fname] = fval if fval not in ("-", "no data stored", "") else None
+            values[fname] = _strip_suffix(fval) if fval not in ("-", "no data stored", "") else None
         if not fields:
             fields = ["value"]
             values = {"value": None}
@@ -234,7 +244,9 @@ class EbusdTcpBackend:
         if result.error:
             _LOGGER.debug("Read error %s.%s: %s", circuit, name, result.error)
             return None
-        return result.data.strip() or None
+        raw = result.data.strip()
+        return _strip_suffix(raw) if raw else None
+
 
     # Write a value to an ebusd register, verify by read-back
     async def async_write(self, circuit: str, name: str, value: str) -> WriteResult:

--- a/custom_components/vaillant_ebus/backend/tcp.py
+++ b/custom_components/vaillant_ebus/backend/tcp.py
@@ -200,9 +200,12 @@ class EbusdTcpBackend:
             rhs = rhs.strip()
             parts = lhs.split(" ", 1)
             circuit_name = parts[0]
-            if len(parts) <= 1 or not parts[1].strip():
+            reg_name = parts[1].strip() if len(parts) > 1 else ""
+            if not reg_name and circuit_name.lower().startswith("scan"):
+                # Scan circuit metadata line: "scan.XX = MF;TYPE;SW;HW"
+                return circuit_name, reg_name, ["value"], {"value": _strip_suffix(rhs)}, "", ""
+            if not reg_name:
                 return None
-            reg_name = parts[1].strip()
             if rhs in ("-", "no data stored", "") or rhs.startswith(("(empty ", "(ERR")):
                 return circuit_name, reg_name, ["value"], {"value": None}, "", ""
             return circuit_name, reg_name, ["value"], {"value": _strip_suffix(rhs)}, "", ""

--- a/custom_components/vaillant_ebus/binary_sensor.py
+++ b/custom_components/vaillant_ebus/binary_sensor.py
@@ -122,9 +122,10 @@ class EbusdFaultSensor(CoordinatorEntity[VaillantCoordinator], BinarySensorEntit
     # True when either HMU or CTLV2 has active error codes
     @property
     def is_on(self) -> bool:
+        c = self.coordinator.heating_circuit
         values = (
             self.coordinator.data.get("ebusd", {}).get("hmu.Currenterror.value"),
-            self.coordinator.data.get("ebusd", {}).get("ctlv2.Currenterror.value"),
+            self.coordinator.data.get("ebusd", {}).get(f"{c}.Currenterror.value"),
         )
         return any(
             value and any(part.strip() not in {"", "-"} for part in str(value).split(";"))

--- a/custom_components/vaillant_ebus/calendar.py
+++ b/custom_components/vaillant_ebus/calendar.py
@@ -52,7 +52,7 @@ class EbusdCalendar(CoordinatorEntity[VaillantCoordinator], CalendarEntity):
         self._prefix = prefix
         self._attr_name = name
         self._attr_unique_id = f"{entry.entry_id}_calendar_{prefix.lower()}"
-        self._attr_device_info = coordinator.get_device_info("ctlv2")
+        self._attr_device_info = coordinator.get_device_info(coordinator.heating_circuit)
 
     @property
     def event(self) -> CalendarEvent | None:
@@ -91,11 +91,12 @@ class EbusdCalendar(CoordinatorEntity[VaillantCoordinator], CalendarEntity):
 
     # Get timer register value from coordinator data or register cache
     def _value(self, name: str) -> str | None:
-        key = f"ctlv2.{name}.value"
+        c = self.coordinator.heating_circuit
+        key = f"{c}.{name}.value"
         value = self.coordinator.data.get("ebusd", {}).get(key)
         if value is not None:
             return str(value)
-        register = self.coordinator.registers.get(f"ctlv2.{name}")
+        register = self.coordinator.registers.get(f"{c}.{name}")
         return register.value.get("value") if register else None
 
 

--- a/custom_components/vaillant_ebus/climate.py
+++ b/custom_components/vaillant_ebus/climate.py
@@ -26,17 +26,6 @@ from .coordinator import VaillantCoordinator
 _LOGGER = logging.getLogger(__name__)
 
 ZONE = "z1"
-CIRCUIT = "ctlv2"
-ROOM_TEMPERATURE = f"{CIRCUIT}.Z1RoomTemp.value"
-TARGET_TEMPERATURE = f"{CIRCUIT}.Z1ActualRoomTempDesired.value"
-OPERATION_MODE = f"{CIRCUIT}.Z1OpMode.value"
-DAY_TEMPERATURE = f"{CIRCUIT}.Z1DayTemp.value"
-NIGHT_TEMPERATURE = f"{CIRCUIT}.Z1NightTemp.value"
-HC_STATUS = f"{CIRCUIT}.Hc1Status.value"
-COMPRESSOR_STATUS = "hmu.RunDataStatuscode.value"
-QUICK_VETO_TEMP = f"{CIRCUIT}.Z1QuickVetoTemp.value"
-HOLIDAY_START = f"{CIRCUIT}.Z1HolidayStartPeriod.value"
-HOLIDAY_END = f"{CIRCUIT}.Z1HolidayEndPeriod.value"
 
 HEATING_STATES = frozenset({
     "heat_compressor_active",
@@ -54,8 +43,10 @@ DATE_FMT = "%d.%m.%Y"
 HOLIDAY_RESET = "01.01.2015"
 
 
-# Look up a string value from coordinator ebusd data by key
-def _value(coordinator: VaillantCoordinator, key: str) -> str | None:
+# Look up a string value from coordinator ebusd data by register name
+def _value(coordinator: VaillantCoordinator, register: str, circuit: str | None = None) -> str | None:
+    ckt = circuit or coordinator.heating_circuit
+    key = f"{ckt}.{register}.value"
     value = coordinator.data.get("ebusd", {}).get(key)
     return str(value) if value is not None else None
 
@@ -106,19 +97,19 @@ class EbusdClimate(CoordinatorEntity[VaillantCoordinator], ClimateEntity):
     # Current room temperature from Z1RoomTemp
     @property
     def current_temperature(self) -> float | None:
-        return _float(_value(self.coordinator, ROOM_TEMPERATURE))
+        return _float(_value(self.coordinator, "Z1RoomTemp"))
 
     # Target temperature: quick veto temp (boost) or actual/target, filtered to valid range
     @property
     def target_temperature(self) -> float | None:
         if self.preset_mode == PRESET_BOOST:
-            qv = _float(_value(self.coordinator, QUICK_VETO_TEMP))
+            qv = _float(_value(self.coordinator, "Z1QuickVetoTemp"))
             if qv is not None and 5 <= qv <= 30:
                 return qv
-        value = _float(_value(self.coordinator, TARGET_TEMPERATURE))
+        value = _float(_value(self.coordinator, "Z1ActualRoomTempDesired"))
         if value is not None and 5 <= value <= 30:
             return value
-        return _float(_value(self.coordinator, DAY_TEMPERATURE))
+        return _float(_value(self.coordinator, "Z1DayTemp"))
 
     # Supported features: preset mode, target temp, turn on/off
     @property
@@ -135,17 +126,17 @@ class EbusdClimate(CoordinatorEntity[VaillantCoordinator], ClimateEntity):
     def hvac_mode(self) -> HVACMode | None:
         if self._optimistic_hvac_mode is not None:
             return self._optimistic_hvac_mode
-        return _hvac_mode(_value(self.coordinator, OPERATION_MODE))
+        return _hvac_mode(_value(self.coordinator, "Z1OpMode"))
 
     # HVAC action derived from HC1 status, pump, and compressor state
     @property
     def hvac_action(self) -> HVACAction | None:
-        hc = _float(_value(self.coordinator, HC_STATUS))
+        hc = _float(_value(self.coordinator, "Hc1Status"))
         zone_active = hc is not None and hc > 0
         if hc is None:
-            pump = _value(self.coordinator, f"{CIRCUIT}.Hc1PumpStatus.value")
+            pump = _value(self.coordinator, "Hc1PumpStatus")
             zone_active = (pump or "").lower() in ("on", "1", "true", "yes", "running")
-        comp = (_value(self.coordinator, COMPRESSOR_STATUS) or "").lower()
+        comp = (_value(self.coordinator, "RunDataStatuscode", "hmu") or "").lower()
         global_heat = comp in HEATING_STATES
         global_cool = comp in COOLING_STATES
         if zone_active:
@@ -169,8 +160,8 @@ class EbusdClimate(CoordinatorEntity[VaillantCoordinator], ClimateEntity):
     def preset_mode(self) -> str | None:
         if self._quick_veto_until and self._quick_veto_until > datetime.now():
             return PRESET_BOOST
-        h_start = _value(self.coordinator, HOLIDAY_START)
-        h_end = _value(self.coordinator, HOLIDAY_END)
+        h_start = _value(self.coordinator, "Z1HolidayStartPeriod")
+        h_end = _value(self.coordinator, "Z1HolidayEndPeriod")
         if h_start and h_end and h_start != HOLIDAY_RESET:
             try:
                 now = datetime.now().date()
@@ -244,7 +235,7 @@ class EbusdClimate(CoordinatorEntity[VaillantCoordinator], ClimateEntity):
         if self._quick_veto_until and self._quick_veto_until <= datetime.now():
             self._quick_veto_until = None
         if self._optimistic_hvac_mode is not None:
-            confirmed = _hvac_mode(_value(self.coordinator, OPERATION_MODE))
+            confirmed = _hvac_mode(_value(self.coordinator, "Z1OpMode"))
             if confirmed == self._optimistic_hvac_mode:
                 self._optimistic_hvac_mode = None
         super()._handle_coordinator_update()
@@ -253,7 +244,7 @@ class EbusdClimate(CoordinatorEntity[VaillantCoordinator], ClimateEntity):
     async def _cancel_quick_veto(self) -> None:
         self._quick_veto_until = None
         self.async_write_ha_state()
-        day_temp = _float(_value(self.coordinator, DAY_TEMPERATURE))
+        day_temp = _float(_value(self.coordinator, "Z1DayTemp"))
         if day_temp is not None:
             await self._write("Z1QuickVetoTemp", str(day_temp))
         await self._write("Z1QuickVetoDuration", "0")
@@ -263,7 +254,7 @@ class EbusdClimate(CoordinatorEntity[VaillantCoordinator], ClimateEntity):
         if temp_override is not None:
             veto_temp = temp_override
         else:
-            temp = _float(_value(self.coordinator, ROOM_TEMPERATURE))
+            temp = _float(_value(self.coordinator, "Z1RoomTemp"))
             options = self.coordinator._entry.options
             veto_temp = options.get("quick_veto_temp")
             if veto_temp is None and temp is not None:
@@ -283,7 +274,7 @@ class EbusdClimate(CoordinatorEntity[VaillantCoordinator], ClimateEntity):
         away_duration = self.coordinator._entry.options.get("away_duration", 7)
         await self._write("Z1HolidayStartPeriod", today.strftime(DATE_FMT))
         await self._write("Z1HolidayEndPeriod", (today + timedelta(days=away_duration)).strftime(DATE_FMT))
-        ht = _float(_value(self.coordinator, f"{CIRCUIT}.Z1HolidayTemp.value"))
+        ht = _float(_value(self.coordinator, "Z1HolidayTemp"))
         if ht is None:
             await self._write("Z1HolidayTemp", "15.0")
 
@@ -292,9 +283,9 @@ class EbusdClimate(CoordinatorEntity[VaillantCoordinator], ClimateEntity):
         await self._write("Z1HolidayStartPeriod", HOLIDAY_RESET)
         await self._write("Z1HolidayEndPeriod", HOLIDAY_RESET)
 
-    # Write register to CTLV2 circuit via backend
+    # Write register to heating circuit via backend
     async def _write(self, name: str, value: str) -> bool:
-        return await self._write_raw(CIRCUIT, name, value)
+        return await self._write_raw(self.coordinator.heating_circuit, name, value)
 
     # Write register to arbitrary circuit via backend, trigger refresh on success
     async def _write_raw(self, circuit: str, name: str, value: str) -> bool:
@@ -308,12 +299,6 @@ class EbusdClimate(CoordinatorEntity[VaillantCoordinator], ClimateEntity):
             return result.success
         except Exception:
             return False
-
-
-CIRCUIT_HMU = "hmu"
-MIN_FLOW_TEMP = f"{CIRCUIT}.Hc1MinFlowTempDesired.value"
-MAX_FLOW_TEMP = f"{CIRCUIT}.Hc1MaxFlowTempDesired.value"
-CURRENT_FLOW_TEMP = f"{CIRCUIT}.Hc1FlowTemp.value"
 
 
 class EbusdFlowTempRange(CoordinatorEntity[VaillantCoordinator], ClimateEntity):
@@ -340,22 +325,22 @@ class EbusdFlowTempRange(CoordinatorEntity[VaillantCoordinator], ClimateEntity):
     # Current flow temperature from Hc1FlowTemp
     @property
     def current_temperature(self) -> float | None:
-        return _float(_value(self.coordinator, CURRENT_FLOW_TEMP))
+        return _float(_value(self.coordinator, "Hc1FlowTemp"))
 
     # Minimum flow temperature target from Hc1MinFlowTempDesired
     @property
     def target_temperature_low(self) -> float | None:
-        return _float(_value(self.coordinator, MIN_FLOW_TEMP))
+        return _float(_value(self.coordinator, "Hc1MinFlowTempDesired"))
 
     # Maximum flow temperature target from Hc1MaxFlowTempDesired
     @property
     def target_temperature_high(self) -> float | None:
-        return _float(_value(self.coordinator, MAX_FLOW_TEMP))
+        return _float(_value(self.coordinator, "Hc1MaxFlowTempDesired"))
 
     # HVAC action from compressor status (heating/cooling/idle/off)
     @property
     def hvac_action(self) -> HVACAction | None:
-        comp = (_value(self.coordinator, COMPRESSOR_STATUS) or "").lower()
+        comp = (_value(self.coordinator, "RunDataStatuscode", "hmu") or "").lower()
         if comp in HEATING_STATES:
             return HVACAction.HEATING
         if comp in COOLING_STATES:
@@ -369,7 +354,7 @@ class EbusdFlowTempRange(CoordinatorEntity[VaillantCoordinator], ClimateEntity):
     # HVAC mode from Z1OpMode
     @property
     def hvac_mode(self) -> HVACMode | None:
-        return _hvac_mode(_value(self.coordinator, OPERATION_MODE))
+        return _hvac_mode(_value(self.coordinator, "Z1OpMode"))
 
     @property
     def available(self) -> bool:
@@ -384,13 +369,13 @@ class EbusdFlowTempRange(CoordinatorEntity[VaillantCoordinator], ClimateEntity):
         if high is not None:
             await self._write("Hc1MaxFlowTempDesired", str(int(high)))
 
-    # Write register to CTLV2 circuit, trigger refresh on success
+    # Write register to heating circuit, trigger refresh on success
     async def _write(self, name: str, value: str) -> bool:
         backend = self.coordinator.ebusd_backend
         if not backend:
             return False
         try:
-            result = await backend.async_write(CIRCUIT, name, value)
+            result = await backend.async_write(self.coordinator.heating_circuit, name, value)
             if result.success:
                 await self.coordinator.async_request_refresh()
             return result.success

--- a/custom_components/vaillant_ebus/coordinator.py
+++ b/custom_components/vaillant_ebus/coordinator.py
@@ -43,7 +43,7 @@ class VaillantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._active_zone_circuits: set[str] = set()
         self._started = False
         self._ebusd_connected = False
-        self.heating_circuit = "ctlv2"
+        self._heating_circuit = "ctlv2"
 
         scan_interval = entry.data.get(CONF_SCAN_INTERVAL, DEFAULT_EBUSD_POLL_INTERVAL)
         super().__init__(
@@ -127,10 +127,6 @@ class VaillantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._last_find_keys = {r.key for r in discovered}
         for reg in discovered:
             self.registers[reg.key] = reg
-        for reg in discovered:
-            if reg.name == "Z1OpMode" and reg.has_data:
-                self.heating_circuit = reg.circuit
-                break
         _LOGGER.info("Found %d registers across %d circuit(s): %s",
                      len(discovered),
                      len({r.circuit for r in discovered}),
@@ -246,12 +242,94 @@ class VaillantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             else:
                 device_id = "general"
             value = reg.value.get("value")
-            if value is not None and value not in ("-", "no data stored", ""):
-                self._scan_metadata.setdefault(device_id, {})[reg.name.upper()] = str(value)
-                self._present_devices.add(device_id)
+            if value is None or value in ("-", "no data stored", ""):
+                continue
+            val = str(value)
+            # Parse model lines: "Vaillant;BASV2;0507;1704" → MF;TYPE;SW;HW
+            if not reg.name:
+                parts = val.split(";")
+                if len(parts) == 4:
+                    meta = self._scan_metadata.setdefault(device_id, {})
+                    meta["MF"] = parts[0]
+                    meta["TYPE"] = parts[1]
+                    meta["SW"] = parts[2]
+                    meta["HW"] = parts[3]
+                    self._present_devices.add(device_id)
+                    continue
+            self._scan_metadata.setdefault(device_id, {})[reg.name.upper()] = val
+            self._present_devices.add(device_id)
         if self._scan_metadata:
             _LOGGER.info("Scan metadata: %s | present devices: %s",
                          self._scan_metadata, self._present_devices)
+
+    # Map circuit prefix → device type. Prefixes match all numeric variants (ctlv1-9, basv2, etc.)
+    CIRCUIT_TYPE_BY_PREFIX: dict[str, str] = {
+        "hmu": "heat_pump",
+        "ctlv": "heating_controller",
+        "basv": "heating_controller",
+        "bai": "heating_controller",
+        "z": "zone",
+        "dhw": "dhw",
+        "Broadcast": "diagnostic",
+        "vwz": "ventilation",
+        "vwzio": "ventilation",
+    }
+    # Map scan TYPE field → circuit type
+    DEVICE_TYPE_TO_CIRCUIT_TYPE: dict[str, str] = {
+        "hmu": "heat_pump", "hmu00": "heat_pump",
+        "basv": "heating_controller", "basv2": "heating_controller",
+        "vwz": "ventilation", "vwzio": "ventilation",
+        "netx2": "diagnostic",
+    }
+
+    # Classify each circuit by device type using scan metadata + circuit prefix
+    def _detect_circuit_types(self) -> None:
+        ctypes: dict[str, str] = {}
+        # Priority 1: scan TYPE field → circuit type + matching circuit
+        type_prefix_ctypes = [("ctlv", "heating_controller"), ("bai", "heating_controller")]
+        for device_id, meta in getattr(self, "_scan_metadata", {}).items():
+            raw_type = meta.get("TYPE", "").lower()
+            if not raw_type:
+                continue
+            ctype = self.DEVICE_TYPE_TO_CIRCUIT_TYPE.get(raw_type)
+            if not ctype:
+                for prefix, t in type_prefix_ctypes:
+                    if raw_type.startswith(prefix):
+                        ctype = t
+                        break
+            if not ctype:
+                continue
+            # Match TYPE to circuit: strip trailing digits (basv2 → basv)
+            ckt_prefix = raw_type.rstrip("0123456789")
+            for circuit in self.registers:
+                if circuit.lower().startswith(ckt_prefix) and not circuit.lower().startswith("scan"):
+                    ctypes[circuit] = ctype
+                    break
+        # Priority 2: circuit prefix heuristic
+        for circuit in self.registers:
+            if circuit in ctypes or circuit.lower().startswith(("scan",)) or "." in circuit:
+                continue
+            for prefix, ctype in self.CIRCUIT_TYPE_BY_PREFIX.items():
+                if circuit.lower().startswith(prefix):
+                    ctypes[circuit] = ctype
+                    break
+        # Priority 3: fallback for heating_controller via Z1OpMode
+        if "heating_controller" not in ctypes.values():
+            for reg in self.registers.values():
+                if reg.name == "Z1OpMode" and reg.has_data:
+                    ctypes[reg.circuit] = "heating_controller"
+                    break
+        self._circuit_types = ctypes
+
+    # Return all circuits matching a device type
+    def circuits_by_type(self, ctype: str) -> list[str]:
+        return [c for c, t in getattr(self, "_circuit_types", {}).items() if t == ctype]
+
+    @property
+    def heating_circuit(self) -> str:
+        # First detected heating_controller circuit, fallback to seed default
+        circuits = self.circuits_by_type("heating_controller")
+        return circuits[0] if circuits else self._heating_circuit
 
     DEVICE_ID_TO_CIRCUIT = {
         "08": "hmu", "15": "ctlv2", "76": "vwz", "f6": "Broadcast",

--- a/custom_components/vaillant_ebus/coordinator.py
+++ b/custom_components/vaillant_ebus/coordinator.py
@@ -198,6 +198,10 @@ class VaillantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     translated = value
                     if reg.key == "hmu.RunDataStatuscode":
                         translated = COMPRESSOR_STATUS_LABELS.get(value, value)
+                    for suffix in (";ok", ";err", ";inv", ";too_small", ";too_big", ";nan", ";unknown"):
+                        if translated.endswith(suffix):
+                            translated = translated[:-len(suffix)]
+                            break
                     values[f"{reg.circuit}.{reg.name}.{field}"] = translated
         self._save_cache(values)
         return values

--- a/custom_components/vaillant_ebus/coordinator.py
+++ b/custom_components/vaillant_ebus/coordinator.py
@@ -43,6 +43,7 @@ class VaillantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._active_zone_circuits: set[str] = set()
         self._started = False
         self._ebusd_connected = False
+        self.heating_circuit = "ctlv2"
 
         scan_interval = entry.data.get(CONF_SCAN_INTERVAL, DEFAULT_EBUSD_POLL_INTERVAL)
         super().__init__(
@@ -73,7 +74,7 @@ class VaillantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 value={"value": cached} if cached else {"value": None},
                 has_data=cached is not None,
             )
-        core_circuits: set[str] = {"hmu", "ctlv2", "Broadcast"}
+        core_circuits: set[str] = {"hmu", self.heating_circuit, "Broadcast"}
         active: set[str] = set(core_circuits)
         for reg in self.registers.values():
             if reg.has_data:
@@ -126,6 +127,10 @@ class VaillantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._last_find_keys = {r.key for r in discovered}
         for reg in discovered:
             self.registers[reg.key] = reg
+        for reg in discovered:
+            if reg.name == "Z1OpMode" and reg.has_data:
+                self.heating_circuit = reg.circuit
+                break
         _LOGGER.info("Found %d registers across %d circuit(s): %s",
                      len(discovered),
                      len({r.circuit for r in discovered}),
@@ -160,7 +165,7 @@ class VaillantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         self._parse_scan_metadata()
 
-        active_present: set[str] = {"hmu", "ctlv2", "Broadcast"}
+        active_present: set[str] = {"hmu", self.heating_circuit, "Broadcast"}
         for reg in self.registers.values():
             if reg.has_data:
                 active_present.add(reg.circuit)
@@ -324,7 +329,7 @@ class VaillantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             self._active_zone_circuits = _detect_active_circuits(
                 list(self.registers.values())
             )
-            fp_present: set[str] = {"hmu", "ctlv2", "Broadcast"}
+            fp_present: set[str] = {"hmu", self.heating_circuit, "Broadcast"}
             for reg in self.registers.values():
                 if reg.has_data:
                     fp_present.add(reg.circuit)
@@ -374,10 +379,10 @@ class VaillantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             await self.ebusd_backend.async_disconnect()
 
     PARENT_CIRCUITS: dict[str, str] = {
-        "ctlv2": "hmu", "z1": "ctlv2", "dhw": "ctlv2", "Broadcast": "hmu",
+        "ctlv2": "hmu", "basv": "hmu", "z1": "ctlv2", "dhw": "ctlv2", "Broadcast": "hmu",
     }
     CIRCUIT_TO_DEVICE_ID: dict[str, str] = {
-        "hmu": "08", "ctlv2": "15", "vwz": "76", "Broadcast": "f6",
+        "hmu": "08", "ctlv2": "15", "basv": "15", "vwz": "76", "Broadcast": "f6",
     }
 
     # Build HA DeviceInfo for a circuit, using scan metadata (SW/HW) when available

--- a/custom_components/vaillant_ebus/datetime.py
+++ b/custom_components/vaillant_ebus/datetime.py
@@ -27,8 +27,6 @@ HOLIDAY_ENTITIES = [
     ("DHW Holiday End", "HwcHolidayEndPeriod", "mdi:calendar-end", "dhw"),
 ]
 
-CIRCUIT = "ctlv2"
-
 
 # Create datetime entities for quick veto end and holiday periods
 async def async_setup_entry(
@@ -63,8 +61,9 @@ class EbusdQuickVetoEndEntity(CoordinatorEntity[VaillantCoordinator], DateTimeEn
     @property
     def native_value(self) -> datetime | None:
         data = self.coordinator.data.get("ebusd", {})
-        end_date = data.get("ctlv2.Z1QuickVetoEndDate.value")
-        end_time = data.get("ctlv2.Z1QuickVetoEndTime.value")
+        c = self.coordinator.heating_circuit
+        end_date = data.get(f"{c}.Z1QuickVetoEndDate.value")
+        end_time = data.get(f"{c}.Z1QuickVetoEndTime.value")
         if not end_date or not end_time or end_date == HOLIDAY_RESET:
             return None
         try:
@@ -97,7 +96,7 @@ class EbusdHolidayEntity(CoordinatorEntity[VaillantCoordinator], DateTimeEntity)
     # Return holiday start/end date as datetime (time set to midnight)
     @property
     def native_value(self) -> datetime | None:
-        raw = self.coordinator.data.get("ebusd", {}).get(f"{CIRCUIT}.{self._register}.value")
+        raw = self.coordinator.data.get("ebusd", {}).get(f"{self.coordinator.heating_circuit}.{self._register}.value")
         if not raw or str(raw) == HOLIDAY_RESET:
             return None
         try:
@@ -111,6 +110,6 @@ class EbusdHolidayEntity(CoordinatorEntity[VaillantCoordinator], DateTimeEntity)
         backend = self.coordinator.ebusd_backend
         if backend:
             date_str = value.strftime(DATE_FMT)
-            result = await backend.async_write(CIRCUIT, self._register, date_str)
+            result = await backend.async_write(self.coordinator.heating_circuit, self._register, date_str)
             if result.success:
                 await self.coordinator.async_request_refresh()

--- a/custom_components/vaillant_ebus/manifest.json
+++ b/custom_components/vaillant_ebus/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/MarkBovee/vaillant-ebus/issues",
   "requirements": [],
-  "version": "1.1.0"
+  "version": "1.1.1"
 }

--- a/custom_components/vaillant_ebus/services.yaml
+++ b/custom_components/vaillant_ebus/services.yaml
@@ -5,13 +5,7 @@ read_parameter:
     circuit:
       required: true
       selector:
-        select:
-          options:
-            - "hmu"
-            - "ctlv2"
-            - "Broadcast"
-            - "global"
-            - "vwz00"
+        text:
     name:
       required: true
       selector:
@@ -28,13 +22,7 @@ write_parameter:
     circuit:
       required: true
       selector:
-        select:
-          options:
-            - "hmu"
-            - "ctlv2"
-            - "Broadcast"
-            - "global"
-            - "vwz00"
+        text:
     name:
       required: true
       selector:

--- a/custom_components/vaillant_ebus/switch.py
+++ b/custom_components/vaillant_ebus/switch.py
@@ -139,8 +139,8 @@ class AwayModeSwitch(CoordinatorEntity[VaillantCoordinator], SwitchEntity):
     def is_on(self) -> bool | None:
         # True when holiday start/end dates contain today
         data = self.coordinator.data.get("ebusd", {})
-        start = data.get("ctlv2.Z1HolidayStartPeriod.value")
-        end = data.get("ctlv2.Z1HolidayEndPeriod.value")
+        start = data.get(f"{self.coordinator.heating_circuit}.Z1HolidayStartPeriod.value")
+        end = data.get(f"{self.coordinator.heating_circuit}.Z1HolidayEndPeriod.value")
         if start is None or end is None:
             return None
         return _is_holiday_active(start, end)
@@ -152,17 +152,17 @@ class AwayModeSwitch(CoordinatorEntity[VaillantCoordinator], SwitchEntity):
             return
         today = _today_str()
         data = self.coordinator.data.get("ebusd", {})
-        holiday_temp = data.get("ctlv2.Z1HolidayTemp.value", "15")
+        holiday_temp = data.get(f"{self.coordinator.heating_circuit}.Z1HolidayTemp.value", "15")
         writes = [
-            ("ctlv2", "Z1HolidayStartPeriod", today),
-            ("ctlv2", "Z1HolidayEndPeriod", FAR_FUTURE),
-            ("ctlv2", "HwcHolidayStartPeriod", today),
-            ("ctlv2", "HwcHolidayEndPeriod", FAR_FUTURE),
+            (self.coordinator.heating_circuit, "Z1HolidayStartPeriod", today),
+            (self.coordinator.heating_circuit, "Z1HolidayEndPeriod", FAR_FUTURE),
+            (self.coordinator.heating_circuit, "HwcHolidayStartPeriod", today),
+            (self.coordinator.heating_circuit, "HwcHolidayEndPeriod", FAR_FUTURE),
         ]
         for circuit, name, value in writes:
             await backend.async_write(circuit, name, value)
         if holiday_temp:
-            await backend.async_write("ctlv2", "Z1HolidayTemp", holiday_temp)
+            await backend.async_write(self.coordinator.heating_circuit, "Z1HolidayTemp", holiday_temp)
         await self.coordinator.async_request_refresh()
 
     # Reset holiday dates to unset, disable away mode
@@ -171,14 +171,14 @@ class AwayModeSwitch(CoordinatorEntity[VaillantCoordinator], SwitchEntity):
         if not backend:
             return
         writes = [
-            ("ctlv2", "Z1HolidayStartPeriod", UNSET_DATE),
-            ("ctlv2", "Z1HolidayEndPeriod", UNSET_DATE),
-            ("ctlv2", "HwcHolidayStartPeriod", UNSET_DATE),
-            ("ctlv2", "HwcHolidayEndPeriod", UNSET_DATE),
+            (self.coordinator.heating_circuit, "Z1HolidayStartPeriod", UNSET_DATE),
+            (self.coordinator.heating_circuit, "Z1HolidayEndPeriod", UNSET_DATE),
+            (self.coordinator.heating_circuit, "HwcHolidayStartPeriod", UNSET_DATE),
+            (self.coordinator.heating_circuit, "HwcHolidayEndPeriod", UNSET_DATE),
         ]
         for circuit, name, value in writes:
             await backend.async_write(circuit, name, value)
-        await backend.async_write("ctlv2", "Z1HolidayTemp", "15")
+        await backend.async_write(self.coordinator.heating_circuit, "Z1HolidayTemp", "15")
         await self.coordinator.async_request_refresh()
 
 
@@ -202,7 +202,7 @@ class HwcBoostSwitch(CoordinatorEntity[VaillantCoordinator], SwitchEntity):
     @property
     def is_on(self) -> bool | None:
         data = self.coordinator.data.get("ebusd", {})
-        raw = data.get("ctlv2.HwcSFMode.value")
+        raw = data.get(f"{self.coordinator.heating_circuit}.HwcSFMode.value")
         if raw is None:
             return None
         return raw.strip().lower() == "load"
@@ -212,7 +212,7 @@ class HwcBoostSwitch(CoordinatorEntity[VaillantCoordinator], SwitchEntity):
         backend = self.coordinator.ebusd_backend
         if not backend:
             return
-        await backend.async_write("ctlv2", "HwcSFMode", "load")
+        await backend.async_write(self.coordinator.heating_circuit, "HwcSFMode", "load")
         await self.coordinator.async_request_refresh()
 
     # Write "auto" to HwcSFMode to stop DHW boost
@@ -220,7 +220,7 @@ class HwcBoostSwitch(CoordinatorEntity[VaillantCoordinator], SwitchEntity):
         backend = self.coordinator.ebusd_backend
         if not backend:
             return
-        await backend.async_write("ctlv2", "HwcSFMode", "auto")
+        await backend.async_write(self.coordinator.heating_circuit, "HwcSFMode", "auto")
         await self.coordinator.async_request_refresh()
 
 
@@ -244,8 +244,8 @@ class HwcAwayModeSwitch(CoordinatorEntity[VaillantCoordinator], SwitchEntity):
     @property
     def is_on(self) -> bool | None:
         data = self.coordinator.data.get("ebusd", {})
-        start = data.get("ctlv2.HwcHolidayStartPeriod.value")
-        end = data.get("ctlv2.HwcHolidayEndPeriod.value")
+        start = data.get(f"{self.coordinator.heating_circuit}.HwcHolidayStartPeriod.value")
+        end = data.get(f"{self.coordinator.heating_circuit}.HwcHolidayEndPeriod.value")
         if start is None or end is None:
             return None
         return _is_holiday_active(start, end)
@@ -256,8 +256,8 @@ class HwcAwayModeSwitch(CoordinatorEntity[VaillantCoordinator], SwitchEntity):
         if not backend:
             return
         today = _today_str()
-        await backend.async_write("ctlv2", "HwcHolidayStartPeriod", today)
-        await backend.async_write("ctlv2", "HwcHolidayEndPeriod", FAR_FUTURE)
+        await backend.async_write(self.coordinator.heating_circuit, "HwcHolidayStartPeriod", today)
+        await backend.async_write(self.coordinator.heating_circuit, "HwcHolidayEndPeriod", FAR_FUTURE)
         await self.coordinator.async_request_refresh()
 
     # Reset DHW holiday dates to unset value
@@ -265,6 +265,6 @@ class HwcAwayModeSwitch(CoordinatorEntity[VaillantCoordinator], SwitchEntity):
         backend = self.coordinator.ebusd_backend
         if not backend:
             return
-        await backend.async_write("ctlv2", "HwcHolidayStartPeriod", UNSET_DATE)
-        await backend.async_write("ctlv2", "HwcHolidayEndPeriod", UNSET_DATE)
+        await backend.async_write(self.coordinator.heating_circuit, "HwcHolidayStartPeriod", UNSET_DATE)
+        await backend.async_write(self.coordinator.heating_circuit, "HwcHolidayEndPeriod", UNSET_DATE)
         await self.coordinator.async_request_refresh()

--- a/custom_components/vaillant_ebus/water_heater.py
+++ b/custom_components/vaillant_ebus/water_heater.py
@@ -16,13 +16,6 @@ from .const import CONF_AWAY_DURATION, DEFAULT_AWAY_DURATION, DOMAIN
 from .coordinator import VaillantCoordinator
 
 ZONE = "dhw"
-CIRCUIT = "ctlv2"
-CURRENT_TEMPERATURE = f"{CIRCUIT}.HwcStorageTemp.value"
-TARGET_TEMPERATURE = f"{CIRCUIT}.HwcTempDesired.value"
-OPERATION_MODE = f"{CIRCUIT}.HwcOpMode.value"
-HWC_SF_MODE = f"{CIRCUIT}.HwcSFMode.value"
-HOLIDAY_START = f"{CIRCUIT}.HwcHolidayStartPeriod.value"
-HOLIDAY_END = f"{CIRCUIT}.HwcHolidayEndPeriod.value"
 
 EBUSD_TO_HA_OPMODE = {
     "off": "off",
@@ -38,8 +31,10 @@ DATE_FMT = "%d.%m.%Y"
 HOLIDAY_RESET = "01.01.2015"
 
 
-# Look up a string value from coordinator ebusd data by key
-def _value(coordinator: VaillantCoordinator, key: str) -> str | None:
+# Look up a string value from coordinator ebusd data by register name
+def _value(coordinator: VaillantCoordinator, register: str) -> str | None:
+    circuit = coordinator.heating_circuit
+    key = f"{circuit}.{register}.value"
     value = coordinator.data.get("ebusd", {}).get(key)
     return str(value) if value is not None else None
 
@@ -91,8 +86,8 @@ class EbusdWaterHeater(CoordinatorEntity[VaillantCoordinator], WaterHeaterEntity
     # True when HwcHolidayStartPeriod/EndPeriod bracket today
     @property
     def is_away_mode_on(self) -> bool | None:
-        h_start = _value(self.coordinator, HOLIDAY_START)
-        h_end = _value(self.coordinator, HOLIDAY_END)
+        h_start = _value(self.coordinator, "HwcHolidayStartPeriod")
+        h_end = _value(self.coordinator, "HwcHolidayEndPeriod")
         if not h_start or not h_end:
             return None
         try:
@@ -106,21 +101,21 @@ class EbusdWaterHeater(CoordinatorEntity[VaillantCoordinator], WaterHeaterEntity
     # Current DHW storage temperature from HwcStorageTemp
     @property
     def current_temperature(self) -> float | None:
-        return _float(_value(self.coordinator, CURRENT_TEMPERATURE))
+        return _float(_value(self.coordinator, "HwcStorageTemp"))
 
     # Target temperature from HwcTempDesired, filtered to valid range
     @property
     def target_temperature(self) -> float | None:
-        value = _float(_value(self.coordinator, TARGET_TEMPERATURE))
+        value = _float(_value(self.coordinator, "HwcTempDesired"))
         return value if value is not None and 30 <= value <= 70 else None
 
     # Current operation mode: off/auto/manual/boost (boost from HwcSFMode)
     @property
     def current_operation(self) -> str | None:
-        sf = (_value(self.coordinator, HWC_SF_MODE) or "").lower()
+        sf = (_value(self.coordinator, "HwcSFMode") or "").lower()
         if sf == "load":
             return "boost"
-        operation = (_value(self.coordinator, OPERATION_MODE) or "").lower()
+        operation = (_value(self.coordinator, "HwcOpMode") or "").lower()
         return EBUSD_TO_HA_OPMODE.get(operation)
 
     @property
@@ -141,11 +136,11 @@ class EbusdWaterHeater(CoordinatorEntity[VaillantCoordinator], WaterHeaterEntity
         if not backend:
             return
         if operation_mode == "boost":
-            await backend.async_write(CIRCUIT, "HwcSFMode", "load")
+            await backend.async_write(self.coordinator.heating_circuit, "HwcSFMode", "load")
         else:
             ebusd_mode = HA_TO_EBUSD_OPMODE.get(operation_mode, operation_mode)
-            await backend.async_write(CIRCUIT, "HwcSFMode", "auto")
-            await backend.async_write(CIRCUIT, "HwcOpMode", ebusd_mode)
+            await backend.async_write(self.coordinator.heating_circuit, "HwcSFMode", "auto")
+            await backend.async_write(self.coordinator.heating_circuit, "HwcOpMode", ebusd_mode)
         await self.coordinator.async_request_refresh()
 
     # Turn DHW on by setting operation mode to auto
@@ -169,10 +164,10 @@ class EbusdWaterHeater(CoordinatorEntity[VaillantCoordinator], WaterHeaterEntity
         await self._write("HwcHolidayStartPeriod", HOLIDAY_RESET)
         await self._write("HwcHolidayEndPeriod", HOLIDAY_RESET)
 
-    # Write value to a CTLV2 register and trigger coordinator refresh
+    # Write value to a DHW register and trigger coordinator refresh
     async def _write(self, name: str, value: str) -> None:
         backend = self.coordinator.ebusd_backend
         if backend:
-            result = await backend.async_write(CIRCUIT, name, value)
+            result = await backend.async_write(self.coordinator.heating_circuit, name, value)
             if result.success:
                 await self.coordinator.async_request_refresh()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vaillant-ebus"
-version = "1.1.0"
+version = "1.1.1"
 description = "Home Assistant integration for Vaillant heat pumps via ebusd TCP"
 requires-python = ">=3.14"
 license = { text = "Apache-2.0" }


### PR DESCRIPTION
## v1.1.1

### ;ok suffix fix
ebusd 26.x appends status suffix (\`;ok\`, \`;err\`) to read responses. Stripped at TCP input boundary to prevent sensors showing as unavailable.

### BASV2 support
Full support for Vaillant BASV2 controller (heating registers under \`basv\` circuit instead of \`ctlv2\`). Dynamic circuit type detection from eBUS scan metadata.

### Breaking
- Services YAML: circuit dropdowns replaced with text input (accepts any circuit name)

### CHANGELOG
See CHANGELOG.md for full details.