### PR TITLE
docs: expand v1.2.0 technical release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@
 Monolithic coordinator split into 5 independent services with dedicated
 test fixtures from 3 real systems (aroTHERM, flexoCOMPACT/BASV2, recoVAIR/V32).
 
+### Technical rationale and discovery contract
+
+The previous coordinator coupled TCP I/O, raw-value parsing, register
+existence, device topology, entity generation, and HA registry state. This
+made an installation-specific assumption in any layer difficult to isolate or
+test.
+
+The 1.2.0 pipeline is:
+
+```text
+ebusd find + scan metadata
+  -> DiscoveryService: DeviceGraph
+  -> EntityFactoryService: EntityDescriptions
+  -> Home Assistant platforms
+```
+
+- The graph is derived from discovered circuits and register names. There is no
+  static inventory of entities, devices, zones, or registers.
+- `REGISTER_MAP` supplies presentation metadata only (name, icon, unit, and
+  platform hints); it cannot create an entity for a register absent from
+  discovery.
+- Scan metadata and generic register-prefix rules classify known hardware.
+  An unrecognized type becomes an `UNKNOWN` graph node, but retains its ebusd
+  circuit, scan type, SW/HW versions, and discovered entities. Home Assistant
+  can therefore expose it as `Vaillant <scan type>` without an allowlist.
+- `CIRCUIT_NAMES` remains the narrow exception: it contains display labels
+  only, not topology or entity-existence decisions.
+
+New hardware support now starts with a raw `find`/scan dump: add it as a
+fixture, exercise the same discovery pipeline, and assert the resulting graph
+before adding any special handling.
+
 - **EbusService** — TCP transport only, no register semantics.
 - **RegisterService** — value parsing (DATA1b, EXP, BCD, IGN, STR),
   sentinel detection ("Open", "no data stored"), writeability from
@@ -52,9 +84,11 @@ test fixtures from 3 real systems (aroTHERM, flexoCOMPACT/BASV2, recoVAIR/V32).
 ### Tests
 
 - 210 total (was 41) — 184 new tests
-- 3-system fixture coverage: aroTHERM, BASV2, V32
+- Raw discovery-dump coverage from three real systems: aroTHERM, community
+  flexoCOMPACT/BASV2 with vwzIO, and community recoVAIR/V32.
 - FakeEbusdServer for integration tests
-- Community fixtures validate non-aroTHERM hardware
+- Community fixtures verify BASV2 controller, passive-cooling, and ventilation
+  classification; unknown circuits still produce safe `UNKNOWN` nodes.
 - All services tested with mocked dependencies
 - Entity-routing tests cover single-zone, active/inactive secondary-zone,
   DHW, YAML override, and dynamic `ctlv0`/`ctlv2`/`ctlv9` naming behavior.

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -363,6 +363,29 @@ async def test_get_device_info_prefers_circuit_names() -> None:
             assert c.get_device_info("hmu")["identifiers"] == {("vaillant_ebus", "hmu")}
 
 
+# Intent: expose unclassified devices using their ebusd scan metadata.
+async def test_get_device_info_for_unknown_scan_type() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+            c = VaillantCoordinator(_hass(tmpdir), _entry())
+            graph = _make_graph()
+            graph.nodes["xyz"] = DeviceNode(
+                circuit="xyz",
+                device_type=DeviceType.UNKNOWN,
+                scan_type="XYZ01",
+                scan_sw="1234",
+                scan_hw="5678",
+            )
+            c._graph = graph
+            c.ebus = MagicMock()
+            c.ebus.version = "23.2"
+
+            info = c.get_device_info("xyz")
+            assert info["name"] == "Vaillant XYZ01"
+            assert info["sw_version"] == "1234"
+            assert info["hw_version"] == "5678"
+            assert info["identifiers"] == {("vaillant_ebus", "xyz")}
+
+
 async def test_entities_generated_after_discovery() -> None:
     with tempfile.TemporaryDirectory() as tmpdir:
         c = VaillantCoordinator(_hass(tmpdir), _entry())

--- a/tests/test_discovery_service.py
+++ b/tests/test_discovery_service.py
@@ -169,6 +169,22 @@ def test_categorize_unknown_circuit() -> None:
     assert result == DeviceType.UNKNOWN
 
 
+# Intent: retain scan metadata and entities for an unclassified ebusd device.
+def test_unknown_scan_type_retains_ebusd_metadata() -> None:
+    graph = DiscoveryService.build_device_graph(
+        [
+            "scan.01 = Vaillant;XYZ01;1234;5678",
+            "xyz Status = ready",
+        ]
+    )
+    node = graph.nodes["xyz"]
+    assert node.device_type == DeviceType.UNKNOWN
+    assert node.scan_type == "XYZ01"
+    assert node.scan_sw == "1234"
+    assert node.scan_hw == "5678"
+    assert node.registers == ["xyz.Status"]
+
+
 def test_categorize_by_register_z1opmode() -> None:
     result = DiscoveryService.categorize_circuit("unknown_ckt", ["unknown_ckt.Z1OpMode"], "")
     assert result == DeviceType.HEATING_CONTROLLER


### PR DESCRIPTION
- Document the data-driven discovery contract and technical rationale\n- Clarify how unknown ebusd device types retain scan metadata and entities\n- Add regression coverage for unknown scan metadata through DeviceInfo