### PR TITLE
release: v1.3.0 - manual cooling via ebusd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ captures/
 /scripts/
 strings.json
 data-dump/
+discovery_dumps/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,24 @@ Climate behavior must follow the corresponding `mypyllant` implementation.
 - Before changing integration code for a register write, test the register directly against ebusd over TCP or HTTP, verify a `done` response, and read the value back.
 - Treat registers that return `ERR: element not found` or `no data stored` as unsupported or temporarily unavailable; do not fabricate values or entities.
 
+## Discovering Registers Absent From CSV
+
+The installed ebusd CSV files only cover what `find` returns. The bus carries more
+telegrams; capture them with `grab` and mine the unknown ones for new registers.
+
+- Live grab: `grab` → wait N seconds → `grab result all` → `grab stop`. Do **not**
+  use `grab -m ...` (invalid syntax). A grab that runs while the user changes a
+  setting in the myVaillant app shows the write telegram that carries the new
+  register (app → cloud → NETX2 → bus).
+- Unknown telegrams have no register label after the count: `.../ 09410111... = 3`.
+  Labeled ones look like `... = 19: hmu SetMode`. Parse them with
+  `backend/grab_parser.py` (`parse_grab_lines`, `unknown_telegrams`).
+- Dumps capture them as `unknown_telegrams` (and `labeled_telegrams`) next to the
+  raw `grab` lines. When a dump exists, prefer mining its `unknown_telegrams` over
+  a fresh grab.
+- Register candidates found this way must be verified against ebusd (message format,
+  read-back value) before adding a `define -r` to `_define_custom_registers()`.
+
 ## Known Limitations
 
 - Many heat-pump registers return `no data stored` while the compressor is idle.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
   `datetime.vaillant_ebus_manual_cooling_start_date` and
   `datetime.vaillant_ebus_manual_cooling_end_date` (setting the end date writes
   the new manual cooling period).
+- **Climate COOL mode starts a manual cooling period.** Selecting COOL on the
+  climate entity now writes the manual cooling end date (today + `COOLING_DAYS`
+  days) through the runtime write route and switches the zone to auto, instead
+  of writing the ineffective `night` operation mode.
 
 ## 1.2.5 - 2026-08-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,28 +2,45 @@
 
 ## 1.3.0 - 2026-08-14
 
+> **Cooling works!** After a deep investigation (see below), this release exposes
+> the manual cooling period on the eBUS bus — you can now read **and write** the
+> "cool until [date]" period that the myVaillant app manages, and drive it from
+> the Home Assistant climate entity.
+
+### New & found registers
+
+- **Manual cooling start/end date** (`ctlv2.ManualCoolingStartDate` /
+  `ctlv2.ManualCoolingEndDate`) — previously absent from every ebusd CSV. Derived
+  from `john30/ebusd-configuration` issue #644 (`@ext(0xda,0)` / `@ext(0xdb,0)`
+  on the `_720` r_1 base) and verified on a real CTLV2 `SW0514`/`HW1104`. The
+  field layout is the holiday/away date type (`value,,IGN:4,,,,value,,HDA:3`,
+  year byte = year−2000, no BCD), with a `value,m,HDA:3` write route on the
+  `0201...` write-sub. Exposed as read/write datetime entities:
+  - `datetime.vaillant_ebus_manual_cooling_start_date`
+  - `datetime.vaillant_ebus_manual_cooling_end_date`
+- **Climate COOL mode now starts a real cooling period.** Selecting COOL writes
+  the manual cooling end date (today + configurable `cooling_duration`, default
+  3 days) and switches the zone to auto. Selecting HEAT clears the end date and
+  switches to day. The old `"cool": "night"` write was removed because `night`
+  is not retained by this controller.
+- **Configurable `cooling_duration`** option (days) in the integration settings.
+
+### Investigation notes
+
+A 300 s bus capture while cooling was turned on in the app showed zero write
+telegrams (the app drives the outdoor unit via NETX2/cloud, not the controller
+bus), and the old `15.700.csv` cooling sub-addresses returned `invalid position`.
+The `_720`-conditional cooling-program registers (`Hc1CoolingEnabled`,
+`Z1CoolingOpMode`, timers) are absent on this hardware, but the manual-cooling
+period itself is readable and writable.
+
 ### Added
 
-- **Manual cooling start/end dates as read/write datetime entities.** The
-  myVaillant-app "cool until [date]" period is exposed from the ebusd bus. The
-  registers are runtime-defined (GitHub issue john30/ebusd-configuration#644,
-  verified on CTLV2 SW0514/HW1104) using the same `value,,IGN:4,,,,value,,HDA:3`
-  field layout as the holiday/away date registers, with a `value,m,HDA:3` write
-  route on the `0201...` write-sub. Exposed as
-  `datetime.vaillant_ebus_manual_cooling_start_date` and
-  `datetime.vaillant_ebus_manual_cooling_end_date` (setting the end date writes
-  the new manual cooling period).
-- **Climate COOL mode starts a manual cooling period.** Selecting COOL on the
-  climate entity now writes the manual cooling end date (today +
-  `cooling_duration` days) through the runtime write route and switches the
-  zone to auto, instead of writing the ineffective `night` operation mode.
-- **Configurable manual cooling duration.** The `cooling_duration` option
-  (default 3 days) controls how many days the climate COOL mode keeps cooling
-  active.
-- **Discovery dumps now include structured grab telegrams:** `labeled_telegrams`
-  and `unknown_telegrams` entries next to the raw `grab` lines. Unknown telegrams
+- **Structured grab telegrams in discovery dumps:** `labeled_telegrams` and
+  `unknown_telegrams` entries next to the raw `grab` lines. Unknown telegrams
   (no register label in the ebusd CSV) are candidates for runtime `define -r`
-  registers absent from the installed CSV files.
+  registers absent from the installed CSV files — the basis for the cooling
+  register discovery above.
 
 ### Changed
 
@@ -43,6 +60,15 @@
 - **Dump export step ends with an abort message** instead of a create-entry result,
   so the frontend shows the "export started" message instead of "Options
   successfully saved".
+
+### Test it
+
+- Set your climate to **COOL** and check `datetime.vaillant_ebus_manual_cooling_end_date`
+  moves to today + `cooling_duration`. Switch back to **HEAT** and it resets.
+- If your heat pump does not expose the manual-cooling registers (different
+  firmware), the datetime entities simply stay unavailable — nothing breaks.
+- Use **Settings → Export Discovery Dump** to capture registers + raw bus
+  traffic, and share the YAML if a register is missing so it can be mapped.
 
 ## 1.2.4 - 2026-08-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 1.2.6 - 2026-08-14
+
+### Added
+
+- **Manual cooling start/end dates as read-only sensors.** The myVaillant-app
+  "cool until [date]" period is exposed from the ebusd bus. The registers are
+  runtime-defined (GitHub issue john30/ebusd-configuration#644, verified on
+  CTLV2 SW0514/HW1104) using the same `value,,IGN:4,,,,value,,HDA:3` field
+  layout as the holiday/away date registers. Exposed as
+  `sensor.vaillant_ebus_manual_cooling_start_date` and
+  `sensor.vaillant_ebus_manual_cooling_end_date`.
+
 ## 1.2.5 - 2026-08-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,9 @@
   `datetime.vaillant_ebus_manual_cooling_end_date` (setting the end date writes
   the new manual cooling period).
 - **Climate COOL mode starts a manual cooling period.** Selecting COOL on the
-  climate entity now writes the manual cooling end date (today + `COOLING_DAYS`
-  days) through the runtime write route and switches the zone to auto, instead
-  of writing the ineffective `night` operation mode.
+  climate entity now writes the manual cooling end date (today +
+  `COOLING_DAYS_DEFAULT` days) through the runtime write route and switches the
+  zone to auto, instead of writing the ineffective `night` operation mode.
 
 ## 1.2.5 - 2026-08-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,15 @@
 
 ### Added
 
-- **Manual cooling start/end dates as read-only sensors.** The myVaillant-app
-  "cool until [date]" period is exposed from the ebusd bus. The registers are
-  runtime-defined (GitHub issue john30/ebusd-configuration#644, verified on
-  CTLV2 SW0514/HW1104) using the same `value,,IGN:4,,,,value,,HDA:3` field
-  layout as the holiday/away date registers. Exposed as
-  `sensor.vaillant_ebus_manual_cooling_start_date` and
-  `sensor.vaillant_ebus_manual_cooling_end_date`.
+- **Manual cooling start/end dates as read/write datetime entities.** The
+  myVaillant-app "cool until [date]" period is exposed from the ebusd bus. The
+  registers are runtime-defined (GitHub issue john30/ebusd-configuration#644,
+  verified on CTLV2 SW0514/HW1104) using the same `value,,IGN:4,,,,value,,HDA:3`
+  field layout as the holiday/away date registers, with a `value,m,HDA:3` write
+  route on the `0201...` write-sub. Exposed as
+  `datetime.vaillant_ebus_manual_cooling_start_date` and
+  `datetime.vaillant_ebus_manual_cooling_end_date` (setting the end date writes
+  the new manual cooling period).
 
 ## 1.2.5 - 2026-08-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.2.6 - 2026-08-14
+## 1.3.0 - 2026-08-14
 
 ### Added
 
@@ -15,13 +15,11 @@
   the new manual cooling period).
 - **Climate COOL mode starts a manual cooling period.** Selecting COOL on the
   climate entity now writes the manual cooling end date (today +
-  `COOLING_DAYS_DEFAULT` days) through the runtime write route and switches the
+  `cooling_duration` days) through the runtime write route and switches the
   zone to auto, instead of writing the ineffective `night` operation mode.
-
-## 1.2.5 - 2026-08-14
-
-### Added
-
+- **Configurable manual cooling duration.** The `cooling_duration` option
+  (default 3 days) controls how many days the climate COOL mode keeps cooling
+  active.
 - **Discovery dumps now include structured grab telegrams:** `labeled_telegrams`
   and `unknown_telegrams` entries next to the raw `grab` lines. Unknown telegrams
   (no register label in the ebusd CSV) are candidates for runtime `define -r`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,14 @@
 
 ### Changed
 
+- **Central register write path.** All entities now write through the
+  coordinator `async_write_registers()` API, which bundles multiple writes and
+  triggers a single refresh. Multi-register operations (holiday periods, DHW
+  mode, manual cooling) are written atomically.
+- **Climate COOL/HEAT is now symmetric.** Selecting COOL writes the manual
+  cooling end date and switches to auto; selecting HEAT clears the manual
+  cooling end date and switches to day, so a cooling period is properly
+  cancelled instead of left running.
 - **Discovery dump export runs in the background:** long raw eBUS traffic grabs
   no longer block the options flow, so the Home Assistant frontend does not time
   out. The export step now reports that the dump is being written instead of the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 1.2.5 - 2026-08-14
+
+### Added
+
+- **Discovery dumps now include structured grab telegrams:** `labeled_telegrams`
+  and `unknown_telegrams` entries next to the raw `grab` lines. Unknown telegrams
+  (no register label in the ebusd CSV) are candidates for runtime `define -r`
+  registers absent from the installed CSV files.
+
+### Changed
+
+- **Discovery dump export runs in the background:** long raw eBUS traffic grabs
+  no longer block the options flow, so the Home Assistant frontend does not time
+  out. The export step now reports that the dump is being written instead of the
+  misleading "Options successfully saved" message, and a persistent notification
+  appears when the YAML file is ready.
+- **Dump export step ends with an abort message** instead of a create-entry result,
+  so the frontend shows the "export started" message instead of "Options
+  successfully saved".
+
 ## 1.2.4 - 2026-08-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -74,10 +74,11 @@ The normal data flow is: connect to ebusd, define any runtime-only registers, di
 - Dynamically discovers available circuits and registers on connect
 - Generates native Home Assistant entities for sensors, controls, climate, water heating, calendars, and dates
 - Climate entities with quick veto and away mode (calendar-based scheduling)
+- **Cooling control** — read and write the manual cooling period ("cool until [date]") via the climate COOL mode and dedicated datetime entities
 - Water heater entities with DHW boost and temperature control
 - Room humidity (CTLV2) — not available via standard ebusd MQTT
 - Read & write any register via HA services (`vaillant_ebus.read_parameter`, `vaillant_ebus.write_parameter`)
-- Custom registers via `--enabledefine` (e.g. room humidity)
+- Custom registers via `--enabledefine` (e.g. room humidity, manual cooling dates)
 - YAML overrides for entity metadata (names, icons, units)
 
 ## Prerequisites

--- a/custom_components/vaillant_ebus/__init__.py
+++ b/custom_components/vaillant_ebus/__init__.py
@@ -36,21 +36,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             value = await coordinator.ebus.read_register(circuit, name, field)
             _LOGGER.info("read_parameter %s.%s = %s", circuit, name, value)
 
-    # Write a value with read-after-write verification.
+    # Write a value with read-after-write verification via the central write path.
     async def svc_write_parameter(call: ServiceCall) -> None:
         circuit = call.data["circuit"]
         name = call.data["name"]
         value = call.data["value"]
-        if coordinator.ebus:
-            result = await coordinator.ebus.write_register(circuit, name, value)
-            _LOGGER.info(
-                "write_parameter %s.%s=%s: success=%s, verified=%s",
-                circuit,
-                name,
-                value,
-                result.success,
-                result.verified_value,
-            )
+        ok = await coordinator.async_write_register(circuit, name, value)
+        _LOGGER.info("write_parameter %s.%s=%s: success=%s", circuit, name, value, ok)
 
     # Force re-read all active registers.
     async def svc_refresh(call: ServiceCall) -> None:

--- a/custom_components/vaillant_ebus/backend/grab_parser.py
+++ b/custom_components/vaillant_ebus/backend/grab_parser.py
@@ -1,0 +1,47 @@
+"""Parsers for raw ebusd grab output — pure functions, no HA dependencies.
+
+Unknown telegrams (no register label) are candidates for runtime `define -r`
+registers that are absent from the installed ebusd CSV files.
+"""
+
+from __future__ import annotations
+
+
+# Parse ebusd telegrams from grab output into structured records.
+# Known telegrams carry a register label after the count (`= N: hmu SetMode`);
+# unknown ones do not.
+def parse_grab_lines(grab_lines: list[str]) -> list[dict]:
+    telegrams: list[dict] = []
+    for line in grab_lines:
+        line = line.strip()
+        if not line or not line.startswith(("10", "11", "30", "31", "50", "51", "70", "71", "f0", "f1", "f3", "f5")):
+            continue
+        if " = " not in line:
+            continue
+        payload, _, suffix = line.partition(" = ")
+        count_and_label = suffix.strip()
+        count, _, label = count_and_label.partition(": ")
+        count = count.strip()
+        label = label.strip() or None
+        req, _, resp = payload.partition(" / ")
+        req = req.strip()
+        resp = resp.strip() if resp else None
+        if len(req) < 8:
+            continue
+        telegrams.append(
+            {
+                "msgid": req[4:8],
+                "master": req[0:2],
+                "slave": req[2:4],
+                "sub": req[8:],
+                "resp": resp,
+                "count": count,
+                "label": label,
+            }
+        )
+    return telegrams
+
+
+# Only telegrams ebusd could not map to a known register label
+def unknown_telegrams(grab_lines: list[str]) -> list[dict]:
+    return [t for t in parse_grab_lines(grab_lines) if t["label"] is None]

--- a/custom_components/vaillant_ebus/backend/mapping.py
+++ b/custom_components/vaillant_ebus/backend/mapping.py
@@ -1222,6 +1222,16 @@ REGISTER_MAP: dict[str, RegisterMeta] = {
         unit="%",
         icon="mdi:water-percent",
     ),
+    "ctlv2.ManualCoolingStartDate": RegisterMeta(
+        friendly_name="Manual Cooling Start Date",
+        icon="mdi:snowflake",
+        entity_category="diagnostic",
+    ),
+    "ctlv2.ManualCoolingEndDate": RegisterMeta(
+        friendly_name="Manual Cooling End Date",
+        icon="mdi:snowflake",
+        entity_category="diagnostic",
+    ),
     "ctlv2.Date": RegisterMeta(
         friendly_name="Date",
         icon="mdi:calendar",

--- a/custom_components/vaillant_ebus/climate.py
+++ b/custom_components/vaillant_ebus/climate.py
@@ -20,7 +20,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN, EBUSD_TO_HA_HVAC, HA_TO_EBUSD_HVAC
+from .const import COOLING_DAYS_DEFAULT, DOMAIN, EBUSD_TO_HA_HVAC, HA_TO_EBUSD_HVAC
 from .coordinator import VaillantCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -186,6 +186,9 @@ class EbusdClimate(CoordinatorEntity[VaillantCoordinator], ClimateEntity):
         self.async_write_ha_state()
         if self.preset_mode == PRESET_BOOST:
             await self._cancel_quick_veto()
+        if hvac_mode == HVACMode.COOL:
+            await self._start_manual_cooling()
+            return
         ebusd_mode = HA_TO_EBUSD_HVAC.get(hvac_mode.value)
         if ebusd_mode is None:
             self._optimistic_hvac_mode = None
@@ -196,6 +199,23 @@ class EbusdClimate(CoordinatorEntity[VaillantCoordinator], ClimateEntity):
             ok = await self._write("Z1OpMode", ebusd_mode)
         except Exception as exc:
             _LOGGER.exception("set_hvac_mode failed: %s", exc)
+            ok = False
+        if not ok:
+            self._optimistic_hvac_mode = None
+            self.async_write_ha_state()
+
+    # Start manual cooling by writing the end date (myVaillant "cool until").
+    # The end date is today plus COOLING_DAYS_DEFAULT; the write route is the
+    # runtime-defined w-define on the 0201... write-sub (value,m,HDA:3).
+    async def _start_manual_cooling(self) -> None:
+        try:
+            today = datetime.now().date()
+            end = today + timedelta(days=COOLING_DAYS_DEFAULT)
+            ok = await self._write_raw("ctlv2", "ManualCoolingEndDate", end.strftime(DATE_FMT))
+            if ok:
+                ok = await self._write("Z1OpMode", "auto")
+        except Exception as exc:
+            _LOGGER.exception("start manual cooling failed: %s", exc)
             ok = False
         if not ok:
             self._optimistic_hvac_mode = None

--- a/custom_components/vaillant_ebus/climate.py
+++ b/custom_components/vaillant_ebus/climate.py
@@ -193,40 +193,53 @@ class EbusdClimate(CoordinatorEntity[VaillantCoordinator], ClimateEntity):
         if self.preset_mode == PRESET_BOOST:
             await self._cancel_quick_veto()
         if hvac_mode == HVACMode.COOL:
-            await self._start_manual_cooling()
-            return
-        ebusd_mode = HA_TO_EBUSD_HVAC.get(hvac_mode.value)
-        if ebusd_mode is None:
-            self._optimistic_hvac_mode = None
-            self.async_write_ha_state()
-            return
-        ok = True
-        try:
-            ok = await self._write("Z1OpMode", ebusd_mode)
-        except Exception as exc:
-            _LOGGER.exception("set_hvac_mode failed: %s", exc)
-            ok = False
+            ok = await self._start_manual_cooling()
+        elif hvac_mode == HVACMode.HEAT:
+            ok = await self._cancel_manual_cooling()
+            if ok:
+                ok = await self._write("Z1OpMode", "day")
+        else:
+            ebusd_mode = HA_TO_EBUSD_HVAC.get(hvac_mode.value)
+            if ebusd_mode is None:
+                self._optimistic_hvac_mode = None
+                self.async_write_ha_state()
+                return
+            try:
+                ok = await self._write("Z1OpMode", ebusd_mode)
+            except Exception as exc:
+                _LOGGER.exception("set_hvac_mode failed: %s", exc)
+                ok = False
         if not ok:
             self._optimistic_hvac_mode = None
             self.async_write_ha_state()
 
-    # Start manual cooling by writing the end date (myVaillant "cool until").
-    # The end date is today plus the configurable cooling_duration; the write
-    # route is the runtime-defined w-define on the 0201... write-sub (value,m,HDA:3).
-    async def _start_manual_cooling(self) -> None:
+    # Start manual cooling: write the end date (today + the configurable
+    # cooling_duration) through the central write path, then set the zone to
+    # auto so the controller engages cooling. The controller manages the start
+    # date itself, so only the end date is written.
+    async def _start_manual_cooling(self) -> bool:
         try:
             days = self.coordinator._entry.options.get(CONF_COOLING_DURATION, DEFAULT_COOLING_DURATION)
             today = datetime.now().date()
             end = today + timedelta(days=days)
-            ok = await self._write_raw("ctlv2", "ManualCoolingEndDate", end.strftime(DATE_FMT))
-            if ok:
-                ok = await self._write("Z1OpMode", "auto")
+            writes = [
+                ("ctlv2", "ManualCoolingEndDate", end.strftime(DATE_FMT)),
+                (self.coordinator.heating_circuit, "Z1OpMode", "auto"),
+            ]
+            return await self.coordinator.async_write_registers(writes)
         except Exception as exc:
             _LOGGER.exception("start manual cooling failed: %s", exc)
-            ok = False
-        if not ok:
-            self._optimistic_hvac_mode = None
-            self.async_write_ha_state()
+            return False
+
+    # Cancel manual cooling by clearing the end date (reset to the holiday
+    # reset sentinel) so the controller stops keeping a cooling period active.
+    # The controller manages the start date itself.
+    async def _cancel_manual_cooling(self) -> bool:
+        try:
+            return await self.coordinator.async_write_register("ctlv2", "ManualCoolingEndDate", HOLIDAY_RESET)
+        except Exception as exc:
+            _LOGGER.exception("cancel manual cooling failed: %s", exc)
+            return False
 
     # Set preset: boost (quick veto), away (holiday), or cancel
     async def async_set_preset_mode(self, preset_mode: str) -> None:
@@ -313,22 +326,13 @@ class EbusdClimate(CoordinatorEntity[VaillantCoordinator], ClimateEntity):
         await self._write("Z1HolidayStartPeriod", HOLIDAY_RESET)
         await self._write("Z1HolidayEndPeriod", HOLIDAY_RESET)
 
-    # Write register to heating circuit via backend
+    # Write register to heating circuit through the central write path
     async def _write(self, name: str, value: str) -> bool:
         return await self._write_raw(self.coordinator.heating_circuit, name, value)
 
-    # Write register to arbitrary circuit via backend, trigger refresh on success
+    # Write register to arbitrary circuit through the central write path
     async def _write_raw(self, circuit: str, name: str, value: str) -> bool:
-        ebus = self.coordinator.ebus
-        if not ebus:
-            return False
-        try:
-            result = await ebus.write_register(circuit, name, value)
-            if result.success:
-                await self.coordinator.async_request_refresh()
-            return result.success
-        except Exception:
-            return False
+        return await self.coordinator.async_write_register(circuit, name, value)
 
 
 class EbusdFlowTempRange(CoordinatorEntity[VaillantCoordinator], ClimateEntity):
@@ -398,15 +402,6 @@ class EbusdFlowTempRange(CoordinatorEntity[VaillantCoordinator], ClimateEntity):
         if high is not None:
             await self._write("Hc1MaxFlowTempDesired", str(int(high)))
 
-    # Write register to heating circuit, trigger refresh on success
+    # Write register to heating circuit through the central write path
     async def _write(self, name: str, value: str) -> bool:
-        ebus = self.coordinator.ebus
-        if not ebus:
-            return False
-        try:
-            result = await ebus.write_register(self.coordinator.heating_circuit, name, value)
-            if result.success:
-                await self.coordinator.async_request_refresh()
-            return result.success
-        except Exception:
-            return False
+        return await self.coordinator.async_write_register(self.coordinator.heating_circuit, name, value)

--- a/custom_components/vaillant_ebus/climate.py
+++ b/custom_components/vaillant_ebus/climate.py
@@ -20,7 +20,13 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import COOLING_DAYS_DEFAULT, DOMAIN, EBUSD_TO_HA_HVAC, HA_TO_EBUSD_HVAC
+from .const import (
+    CONF_COOLING_DURATION,
+    DEFAULT_COOLING_DURATION,
+    DOMAIN,
+    EBUSD_TO_HA_HVAC,
+    HA_TO_EBUSD_HVAC,
+)
 from .coordinator import VaillantCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -205,12 +211,13 @@ class EbusdClimate(CoordinatorEntity[VaillantCoordinator], ClimateEntity):
             self.async_write_ha_state()
 
     # Start manual cooling by writing the end date (myVaillant "cool until").
-    # The end date is today plus COOLING_DAYS_DEFAULT; the write route is the
-    # runtime-defined w-define on the 0201... write-sub (value,m,HDA:3).
+    # The end date is today plus the configurable cooling_duration; the write
+    # route is the runtime-defined w-define on the 0201... write-sub (value,m,HDA:3).
     async def _start_manual_cooling(self) -> None:
         try:
+            days = self.coordinator._entry.options.get(CONF_COOLING_DURATION, DEFAULT_COOLING_DURATION)
             today = datetime.now().date()
-            end = today + timedelta(days=COOLING_DAYS_DEFAULT)
+            end = today + timedelta(days=days)
             ok = await self._write_raw("ctlv2", "ManualCoolingEndDate", end.strftime(DATE_FMT))
             if ok:
                 ok = await self._write("Z1OpMode", "auto")

--- a/custom_components/vaillant_ebus/config_flow.py
+++ b/custom_components/vaillant_ebus/config_flow.py
@@ -227,7 +227,7 @@ class VaillantOptionsFlow(OptionsFlow):
                     vol.Optional(
                         CONF_QUICK_VETO_DURATION,
                         default=options.get(CONF_QUICK_VETO_DURATION, DEFAULT_QUICK_VETO_DURATION),
-                    ): vol.All(vol.Coerce(int), vol.Range(min=1, max=24)),
+                    ): vol.Coerce(int),
                     vol.Optional(
                         CONF_QUICK_VETO_TEMP,
                         default=options.get(CONF_QUICK_VETO_TEMP, DEFAULT_QUICK_VETO_TEMP),
@@ -235,7 +235,7 @@ class VaillantOptionsFlow(OptionsFlow):
                     vol.Optional(
                         CONF_COOLING_DURATION,
                         default=options.get(CONF_COOLING_DURATION, DEFAULT_COOLING_DURATION),
-                    ): vol.All(vol.Coerce(int), vol.Range(min=1, max=30)),
+                    ): vol.Coerce(int),
                 }
             ),
         )

--- a/custom_components/vaillant_ebus/config_flow.py
+++ b/custom_components/vaillant_ebus/config_flow.py
@@ -13,12 +13,14 @@ from homeassistant.data_entry_flow import FlowResult
 
 from .const import (
     CONF_AWAY_DURATION,
+    CONF_COOLING_DURATION,
     CONF_EBUSD_HOST,
     CONF_EBUSD_PORT,
     CONF_QUICK_VETO_DURATION,
     CONF_QUICK_VETO_TEMP,
     CONF_SCAN_INTERVAL,
     DEFAULT_AWAY_DURATION,
+    DEFAULT_COOLING_DURATION,
     DEFAULT_EBUSD_POLL_INTERVAL,
     DEFAULT_EBUSD_PORT,
     DEFAULT_QUICK_VETO_DURATION,
@@ -230,6 +232,10 @@ class VaillantOptionsFlow(OptionsFlow):
                         CONF_QUICK_VETO_TEMP,
                         default=options.get(CONF_QUICK_VETO_TEMP, DEFAULT_QUICK_VETO_TEMP),
                     ): vol.Coerce(float),
+                    vol.Optional(
+                        CONF_COOLING_DURATION,
+                        default=options.get(CONF_COOLING_DURATION, DEFAULT_COOLING_DURATION),
+                    ): vol.All(vol.Coerce(int), vol.Range(min=1, max=30)),
                 }
             ),
         )

--- a/custom_components/vaillant_ebus/config_flow.py
+++ b/custom_components/vaillant_ebus/config_flow.py
@@ -235,7 +235,8 @@ class VaillantOptionsFlow(OptionsFlow):
         )
 
     # Export dump: confirm + grab_duration, runs in background so long grabs
-    # do not block the flow (frontend times out otherwise).
+    # do not block the flow (frontend times out otherwise). Ends with abort so
+    # the frontend shows our own message instead of "Options successfully saved".
     async def async_step_export_dump(self, user_input: dict[str, Any] | None = None) -> FlowResult:
         if user_input is not None:
             coordinator = self.hass.data[DOMAIN].get(self._config_entry.entry_id)
@@ -246,7 +247,7 @@ class VaillantOptionsFlow(OptionsFlow):
                 self.hass.async_create_task(
                     async_export_discovery_dump(self.hass, coordinator, grab_duration)
                 )
-            return self.async_create_entry(title="", data={})
+            return self.async_abort(reason="export_started")
 
         return self.async_show_form(
             step_id="export_dump",

--- a/custom_components/vaillant_ebus/config_flow.py
+++ b/custom_components/vaillant_ebus/config_flow.py
@@ -234,7 +234,8 @@ class VaillantOptionsFlow(OptionsFlow):
             ),
         )
 
-    # Export dump: confirm + grab_duration
+    # Export dump: confirm + grab_duration, runs in background so long grabs
+    # do not block the flow (frontend times out otherwise).
     async def async_step_export_dump(self, user_input: dict[str, Any] | None = None) -> FlowResult:
         if user_input is not None:
             coordinator = self.hass.data[DOMAIN].get(self._config_entry.entry_id)
@@ -242,7 +243,9 @@ class VaillantOptionsFlow(OptionsFlow):
                 grab_duration = user_input.get("grab_duration", 10)
                 from .dump_service import async_export_discovery_dump
 
-                await async_export_discovery_dump(self.hass, coordinator, grab_duration)
+                self.hass.async_create_task(
+                    async_export_discovery_dump(self.hass, coordinator, grab_duration)
+                )
             return self.async_create_entry(title="", data={})
 
         return self.async_show_form(

--- a/custom_components/vaillant_ebus/const.py
+++ b/custom_components/vaillant_ebus/const.py
@@ -57,5 +57,7 @@ HA_TO_EBUSD_HVAC = {
     "off": "off",
     "auto": "auto",
     "heat": "day",
-    "cool": "night",
 }
+
+# Number of days for the manual cooling period when COOL is selected on a climate.
+COOLING_DAYS_DEFAULT = 3

--- a/custom_components/vaillant_ebus/const.py
+++ b/custom_components/vaillant_ebus/const.py
@@ -11,12 +11,14 @@ CONF_SCAN_INTERVAL = "scan_interval"
 CONF_AWAY_DURATION = "away_duration"
 CONF_QUICK_VETO_DURATION = "quick_veto_duration"
 CONF_QUICK_VETO_TEMP = "quick_veto_temp"
+CONF_COOLING_DURATION = "cooling_duration"
 DEFAULT_EBUSD_HOST = ""
 DEFAULT_EBUSD_PORT = 8888
 DEFAULT_EBUSD_POLL_INTERVAL = 30
 DEFAULT_AWAY_DURATION = 7
 DEFAULT_QUICK_VETO_DURATION = 3
 DEFAULT_QUICK_VETO_TEMP = 21.0
+DEFAULT_COOLING_DURATION = 3
 DISCOVERY_PORT = 8888
 DISCOVERY_TIMEOUT = 3
 DISCOVERY_CANDIDATES = ["core-ebusd", "localhost", "127.0.0.1", "homeassistant.local"]
@@ -58,6 +60,3 @@ HA_TO_EBUSD_HVAC = {
     "auto": "auto",
     "heat": "day",
 }
-
-# Number of days for the manual cooling period when COOL is selected on a climate.
-COOLING_DAYS_DEFAULT = 3

--- a/custom_components/vaillant_ebus/coordinator.py
+++ b/custom_components/vaillant_ebus/coordinator.py
@@ -391,6 +391,10 @@ class VaillantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             ",02000000da00,value,,IGN:4,,,,value,,HDA:3",
             "r5,ctlv2,ManualCoolingEndDate,ManualCoolingEndDate,31,15,B524"
             ",02000000db00,value,,IGN:4,,,,value,,HDA:3",
+            "w,ctlv2,ManualCoolingStartDate,ManualCoolingStartDate,31,15,B524"
+            ",02010000da00,value,m,HDA:3",
+            "w,ctlv2,ManualCoolingEndDate,ManualCoolingEndDate,31,15,B524"
+            ",02010000db00,value,m,HDA:3",
         ]
         for definition in defines:
             try:

--- a/custom_components/vaillant_ebus/coordinator.py
+++ b/custom_components/vaillant_ebus/coordinator.py
@@ -607,6 +607,29 @@ class VaillantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         return {"ebusd": await self._async_values_from_registers()}
 
+    # Write one or more registers through the central write path. Each write is
+    # verified by read-back; on any failure the already-written registers are
+    # reported but not rolled back. A single refresh fires after all writes.
+    async def async_write_registers(
+        self,
+        writes: list[tuple[str, str, str]],
+    ) -> bool:
+        if not self.ebus or not self.ebus.is_connected:
+            return False
+        all_ok = True
+        for circuit, name, value in writes:
+            result = await self.ebus.write_register(circuit, name, value)
+            if not result.success:
+                _LOGGER.warning("Write failed %s.%s=%s: %s", circuit, name, value, result.error_message)
+                all_ok = False
+        if all_ok:
+            self.async_request_refresh()
+        return all_ok
+
+    # Convenience wrapper for a single-register write through the central path.
+    async def async_write_register(self, circuit: str, name: str, value: str) -> bool:
+        return await self.async_write_registers([(circuit, name, value)])
+
     async def async_stop(self) -> None:
         if self._cancel_delayed_rediscovery:
             self._cancel_delayed_rediscovery()

--- a/custom_components/vaillant_ebus/coordinator.py
+++ b/custom_components/vaillant_ebus/coordinator.py
@@ -387,6 +387,10 @@ class VaillantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         defines = [
             "r5,ctlv2,z1RoomHumidity,z1RoomHumidity,31,15,B524,020003002800"
             ",value,,IGN:4,,,,value,,EXP,,%,z1 Room Humidity",
+            "r5,ctlv2,ManualCoolingStartDate,ManualCoolingStartDate,31,15,B524"
+            ",02000000da00,value,,IGN:4,,,,value,,HDA:3",
+            "r5,ctlv2,ManualCoolingEndDate,ManualCoolingEndDate,31,15,B524"
+            ",02000000db00,value,,IGN:4,,,,value,,HDA:3",
         ]
         for definition in defines:
             try:

--- a/custom_components/vaillant_ebus/datetime.py
+++ b/custom_components/vaillant_ebus/datetime.py
@@ -113,14 +113,12 @@ class EbusdHolidayEntity(CoordinatorEntity[VaillantCoordinator], DateTimeEntity)
         except ValueError, TypeError:
             return None
 
-    # Write holiday date to ebusd register and trigger refresh
+    # Write holiday date to ebusd register through the central write path
     async def async_set_value(self, value: datetime) -> None:
-        ebus = self.coordinator.ebus
-        if ebus:
-            date_str = value.strftime(DATE_FMT)
-            result = await ebus.write_register(self.coordinator.heating_circuit, self._register, date_str)
-            if result.success:
-                await self.coordinator.async_request_refresh()
+        if self.coordinator.ebus:
+            await self.coordinator.async_write_register(
+                self.coordinator.heating_circuit, self._register, value.strftime(DATE_FMT)
+            )
 
 
 class EbusdManualCoolingEntity(CoordinatorEntity[VaillantCoordinator], DateTimeEntity):
@@ -156,9 +154,5 @@ class EbusdManualCoolingEntity(CoordinatorEntity[VaillantCoordinator], DateTimeE
             return None
 
     async def async_set_value(self, value: datetime) -> None:
-        ebus = self.coordinator.ebus
-        if ebus:
-            date_str = value.strftime(DATE_FMT)
-            result = await ebus.write_register("ctlv2", self._register, date_str)
-            if result.success:
-                await self.coordinator.async_request_refresh()
+        if self.coordinator.ebus:
+            await self.coordinator.async_write_register("ctlv2", self._register, value.strftime(DATE_FMT))

--- a/custom_components/vaillant_ebus/datetime.py
+++ b/custom_components/vaillant_ebus/datetime.py
@@ -27,6 +27,12 @@ HOLIDAY_ENTITIES = [
     ("DHW Holiday End", "HwcHolidayEndPeriod", "mdi:calendar-end", "dhw"),
 ]
 
+# Manual cooling period (myVaillant "cool until [date]"), read/write on ctlv2.
+MANUAL_COOLING_ENTITIES = [
+    ("Manual Cooling Start Date", "ManualCoolingStartDate", "mdi:snowflake", "ctlv2"),
+    ("Manual Cooling End Date", "ManualCoolingEndDate", "mdi:snowflake", "ctlv2"),
+]
+
 
 # Create datetime entities for quick veto end and holiday periods
 async def async_setup_entry(
@@ -38,6 +44,8 @@ async def async_setup_entry(
     entities: list[DateTimeEntity] = [EbusdQuickVetoEndEntity(coordinator, entry)]
     for name, register, icon, zone in HOLIDAY_ENTITIES:
         entities.append(EbusdHolidayEntity(coordinator, entry, name, register, icon, zone))
+    for name, register, icon, zone in MANUAL_COOLING_ENTITIES:
+        entities.append(EbusdManualCoolingEntity(coordinator, entry, name, register, icon, zone))
     async_add_entities(entities)
 
 
@@ -111,5 +119,46 @@ class EbusdHolidayEntity(CoordinatorEntity[VaillantCoordinator], DateTimeEntity)
         if ebus:
             date_str = value.strftime(DATE_FMT)
             result = await ebus.write_register(self.coordinator.heating_circuit, self._register, date_str)
+            if result.success:
+                await self.coordinator.async_request_refresh()
+
+
+class EbusdManualCoolingEntity(CoordinatorEntity[VaillantCoordinator], DateTimeEntity):
+    """Manual cooling start/end date (myVaillant 'cool until [date]')."""
+
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: VaillantCoordinator,
+        entry: ConfigEntry,
+        name: str,
+        register: str,
+        icon: str,
+        zone: str,
+    ) -> None:
+        super().__init__(coordinator)
+        self._register = register
+        self._attr_name = name
+        self._attr_icon = icon
+        self._attr_unique_id = f"{entry.entry_id}_{register.lower()}"
+        self._attr_device_info = coordinator.get_device_info(zone)
+
+    @property
+    def native_value(self) -> datetime | None:
+        raw = self.coordinator.data.get("ebusd", {}).get(f"ctlv2.{self._register}.value")
+        if not raw or str(raw) in ("-", "") or str(raw).startswith(("ERR:", "no data stored")):
+            return None
+        try:
+            naive = datetime.strptime(f"{raw} {DEFAULT_TIME}", f"{DATE_FMT} {TIME_FMT}")
+            return naive.replace(tzinfo=dt_util.DEFAULT_TIME_ZONE)
+        except ValueError:
+            return None
+
+    async def async_set_value(self, value: datetime) -> None:
+        ebus = self.coordinator.ebus
+        if ebus:
+            date_str = value.strftime(DATE_FMT)
+            result = await ebus.write_register("ctlv2", self._register, date_str)
             if result.success:
                 await self.coordinator.async_request_refresh()

--- a/custom_components/vaillant_ebus/dump_service.py
+++ b/custom_components/vaillant_ebus/dump_service.py
@@ -10,6 +10,7 @@ import yaml
 from homeassistant.components import persistent_notification
 from homeassistant.core import HomeAssistant
 
+from .backend.grab_parser import parse_grab_lines, unknown_telegrams
 from .backend.mapping import REGISTER_MAP
 from .const import DOMAIN, SENSITIVE_FIELDS
 from .coordinator import VaillantCoordinator
@@ -197,6 +198,12 @@ async def async_export_discovery_dump(
     }
     if grab_lines:
         dump_data["grab"] = grab_lines
+        try:
+            telegrams = parse_grab_lines(grab_lines)
+            dump_data["labeled_telegrams"] = [t for t in telegrams if t["label"]]
+            dump_data["unknown_telegrams"] = unknown_telegrams(grab_lines)
+        except Exception as exc:  # pragma: no cover - defensive
+            _LOGGER.warning("Failed to parse grab telegrams: %s", exc)
     if after_registers:
         dump_data["after_registers"] = after_registers
         dump_data["raw_find_lines_after"] = after_raw_lines

--- a/custom_components/vaillant_ebus/manifest.json
+++ b/custom_components/vaillant_ebus/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/MarkBovee/vaillant-ebus/issues",
   "requirements": [],
-  "version": "1.2.5"
+  "version": "1.2.6"
 }

--- a/custom_components/vaillant_ebus/manifest.json
+++ b/custom_components/vaillant_ebus/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/MarkBovee/vaillant-ebus/issues",
   "requirements": [],
-  "version": "1.2.4"
+  "version": "1.2.5"
 }

--- a/custom_components/vaillant_ebus/manifest.json
+++ b/custom_components/vaillant_ebus/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/MarkBovee/vaillant-ebus/issues",
   "requirements": [],
-  "version": "1.2.6"
+  "version": "1.3.0"
 }

--- a/custom_components/vaillant_ebus/number.py
+++ b/custom_components/vaillant_ebus/number.py
@@ -86,12 +86,6 @@ class EbusdNumber(CoordinatorEntity[VaillantCoordinator], NumberEntity):
             raise ValueError(f"Value {value} not in [{self._attr_native_min_value}, {self._attr_native_max_value}]")
         if not self.coordinator.ebus:
             return
-        result = await self.coordinator.ebus.write_register(
-            self._desc.circuit,
-            self._desc.name,
-            str(value),
-        )
-        if result.success:
-            await self.coordinator.async_request_refresh()
-        else:
-            _LOGGER.warning("Write failed for %s: %s", self._desc.key, result.error_message)
+        ok = await self.coordinator.async_write_register(self._desc.circuit, self._desc.name, str(value))
+        if not ok:
+            _LOGGER.warning("Write failed for %s", self._desc.key)

--- a/custom_components/vaillant_ebus/select.py
+++ b/custom_components/vaillant_ebus/select.py
@@ -77,12 +77,6 @@ class EbusdSelect(CoordinatorEntity[VaillantCoordinator], SelectEntity):
             raise ValueError(f"Option '{option}' not valid for {self._desc.key}. Valid options: {self._attr_options}")
         if not self.coordinator.ebus:
             return
-        result = await self.coordinator.ebus.write_register(
-            self._desc.circuit,
-            self._desc.name,
-            option,
-        )
-        if result.success:
-            await self.coordinator.async_request_refresh()
-        else:
-            _LOGGER.warning("Write failed for %s: %s", self._desc.key, result.error_message)
+        ok = await self.coordinator.async_write_register(self._desc.circuit, self._desc.name, option)
+        if not ok:
+            _LOGGER.warning("Write failed for %s", self._desc.key)

--- a/custom_components/vaillant_ebus/strings.json
+++ b/custom_components/vaillant_ebus/strings.json
@@ -41,7 +41,8 @@
           "scan_interval": "Poll interval (seconds)",
           "away_duration": "Default away duration (days)",
           "quick_veto_duration": "Default quick veto duration (hours)",
-          "quick_veto_temp": "Default quick veto temperature"
+          "quick_veto_temp": "Default quick veto temperature",
+          "cooling_duration": "Manual cooling duration (days)"
         }
       },
       "export_dump": {

--- a/custom_components/vaillant_ebus/strings.json
+++ b/custom_components/vaillant_ebus/strings.json
@@ -51,6 +51,9 @@
           "grab_duration": "Raw traffic capture (seconds)"
         }
       }
+    },
+    "abort": {
+      "export_started": "Discovery dump export started. The YAML file is written in the background — a notification will appear when it is ready."
     }
   }
 }

--- a/custom_components/vaillant_ebus/switch.py
+++ b/custom_components/vaillant_ebus/switch.py
@@ -93,19 +93,13 @@ class EbusdSwitch(CoordinatorEntity[VaillantCoordinator], SwitchEntity):
     async def async_turn_off(self, **kwargs: Any) -> None:
         await self._write("0")
 
-    # Write value to ebusd and trigger refresh
+    # Write value to ebusd through the central write path
     async def _write(self, value: str) -> None:
         if not self.coordinator.ebus:
             return
-        result = await self.coordinator.ebus.write_register(
-            self._desc.circuit,
-            self._desc.name,
-            value,
-        )
-        if result.success:
-            await self.coordinator.async_request_refresh()
-        else:
-            _LOGGER.warning("Write failed for %s: %s", self._desc.key, result.error_message)
+        ok = await self.coordinator.async_write_register(self._desc.circuit, self._desc.name, value)
+        if not ok:
+            _LOGGER.warning("Write failed for %s", self._desc.key)
 
 
 # Parse Vaillant date string to date object
@@ -159,8 +153,7 @@ class AwayModeSwitch(CoordinatorEntity[VaillantCoordinator], SwitchEntity):
 
     # Set holiday dates from today to far future, enable away mode
     async def async_turn_on(self, **kwargs: Any) -> None:
-        ebus = self.coordinator.ebus
-        if not ebus:
+        if not self.coordinator.ebus:
             return
         today = _today_str()
         data = self.coordinator.data.get("ebusd", {})
@@ -171,27 +164,22 @@ class AwayModeSwitch(CoordinatorEntity[VaillantCoordinator], SwitchEntity):
             (self.coordinator.heating_circuit, "HwcHolidayStartPeriod", today),
             (self.coordinator.heating_circuit, "HwcHolidayEndPeriod", FAR_FUTURE),
         ]
-        for circuit, name, value in writes:
-            await ebus.write_register(circuit, name, value)
         if holiday_temp:
-            await ebus.write_register(self.coordinator.heating_circuit, "Z1HolidayTemp", holiday_temp)
-        await self.coordinator.async_request_refresh()
+            writes.append((self.coordinator.heating_circuit, "Z1HolidayTemp", holiday_temp))
+        await self.coordinator.async_write_registers(writes)
 
     # Reset holiday dates to unset, disable away mode
     async def async_turn_off(self, **kwargs: Any) -> None:
-        ebus = self.coordinator.ebus
-        if not ebus:
+        if not self.coordinator.ebus:
             return
         writes = [
             (self.coordinator.heating_circuit, "Z1HolidayStartPeriod", UNSET_DATE),
             (self.coordinator.heating_circuit, "Z1HolidayEndPeriod", UNSET_DATE),
             (self.coordinator.heating_circuit, "HwcHolidayStartPeriod", UNSET_DATE),
             (self.coordinator.heating_circuit, "HwcHolidayEndPeriod", UNSET_DATE),
+            (self.coordinator.heating_circuit, "Z1HolidayTemp", "15"),
         ]
-        for circuit, name, value in writes:
-            await ebus.write_register(circuit, name, value)
-        await ebus.write_register(self.coordinator.heating_circuit, "Z1HolidayTemp", "15")
-        await self.coordinator.async_request_refresh()
+        await self.coordinator.async_write_registers(writes)
 
 
 class HwcBoostSwitch(CoordinatorEntity[VaillantCoordinator], SwitchEntity):
@@ -221,19 +209,11 @@ class HwcBoostSwitch(CoordinatorEntity[VaillantCoordinator], SwitchEntity):
 
     # Write "load" to HwcSFMode to start DHW boost
     async def async_turn_on(self, **kwargs: Any) -> None:
-        ebus = self.coordinator.ebus
-        if not ebus:
-            return
-        await ebus.write_register(self.coordinator.heating_circuit, "HwcSFMode", "load")
-        await self.coordinator.async_request_refresh()
+        await self.coordinator.async_write_register(self.coordinator.heating_circuit, "HwcSFMode", "load")
 
     # Write "auto" to HwcSFMode to stop DHW boost
     async def async_turn_off(self, **kwargs: Any) -> None:
-        ebus = self.coordinator.ebus
-        if not ebus:
-            return
-        await ebus.write_register(self.coordinator.heating_circuit, "HwcSFMode", "auto")
-        await self.coordinator.async_request_refresh()
+        await self.coordinator.async_write_register(self.coordinator.heating_circuit, "HwcSFMode", "auto")
 
 
 class HwcAwayModeSwitch(CoordinatorEntity[VaillantCoordinator], SwitchEntity):
@@ -264,19 +244,20 @@ class HwcAwayModeSwitch(CoordinatorEntity[VaillantCoordinator], SwitchEntity):
 
     # Set DHW holiday from today to far future
     async def async_turn_on(self, **kwargs: Any) -> None:
-        ebus = self.coordinator.ebus
-        if not ebus:
-            return
-        today = _today_str()
-        await ebus.write_register(self.coordinator.heating_circuit, "HwcHolidayStartPeriod", today)
-        await ebus.write_register(self.coordinator.heating_circuit, "HwcHolidayEndPeriod", FAR_FUTURE)
-        await self.coordinator.async_request_refresh()
+        ckt = self.coordinator.heating_circuit
+        await self.coordinator.async_write_registers(
+            [
+                (ckt, "HwcHolidayStartPeriod", _today_str()),
+                (ckt, "HwcHolidayEndPeriod", FAR_FUTURE),
+            ]
+        )
 
     # Reset DHW holiday dates to unset value
     async def async_turn_off(self, **kwargs: Any) -> None:
-        ebus = self.coordinator.ebus
-        if not ebus:
-            return
-        await ebus.write_register(self.coordinator.heating_circuit, "HwcHolidayStartPeriod", UNSET_DATE)
-        await ebus.write_register(self.coordinator.heating_circuit, "HwcHolidayEndPeriod", UNSET_DATE)
-        await self.coordinator.async_request_refresh()
+        ckt = self.coordinator.heating_circuit
+        await self.coordinator.async_write_registers(
+            [
+                (ckt, "HwcHolidayStartPeriod", UNSET_DATE),
+                (ckt, "HwcHolidayEndPeriod", UNSET_DATE),
+            ]
+        )

--- a/custom_components/vaillant_ebus/translations/en.json
+++ b/custom_components/vaillant_ebus/translations/en.json
@@ -53,6 +53,9 @@
           "grab_duration": "Raw traffic capture (seconds)"
         }
       }
+    },
+    "abort": {
+      "export_started": "Discovery dump export started. The YAML file is written in the background — a notification will appear when it is ready."
     }
   },
   "issues": {

--- a/custom_components/vaillant_ebus/translations/en.json
+++ b/custom_components/vaillant_ebus/translations/en.json
@@ -43,7 +43,8 @@
           "scan_interval": "Poll interval (seconds)",
           "away_duration": "Default away duration (days)",
           "quick_veto_duration": "Default quick veto duration (hours)",
-          "quick_veto_temp": "Default quick veto temperature"
+          "quick_veto_temp": "Default quick veto temperature",
+          "cooling_duration": "Manual cooling duration (days)"
         }
       },
       "export_dump": {

--- a/custom_components/vaillant_ebus/water_heater.py
+++ b/custom_components/vaillant_ebus/water_heater.py
@@ -131,16 +131,17 @@ class EbusdWaterHeater(CoordinatorEntity[VaillantCoordinator], WaterHeaterEntity
     async def async_set_operation_mode(self, operation_mode: str) -> None:
         if operation_mode not in OPERATION_MODES:
             raise ValueError(f"Unsupported DHW operation: {operation_mode}")
-        ebus = self.coordinator.ebus
-        if not ebus:
-            return
+        ckt = self.coordinator.heating_circuit
         if operation_mode == "boost":
-            await ebus.write_register(self.coordinator.heating_circuit, "HwcSFMode", "load")
+            await self.coordinator.async_write_registers([(ckt, "HwcSFMode", "load")])
         else:
             ebusd_mode = HA_TO_EBUSD_OPMODE.get(operation_mode, operation_mode)
-            await ebus.write_register(self.coordinator.heating_circuit, "HwcSFMode", "auto")
-            await ebus.write_register(self.coordinator.heating_circuit, "HwcOpMode", ebusd_mode)
-        await self.coordinator.async_request_refresh()
+            await self.coordinator.async_write_registers(
+                [
+                    (ckt, "HwcSFMode", "auto"),
+                    (ckt, "HwcOpMode", ebusd_mode),
+                ]
+            )
 
     # Turn DHW on by setting operation mode to auto
     async def async_turn_on(self) -> None:
@@ -155,18 +156,22 @@ class EbusdWaterHeater(CoordinatorEntity[VaillantCoordinator], WaterHeaterEntity
         today = date.today().strftime(DATE_FMT)
         away_duration = self.coordinator._entry.options.get(CONF_AWAY_DURATION, DEFAULT_AWAY_DURATION)
         end = (date.today() + timedelta(days=away_duration)).strftime(DATE_FMT)
-        await self._write("HwcHolidayStartPeriod", today)
-        await self._write("HwcHolidayEndPeriod", end)
+        await self.coordinator.async_write_registers(
+            [
+                (self.coordinator.heating_circuit, "HwcHolidayStartPeriod", today),
+                (self.coordinator.heating_circuit, "HwcHolidayEndPeriod", end),
+            ]
+        )
 
     # Disable away mode by resetting holiday dates to unset
     async def async_turn_away_mode_off(self) -> None:
-        await self._write("HwcHolidayStartPeriod", HOLIDAY_RESET)
-        await self._write("HwcHolidayEndPeriod", HOLIDAY_RESET)
+        await self.coordinator.async_write_registers(
+            [
+                (self.coordinator.heating_circuit, "HwcHolidayStartPeriod", HOLIDAY_RESET),
+                (self.coordinator.heating_circuit, "HwcHolidayEndPeriod", HOLIDAY_RESET),
+            ]
+        )
 
-    # Write value to a DHW register and trigger coordinator refresh
+    # Write value to a DHW register through the central write path
     async def _write(self, name: str, value: str) -> None:
-        ebus = self.coordinator.ebus
-        if ebus:
-            result = await ebus.write_register(self.coordinator.heating_circuit, name, value)
-            if result.success:
-                await self.coordinator.async_request_refresh()
+        await self.coordinator.async_write_register(self.coordinator.heating_circuit, name, value)

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -135,9 +135,27 @@ The datetime platform exposes them as read/write `DateTimeEntity` instances.
 
 Selecting `HVACMode.COOL` on the climate entity writes the manual cooling end
 date (today + the `cooling_duration` option, default 3 days) via the write route
-and switches `Z1OpMode` to `auto`. The old `"cool": "night"` write was removed
-from `HA_TO_EBUSD_HVAC` because `night` is not retained by this controller. The
-`cooling_duration` option is configurable per entry in the options flow.
+and switches `Z1OpMode` to `auto`. Selecting `HEAT` clears the manual cooling
+end date and switches to `day`, so a cooling period is properly cancelled. The
+old `"cool": "night"` write was removed from `HA_TO_EBUSD_HVAC` because `night`
+is not retained by this controller. The `cooling_duration` option is
+configurable per entry in the options flow.
+
+### Central write path
+
+All entities write through `VaillantCoordinator.async_write_registers()`, which
+takes a list of `(circuit, name, value)` tuples, writes each (verified by
+read-back), and triggers a single coordinator refresh. Use it for any operation
+that touches more than one register so the writes are grouped:
+
+```python
+await coordinator.async_write_registers([
+    (circuit, "HwcHolidayStartPeriod", today),
+    (circuit, "HwcHolidayEndPeriod", end),
+])
+```
+
+For a single write use `coordinator.async_write_register(circuit, name, value)`.
 
 ## Testing against live ebusd
 

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -134,9 +134,10 @@ The datetime platform exposes them as read/write `DateTimeEntity` instances.
 ### Climate COOL integration
 
 Selecting `HVACMode.COOL` on the climate entity writes the manual cooling end
-date (today + `COOLING_DAYS_DEFAULT`, default 3 days) via the write route and
-switches `Z1OpMode` to `auto`. The old `"cool": "night"` write was removed from
-`HA_TO_EBUSD_HVAC` because `night` is not retained by this controller.
+date (today + the `cooling_duration` option, default 3 days) via the write route
+and switches `Z1OpMode` to `auto`. The old `"cool": "night"` write was removed
+from `HA_TO_EBUSD_HVAC` because `night` is not retained by this controller. The
+`cooling_duration` option is configurable per entry in the options flow.
 
 ## Testing against live ebusd
 

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -104,6 +104,28 @@ defines = [
 
 The register then appears as `ctlv2.z1RoomHumidity` and needs a mapping entry in `mapping.py`.
 
+### Date registers (manual cooling start/end)
+
+The manual cooling start/end dates (myVaillant "cool until [date]") are defined
+the same way, but use the `HDA:3` date field type (day;month;year with the year
+byte as year−2000, no BCD) plus an `IGN:4` skip of the echo prefix, matching the
+holiday/away date registers:
+
+```python
+defines = [
+    "r5,ctlv2,ManualCoolingStartDate,ManualCoolingStartDate,31,15,B524"
+    ",02000000da00,value,,IGN:4,,,,value,,HDA:3",
+    "r5,ctlv2,ManualCoolingEndDate,ManualCoolingEndDate,31,15,B524"
+    ",02000000db00,value,,IGN:4,,,,value,,HDA:3",
+]
+```
+
+These derive from `john30/ebusd-configuration` issue #644
+(`@ext(0xda, 0)` / `@ext(0xdb, 0)` on the `_720` r_1 base) and were verified on a
+CTLV2 `SW0514`/`HW1104`. A write-route exists via a separate `w` define with
+`value,m,HDA:3` on the write-sub `02010000da00/db00`; it is not yet wired into
+the integration.
+
 ## Testing against live ebusd
 
 ```bash

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -117,14 +117,19 @@ defines = [
     ",02000000da00,value,,IGN:4,,,,value,,HDA:3",
     "r5,ctlv2,ManualCoolingEndDate,ManualCoolingEndDate,31,15,B524"
     ",02000000db00,value,,IGN:4,,,,value,,HDA:3",
+    # write route: separate w-define on the 0201... write-sub with value,m
+    "w,ctlv2,ManualCoolingStartDate,ManualCoolingStartDate,31,15,B524"
+    ",02010000da00,value,m,HDA:3",
+    "w,ctlv2,ManualCoolingEndDate,ManualCoolingEndDate,31,15,B524"
+    ",02010000db00,value,m,HDA:3",
 ]
 ```
 
 These derive from `john30/ebusd-configuration` issue #644
 (`@ext(0xda, 0)` / `@ext(0xdb, 0)` on the `_720` r_1 base) and were verified on a
-CTLV2 `SW0514`/`HW1104`. A write-route exists via a separate `w` define with
-`value,m,HDA:3` on the write-sub `02010000da00/db00`; it is not yet wired into
-the integration.
+CTLV2 `SW0514`/`HW1104`. The write route uses the `0201...` write-sub (w_1-base)
+with a `value,m,HDA:3` field; `write_register` then accepts `DD.MM.YYYY` values.
+The datetime platform exposes them as read/write `DateTimeEntity` instances.
 
 ## Testing against live ebusd
 

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -131,6 +131,13 @@ CTLV2 `SW0514`/`HW1104`. The write route uses the `0201...` write-sub (w_1-base)
 with a `value,m,HDA:3` field; `write_register` then accepts `DD.MM.YYYY` values.
 The datetime platform exposes them as read/write `DateTimeEntity` instances.
 
+### Climate COOL integration
+
+Selecting `HVACMode.COOL` on the climate entity writes the manual cooling end
+date (today + `COOLING_DAYS_DEFAULT`, default 3 days) via the write route and
+switches `Z1OpMode` to `auto`. The old `"cool": "night"` write was removed from
+`HA_TO_EBUSD_HVAC` because `night` is not retained by this controller.
+
 ## Testing against live ebusd
 
 ```bash

--- a/tests/fixtures/community/arotherm_plus_cooling_run_discovery.yaml
+++ b/tests/fixtures/community/arotherm_plus_cooling_run_discovery.yaml
@@ -1,0 +1,12597 @@
+# Discovery dump for vaillant_ebus
+# Review this file for sensitive information before sharing
+metadata:
+  timestamp: '2026-08-13T13:32:57.088066'
+  ebusd_version: null
+  register_count: 696
+  grab_duration: 10
+  dump_version: 3
+raw_find_lines:
+- Broadcast Datetime = no data stored
+- Broadcast Error = no data stored
+- Broadcast HwcStatus = no data stored
+- Broadcast Id = no data stored
+- Broadcast IdAnswer = no data stored
+- Broadcast IdQuery = no data stored
+- Broadcast Load = no data stored
+- Broadcast Outsidetemp = 31.062
+- Broadcast Queryexistence =  (empty for 31fe07fe00 / )
+- Broadcast Signoflife = no data stored
+- Broadcast Vdatetime = 13:31:27;13.08.2026
+- Broadcast Vdatetime = no data stored
+- ctlv2 z1RoomHumidity = 50
+- ctlv3 AdaptHeatCurve = yes
+- ctlv3 AdaptHeatCurve = no data stored
+- ctlv3 CcTimer_Config = no data stored
+- ctlv3 CcTimer_Friday0 = no data stored
+- ctlv3 CcTimer_Friday1 = no data stored
+- ctlv3 CcTimer_Friday2 = no data stored
+- ctlv3 CcTimer_Friday = no data stored
+- ctlv3 CcTimer_Monday0 = no data stored
+- ctlv3 CcTimer_Monday1 = no data stored
+- ctlv3 CcTimer_Monday2 = no data stored
+- ctlv3 CcTimer_Monday = no data stored
+- ctlv3 CcTimer_Saturday0 = no data stored
+- ctlv3 CcTimer_Saturday1 = no data stored
+- ctlv3 CcTimer_Saturday2 = no data stored
+- ctlv3 CcTimer_Saturday = no data stored
+- ctlv3 CcTimer_Sunday0 = no data stored
+- ctlv3 CcTimer_Sunday1 = no data stored
+- ctlv3 CcTimer_Sunday2 = no data stored
+- ctlv3 CcTimer_Sunday = no data stored
+- ctlv3 CcTimer_Thursday0 = no data stored
+- ctlv3 CcTimer_Thursday1 = no data stored
+- ctlv3 CcTimer_Thursday2 = no data stored
+- ctlv3 CcTimer_Thursday = no data stored
+- ctlv3 CcTimer_Timeframes = 0;0;0;0;0;0;0
+- ctlv3 CcTimer_Tuesday0 = no data stored
+- ctlv3 CcTimer_Tuesday1 = no data stored
+- ctlv3 CcTimer_Tuesday2 = no data stored
+- ctlv3 CcTimer_Tuesday = no data stored
+- ctlv3 CcTimer_Wednesday0 = no data stored
+- ctlv3 CcTimer_Wednesday1 = no data stored
+- ctlv3 CcTimer_Wednesday2 = no data stored
+- ctlv3 CcTimer_Wednesday = no data stored
+- ctlv3 Clearerrorhistory = no data stored
+- ctlv3 ContinuousHeating = -26
+- ctlv3 ContinuousHeating = no data stored
+- ctlv3 Currenterror = -;-;-;-;-
+- ctlv3 CylinderChargeHyst = 7
+- ctlv3 CylinderChargeHyst = no data stored
+- ctlv3 CylinderChargeOffset = 5
+- ctlv3 CylinderChargeOffset = no data stored
+- ctlv3 Date = 13.08.2026
+- ctlv3 Date = no data stored
+- ctlv3 DisplayedOutsideTemp = 31.125
+- ctlv3 Errorhistory = no data stored
+- ctlv3 FrostOverRideTime = no data stored
+- ctlv3 FrostOverRideTime = no data stored
+- ctlv3 Hc1ActualFlowTempDesired = 21
+- ctlv3 Hc1AutoOffMode = no data stored
+- ctlv3 Hc1AutoOffMode = no data stored
+- ctlv3 Hc1CircuitType = no data stored
+- ctlv3 Hc1ExcessTemp = 0.0
+- ctlv3 Hc1ExcessTemp = no data stored
+- ctlv3 Hc1FlowTemp = 17.75
+- ctlv3 Hc1HeatCurve = 0.4
+- ctlv3 Hc1HeatCurve = no data stored
+- ctlv3 Hc1HeatCurveAdaption = 0.0
+- ctlv3 Hc1MaxFlowTempDesired = 50
+- ctlv3 Hc1MaxFlowTempDesired = no data stored
+- ctlv3 Hc1MinCoolingTempDesired = 21
+- ctlv3 Hc1MinCoolingTempDesired = no data stored
+- ctlv3 Hc1MinFlowTempDesired = 25
+- ctlv3 Hc1MinFlowTempDesired = no data stored
+- ctlv3 Hc1MixerMovement = -25
+- ctlv3 Hc1PumpStatus = 2
+- ctlv3 Hc1PumpStatus = no data stored
+- ctlv3 Hc1RoomTempSwitchOn = modulating
+- ctlv3 Hc1RoomTempSwitchOn = no data stored
+- ctlv3 Hc1Status = no data stored
+- ctlv3 Hc1Status = no data stored
+- ctlv3 Hc1SummerTempLimit = 16
+- ctlv3 Hc1SummerTempLimit = no data stored
+- ctlv3 Hc2ActualFlowTempDesired = 0.0
+- ctlv3 Hc2AutoOffMode = no data stored
+- ctlv3 Hc2AutoOffMode = no data stored
+- ctlv3 Hc2CircuitType = no data stored
+- ctlv3 Hc2ExcessTemp = 0.0
+- ctlv3 Hc2ExcessTemp = no data stored
+- ctlv3 Hc2FlowTemp = 23.875
+- ctlv3 Hc2HeatCurve = 0.3
+- ctlv3 Hc2HeatCurve = no data stored
+- ctlv3 Hc2HeatCurveAdaption = 0.0
+- ctlv3 Hc2MaxFlowTempDesired = 50
+- ctlv3 Hc2MaxFlowTempDesired = no data stored
+- ctlv3 Hc2MinCoolingTempDesired = no data stored
+- ctlv3 Hc2MinCoolingTempDesired = no data stored
+- ctlv3 Hc2MinFlowTempDesired = 15
+- ctlv3 Hc2MinFlowTempDesired = no data stored
+- ctlv3 Hc2MixerMovement = -100
+- ctlv3 Hc2PumpStatus = 0
+- ctlv3 Hc2PumpStatus = no data stored
+- ctlv3 Hc2RoomTempSwitchOn = modulating
+- ctlv3 Hc2RoomTempSwitchOn = no data stored
+- ctlv3 Hc2Status = no data stored
+- ctlv3 Hc2Status = no data stored
+- ctlv3 Hc2SummerTempLimit = 16
+- ctlv3 Hc2SummerTempLimit = no data stored
+- ctlv3 Hc3ActualFlowTempDesired = no data stored
+- ctlv3 Hc3AutoOffMode = no data stored
+- ctlv3 Hc3AutoOffMode = no data stored
+- ctlv3 Hc3CircuitType = no data stored
+- ctlv3 Hc3ExcessTemp = no data stored
+- ctlv3 Hc3ExcessTemp = no data stored
+- ctlv3 Hc3FlowTemp = no data stored
+- ctlv3 Hc3HeatCurve = no data stored
+- ctlv3 Hc3HeatCurve = no data stored
+- ctlv3 Hc3HeatCurveAdaption = no data stored
+- ctlv3 Hc3MaxFlowTempDesired = no data stored
+- ctlv3 Hc3MaxFlowTempDesired = no data stored
+- ctlv3 Hc3MinCoolingTempDesired = no data stored
+- ctlv3 Hc3MinCoolingTempDesired = no data stored
+- ctlv3 Hc3MinFlowTempDesired = no data stored
+- ctlv3 Hc3MinFlowTempDesired = no data stored
+- ctlv3 Hc3MixerMovement = no data stored
+- ctlv3 Hc3PumpStatus = no data stored
+- ctlv3 Hc3PumpStatus = no data stored
+- ctlv3 Hc3RoomTempSwitchOn = no data stored
+- ctlv3 Hc3RoomTempSwitchOn = no data stored
+- ctlv3 Hc3Status = no data stored
+- ctlv3 Hc3Status = no data stored
+- ctlv3 Hc3SummerTempLimit = no data stored
+- ctlv3 Hc3SummerTempLimit = no data stored
+- ctlv3 HcStorageTempBottom =  (empty for f115b5240602000000a000 / 080000a000ffffff7f)
+- ctlv3 HcStorageTempTop =  (empty for f115b52406020000009f00 / 0800009f00ffffff7f)
+- ctlv3 HwcBankHolidayEndPeriod = no data stored
+- ctlv3 HwcBankHolidayEndPeriod = no data stored
+- ctlv3 HwcBankHolidayStartPeriod = no data stored
+- ctlv3 HwcBankHolidayStartPeriod = no data stored
+- ctlv3 HwcFlowTemp = no data stored
+- ctlv3 HwcHolidayEndPeriod = 01.01.2019
+- ctlv3 HwcHolidayEndPeriod = no data stored
+- ctlv3 HwcHolidayStartPeriod = 01.01.2019
+- ctlv3 HwcHolidayStartPeriod = no data stored
+- ctlv3 HwcLockTime = 30
+- ctlv3 HwcLockTime = no data stored
+- ctlv3 HwcMaxFlowTempDesired = 80
+- ctlv3 HwcMaxFlowTempDesired = no data stored
+- ctlv3 HwcOpMode = auto
+- ctlv3 HwcOpMode = no data stored
+- ctlv3 HwcParallelLoading = off
+- ctlv3 HwcParallelLoading = no data stored
+- ctlv3 HwcSFMode = no data stored
+- ctlv3 HwcSFMode = no data stored
+- ctlv3 HwcStorageTemp = 49.5
+- ctlv3 HwcStorageTempBottom =  (empty for f115b52406020000009e00 / 0800009e00ffffff7f)
+- ctlv3 HwcStorageTempTop =  (empty for f115b52406020000009d00 / 0800009d00ffffff7f)
+- ctlv3 HwcTempDesired = 52
+- ctlv3 HwcTempDesired = no data stored
+- ctlv3 HwcTimer_Config = no data stored
+- ctlv3 HwcTimer_Friday0 = 01:00;03:00;52.0
+- ctlv3 HwcTimer_Friday1 = no data stored
+- ctlv3 HwcTimer_Friday2 = no data stored
+- ctlv3 HwcTimer_Friday = no data stored
+- ctlv3 HwcTimer_Monday0 = 01:00;03:00;52.0
+- ctlv3 HwcTimer_Monday1 = no data stored
+- ctlv3 HwcTimer_Monday2 = no data stored
+- ctlv3 HwcTimer_Monday = no data stored
+- ctlv3 HwcTimer_Saturday0 = 01:00;03:00;52.0
+- ctlv3 HwcTimer_Saturday1 = no data stored
+- ctlv3 HwcTimer_Saturday2 = no data stored
+- ctlv3 HwcTimer_Saturday = no data stored
+- ctlv3 HwcTimer_Sunday0 = 01:00;03:00;52.0
+- ctlv3 HwcTimer_Sunday1 = no data stored
+- ctlv3 HwcTimer_Sunday2 = no data stored
+- ctlv3 HwcTimer_Sunday = no data stored
+- ctlv3 HwcTimer_Thursday0 = 01:00;03:00;52.0
+- ctlv3 HwcTimer_Thursday1 = no data stored
+- ctlv3 HwcTimer_Thursday2 = no data stored
+- ctlv3 HwcTimer_Thursday = no data stored
+- ctlv3 HwcTimer_Timeframes = 1;1;1;1;1;1;1
+- ctlv3 HwcTimer_Tuesday0 = 01:00;03:00;52.0
+- ctlv3 HwcTimer_Tuesday1 = no data stored
+- ctlv3 HwcTimer_Tuesday2 = no data stored
+- ctlv3 HwcTimer_Tuesday = no data stored
+- ctlv3 HwcTimer_Wednesday0 = 01:00;03:00;52.0
+- ctlv3 HwcTimer_Wednesday1 = no data stored
+- ctlv3 HwcTimer_Wednesday2 = no data stored
+- ctlv3 HwcTimer_Wednesday = no data stored
+- ctlv3 HydraulicScheme = 8
+- ctlv3 HydraulicScheme = no data stored
+- ctlv3 Installer1 = no data stored
+- ctlv3 Installer1 = no data stored
+- ctlv3 Installer2 = no data stored
+- ctlv3 Installer2 = no data stored
+- ctlv3 KeyCodeforConfigMenu = no data stored
+- ctlv3 KeyCodeforConfigMenu = no data stored
+- ctlv3 MaintenanceDate = no data stored
+- ctlv3 MaintenanceDate = no data stored
+- ctlv3 MaintenanceDue = no
+- ctlv3 MaxCylinderChargeTime = 120
+- ctlv3 MaxCylinderChargeTime = no data stored
+- ctlv3 MaxRoomHumidity = no data stored
+- ctlv3 MaxRoomHumidity = no data stored
+- ctlv3 MultiRelaySetting = 4
+- ctlv3 MultiRelaySetting = no data stored
+- ctlv3 OutsideTempAvg = 22.1055
+- ctlv3 OutsideTempAvg = no data stored
+- ctlv3 PhoneNumber1 = no data stored
+- ctlv3 PhoneNumber1 = no data stored
+- ctlv3 PhoneNumber2 = no data stored
+- ctlv3 PhoneNumber2 = no data stored
+- ctlv3 PrEnergySum = no data stored
+- ctlv3 PrEnergySum = no data stored
+- ctlv3 PrEnergySumHc = no data stored
+- ctlv3 PrEnergySumHc = no data stored
+- ctlv3 PrEnergySumHcLastMonth = no data stored
+- ctlv3 PrEnergySumHcLastMonth = no data stored
+- ctlv3 PrEnergySumHcThisMonth = no data stored
+- ctlv3 PrEnergySumHcThisMonth = no data stored
+- ctlv3 PrEnergySumHwc = no data stored
+- ctlv3 PrEnergySumHwc = no data stored
+- ctlv3 PrEnergySumHwcLastMonth = no data stored
+- ctlv3 PrEnergySumHwcLastMonth = no data stored
+- ctlv3 PrEnergySumHwcThisMonth = no data stored
+- ctlv3 PrEnergySumHwcThisMonth = no data stored
+- ctlv3 PrFuelSum = no data stored
+- ctlv3 PrFuelSum = no data stored
+- ctlv3 PrFuelSumHc = no data stored
+- ctlv3 PrFuelSumHc = no data stored
+- ctlv3 PrFuelSumHcLastMonth = no data stored
+- ctlv3 PrFuelSumHcLastMonth = no data stored
+- ctlv3 PrFuelSumHcThisMonth = no data stored
+- ctlv3 PrFuelSumHcThisMonth = no data stored
+- ctlv3 PrFuelSumHwc = no data stored
+- ctlv3 PrFuelSumHwc = no data stored
+- ctlv3 PrFuelSumHwcLastMonth = no data stored
+- ctlv3 PrFuelSumHwcLastMonth = no data stored
+- ctlv3 PrFuelSumHwcThisMonth = no data stored
+- ctlv3 PrFuelSumHwcThisMonth = no data stored
+- ctlv3 PumpAdditionalTime = no data stored
+- ctlv3 PumpAdditionalTime = no data stored
+- ctlv3 SolarYieldTotal = no data stored
+- ctlv3 SolarYieldTotal = no data stored
+- ctlv3 SystemFlowTemp =  (empty for f115b52406020000004b00 / 0800004b00ffffff7f)
+- ctlv3 Time = 12:35:01
+- ctlv3 Time = no data stored
+- ctlv3 WaterPressure = 1.8
+- ctlv3 YieldTotal = no data stored
+- ctlv3 YieldTotal = no data stored
+- ctlv3 Z1ActualRoomTempDesired = 0.0
+- ctlv3 Z1ActualRoomTempDesired = no data stored
+- ctlv3 Z1BankHolidayEndPeriod = no data stored
+- ctlv3 Z1BankHolidayEndPeriod = no data stored
+- ctlv3 Z1BankHolidayStartPeriod = no data stored
+- ctlv3 Z1BankHolidayStartPeriod = no data stored
+- ctlv3 Z1CoolingTemp = 24
+- ctlv3 Z1CoolingTemp = no data stored
+- ctlv3 Z1DayTemp = 21
+- ctlv3 Z1DayTemp = no data stored
+- ctlv3 Z1HolidayEndPeriod = 01.01.2019
+- ctlv3 Z1HolidayEndPeriod = no data stored
+- ctlv3 Z1HolidayStartPeriod = 01.01.2019
+- ctlv3 Z1HolidayStartPeriod = no data stored
+- ctlv3 Z1HolidayTemp = 20
+- ctlv3 Z1HolidayTemp = no data stored
+- ctlv3 Z1Name1 = no data stored
+- ctlv3 Z1Name1 = no data stored
+- ctlv3 Z1Name2 = no data stored
+- ctlv3 Z1Name2 = no data stored
+- ctlv3 Z1NightTemp = 20
+- ctlv3 Z1NightTemp = no data stored
+- ctlv3 Z1OpMode = day
+- ctlv3 Z1OpMode = no data stored
+- ctlv3 Z1QuickVetoDuration = no data stored
+- ctlv3 Z1QuickVetoDuration = no data stored
+- ctlv3 Z1QuickVetoEndDate = no data stored
+- ctlv3 Z1QuickVetoEndTime = no data stored
+- ctlv3 Z1QuickVetoTemp = no data stored
+- ctlv3 Z1QuickVetoTemp = no data stored
+- ctlv3 Z1RoomTemp = 25.0375
+- ctlv3 Z1RoomZoneMapping = no data stored
+- ctlv3 Z1RoomZoneMapping = no data stored
+- ctlv3 Z1SFMode = no data stored
+- ctlv3 Z1SFMode = no data stored
+- ctlv3 Z1Shortname = no data stored
+- ctlv3 Z1Shortname = no data stored
+- ctlv3 Z1Timer_Config = no data stored
+- ctlv3 Z1Timer_Friday0 = 00:00;24:00;21.0
+- ctlv3 Z1Timer_Friday1 = no data stored
+- ctlv3 Z1Timer_Friday2 = no data stored
+- ctlv3 Z1Timer_Friday = no data stored
+- ctlv3 Z1Timer_Monday0 = 00:00;24:00;21.0
+- ctlv3 Z1Timer_Monday1 = no data stored
+- ctlv3 Z1Timer_Monday2 = no data stored
+- ctlv3 Z1Timer_Monday = no data stored
+- ctlv3 Z1Timer_Saturday0 = 00:00;24:00;21.0
+- ctlv3 Z1Timer_Saturday1 = no data stored
+- ctlv3 Z1Timer_Saturday2 = no data stored
+- ctlv3 Z1Timer_Saturday = no data stored
+- ctlv3 Z1Timer_Sunday0 = 00:00;24:00;21.0
+- ctlv3 Z1Timer_Sunday1 = no data stored
+- ctlv3 Z1Timer_Sunday2 = no data stored
+- ctlv3 Z1Timer_Sunday = no data stored
+- ctlv3 Z1Timer_Thursday0 = 00:00;24:00;21.0
+- ctlv3 Z1Timer_Thursday1 = no data stored
+- ctlv3 Z1Timer_Thursday2 = no data stored
+- ctlv3 Z1Timer_Thursday = no data stored
+- ctlv3 Z1Timer_Timeframes = 1;1;1;1;1;1;1
+- ctlv3 Z1Timer_Tuesday0 = 00:00;24:00;21.0
+- ctlv3 Z1Timer_Tuesday1 = no data stored
+- ctlv3 Z1Timer_Tuesday2 = no data stored
+- ctlv3 Z1Timer_Tuesday = no data stored
+- ctlv3 Z1Timer_Wednesday0 = 00:00;24:00;21.0
+- ctlv3 Z1Timer_Wednesday1 = no data stored
+- ctlv3 Z1Timer_Wednesday2 = no data stored
+- ctlv3 Z1Timer_Wednesday = no data stored
+- ctlv3 Z1ValveStatus = no data stored
+- ctlv3 Z1ValveStatus = no data stored
+- ctlv3 Z2ActualRoomTempDesired = 0.0
+- ctlv3 Z2ActualRoomTempDesired = no data stored
+- ctlv3 Z2BankHolidayEndPeriod = no data stored
+- ctlv3 Z2BankHolidayEndPeriod = no data stored
+- ctlv3 Z2BankHolidayStartPeriod = no data stored
+- ctlv3 Z2BankHolidayStartPeriod = no data stored
+- ctlv3 Z2CoolingTemp = no data stored
+- ctlv3 Z2CoolingTemp = no data stored
+- ctlv3 Z2DayTemp = 20.5
+- ctlv3 Z2DayTemp = no data stored
+- ctlv3 Z2HolidayEndPeriod = 01.01.2019
+- ctlv3 Z2HolidayEndPeriod = no data stored
+- ctlv3 Z2HolidayStartPeriod = 01.01.2019
+- ctlv3 Z2HolidayStartPeriod = no data stored
+- ctlv3 Z2HolidayTemp = 20
+- ctlv3 Z2HolidayTemp = no data stored
+- ctlv3 Z2Name1 = no data stored
+- ctlv3 Z2Name1 = no data stored
+- ctlv3 Z2Name2 = no data stored
+- ctlv3 Z2Name2 = no data stored
+- ctlv3 Z2NightTemp = 21
+- ctlv3 Z2NightTemp = no data stored
+- ctlv3 Z2OpMode = auto
+- ctlv3 Z2OpMode = no data stored
+- ctlv3 Z2QuickVetoDuration = no data stored
+- ctlv3 Z2QuickVetoDuration = no data stored
+- ctlv3 Z2QuickVetoEndDate = no data stored
+- ctlv3 Z2QuickVetoEndTime = 00:00:00
+- ctlv3 Z2QuickVetoTemp = no data stored
+- ctlv3 Z2QuickVetoTemp = no data stored
+- ctlv3 Z2RoomTemp = 27.2875
+- ctlv3 Z2RoomZoneMapping = no data stored
+- ctlv3 Z2RoomZoneMapping = no data stored
+- ctlv3 Z2SFMode = no data stored
+- ctlv3 Z2SFMode = no data stored
+- ctlv3 Z2Shortname = no data stored
+- ctlv3 Z2Shortname = no data stored
+- ctlv3 Z2Timer_Config = no data stored
+- ctlv3 Z2Timer_Friday0 = 03:00;24:00;20.0
+- ctlv3 Z2Timer_Friday1 = no data stored
+- ctlv3 Z2Timer_Friday2 = no data stored
+- ctlv3 Z2Timer_Friday = no data stored
+- ctlv3 Z2Timer_Monday0 = 03:00;24:00;20.0
+- ctlv3 Z2Timer_Monday1 = no data stored
+- ctlv3 Z2Timer_Monday2 = no data stored
+- ctlv3 Z2Timer_Monday = no data stored
+- ctlv3 Z2Timer_Saturday0 = 03:00;24:00;20.0
+- ctlv3 Z2Timer_Saturday1 = no data stored
+- ctlv3 Z2Timer_Saturday2 = no data stored
+- ctlv3 Z2Timer_Saturday = no data stored
+- ctlv3 Z2Timer_Sunday0 = 03:00;24:00;20.0
+- ctlv3 Z2Timer_Sunday1 = no data stored
+- ctlv3 Z2Timer_Sunday2 = no data stored
+- ctlv3 Z2Timer_Sunday = no data stored
+- ctlv3 Z2Timer_Thursday0 = 03:00;24:00;20.0
+- ctlv3 Z2Timer_Thursday1 = no data stored
+- ctlv3 Z2Timer_Thursday2 = no data stored
+- ctlv3 Z2Timer_Thursday = no data stored
+- ctlv3 Z2Timer_Timeframes = 1;1;1;1;1;1;1
+- ctlv3 Z2Timer_Tuesday0 = 03:00;24:00;20.0
+- ctlv3 Z2Timer_Tuesday1 = no data stored
+- ctlv3 Z2Timer_Tuesday2 = no data stored
+- ctlv3 Z2Timer_Tuesday = no data stored
+- ctlv3 Z2Timer_Wednesday0 = 03:00;24:00;20.0
+- ctlv3 Z2Timer_Wednesday1 = no data stored
+- ctlv3 Z2Timer_Wednesday2 = no data stored
+- ctlv3 Z2Timer_Wednesday = no data stored
+- ctlv3 Z2ValveStatus = no data stored
+- ctlv3 Z2ValveStatus = no data stored
+- ctlv3 Z3ActualRoomTempDesired = no data stored
+- ctlv3 Z3ActualRoomTempDesired = no data stored
+- ctlv3 Z3BankHolidayEndPeriod = no data stored
+- ctlv3 Z3BankHolidayEndPeriod = no data stored
+- ctlv3 Z3BankHolidayStartPeriod = no data stored
+- ctlv3 Z3BankHolidayStartPeriod = no data stored
+- ctlv3 Z3DayTemp = no data stored
+- ctlv3 Z3DayTemp = no data stored
+- ctlv3 Z3HolidayEndPeriod = no data stored
+- ctlv3 Z3HolidayEndPeriod = no data stored
+- ctlv3 Z3HolidayStartPeriod = no data stored
+- ctlv3 Z3HolidayStartPeriod = no data stored
+- ctlv3 Z3HolidayTemp = no data stored
+- ctlv3 Z3HolidayTemp = no data stored
+- ctlv3 Z3Name1 = no data stored
+- ctlv3 Z3Name1 = no data stored
+- ctlv3 Z3Name2 = no data stored
+- ctlv3 Z3Name2 = no data stored
+- ctlv3 Z3NightTemp = no data stored
+- ctlv3 Z3NightTemp = no data stored
+- ctlv3 Z3OpMode = no data stored
+- ctlv3 Z3OpMode = no data stored
+- ctlv3 Z3QuickVetoDuration = no data stored
+- ctlv3 Z3QuickVetoDuration = no data stored
+- ctlv3 Z3QuickVetoEndDate = no data stored
+- ctlv3 Z3QuickVetoEndTime = no data stored
+- ctlv3 Z3QuickVetoTemp = no data stored
+- ctlv3 Z3QuickVetoTemp = no data stored
+- ctlv3 Z3RoomTemp = no data stored
+- ctlv3 Z3RoomZoneMapping = no data stored
+- ctlv3 Z3RoomZoneMapping = no data stored
+- ctlv3 Z3SFMode = no data stored
+- ctlv3 Z3SFMode = no data stored
+- ctlv3 Z3Shortname = no data stored
+- ctlv3 Z3Shortname = no data stored
+- ctlv3 Z3Timer_Config = no data stored
+- ctlv3 Z3Timer_Friday0 = no data stored
+- ctlv3 Z3Timer_Friday1 = no data stored
+- ctlv3 Z3Timer_Friday2 = no data stored
+- ctlv3 Z3Timer_Friday = no data stored
+- ctlv3 Z3Timer_Monday0 = no data stored
+- ctlv3 Z3Timer_Monday1 = no data stored
+- ctlv3 Z3Timer_Monday2 = no data stored
+- ctlv3 Z3Timer_Monday = no data stored
+- ctlv3 Z3Timer_Saturday0 = no data stored
+- ctlv3 Z3Timer_Saturday1 = no data stored
+- ctlv3 Z3Timer_Saturday2 = no data stored
+- ctlv3 Z3Timer_Saturday = no data stored
+- ctlv3 Z3Timer_Sunday0 = no data stored
+- ctlv3 Z3Timer_Sunday1 = no data stored
+- ctlv3 Z3Timer_Sunday2 = no data stored
+- ctlv3 Z3Timer_Sunday = no data stored
+- ctlv3 Z3Timer_Thursday0 = no data stored
+- ctlv3 Z3Timer_Thursday1 = no data stored
+- ctlv3 Z3Timer_Thursday2 = no data stored
+- ctlv3 Z3Timer_Thursday = no data stored
+- ctlv3 Z3Timer_Timeframes = no data stored
+- ctlv3 Z3Timer_Tuesday0 = no data stored
+- ctlv3 Z3Timer_Tuesday1 = no data stored
+- ctlv3 Z3Timer_Tuesday2 = no data stored
+- ctlv3 Z3Timer_Tuesday = no data stored
+- ctlv3 Z3Timer_Wednesday0 = no data stored
+- ctlv3 Z3Timer_Wednesday1 = no data stored
+- ctlv3 Z3Timer_Wednesday2 = no data stored
+- ctlv3 Z3Timer_Wednesday = no data stored
+- ctlv3 Z3ValveStatus = no data stored
+- ctlv3 Z3ValveStatus = no data stored
+- General Valuerange = no data stored
+- hmu BuildingCircuitFlow = 776
+- hmu Clearerrorhistory = no data stored
+- hmu CompressorBlocktime = no data stored
+- hmu CompressorHc = 187179;4337
+- hmu CompressorHwc = 52308;736
+- hmu CopCooling = 6.8
+- hmu CopCoolingMonth = 6.6
+- hmu CopHc = 3.4
+- hmu CopHcMonth = 1.1
+- hmu CopHwc = 2.7
+- hmu CopHwcMonth = 3.5
+- hmu CurrentCompressorUtil = 0.00
+- hmu CurrentConsumedPower = 0.5
+- hmu Currenterror = -;-;-;-;-
+- hmu CurrentYieldPower = 2.2
+- hmu DateTime = nosignal;-:-:-;-.-.-;-
+- hmu EnergyIntegral = no data stored
+- hmu Errorhistory = no data stored
+- hmu FlowPressure = no data stored
+- hmu FlowTemp = 22.62
+- hmu PowerConsumptionHmu = 0.529968560
+- hmu RunDataAirInletTemp = 34.7884
+- hmu RunDataBuildingCPumpPower = 100
+- hmu RunDataCompressorInletTemp = 20.2242
+- hmu RunDataCompressorOutletTemp = 54.058
+- hmu RunDataCompressorSpeed = 30
+- hmu RunDataEEVOutletTemp = 37.5521
+- hmu RunDataEEVPositionAbs = 85
+- hmu RunDataFan1Speed = 618.952
+- hmu RunDataFan2Speed = 0.0
+- hmu RunDataHighPressure = 13.0458
+- hmu RunDataStatuscode = cool_compressor_active
+- hmu RunStats4PortValveHours = 320
+- hmu RunStats4PortValveSwitches = 1305
+- hmu RunStatsBuildingCPumpStarts = 2140
+- hmu RunStatsBuildingPumpHours = 11315
+- hmu RunStatsCompressorHours = 4287
+- hmu RunStatsCompressorStarts = 6150
+- hmu RunStatsFan1Hours = 4725
+- hmu RunStatsFan1Starts = 8489
+- hmu RunStatsFan2Hours = 0
+- hmu RunStatsFan2Starts = 0
+- hmu RunStatsHcHours = 8204
+- hmu RunStatsHMUHours = 17725
+- hmu RunStatsHwcHours = 914
+- hmu SetMode = auto;21.0;-;-;1;1;1;0;0;1
+- hmu SetMode = no data stored
+- hmu Status01 = 17.0;20.0;-;-;-;off
+- hmu Status02 = no data stored
+- hmu Status16 = no data stored
+- hmu Status = no data stored
+- hmu StatusCirPump = off
+- hmu SupplyTempWeighted = 22.00
+- hmu TotalEnergyUsage = 3517
+- hmu YieldCoolDay = 0.0
+- hmu YieldCooling = 0.0
+- hmu YieldCoolingMonth = 0.0
+- hmu YieldHc = 6225
+- hmu YieldHcDay = 0.1
+- hmu YieldHcMonth = no data stored
+- hmu YieldHwc = 1857
+- hmu YieldHwcDay = no data stored
+- hmu YieldHwcMonth = no data stored
+- Memory Eeprom = no data stored
+- Memory Eeprom = no data stored
+- Memory Ram = no data stored
+- Memory Ram = no data stored
+- Scan Id = no data stored
+- scan.08  = Vaillant;HMU00;0902;5103
+- Scan.08 Id = 21;24;18;0010047380;1300;105808;N4
+- scan.15  = Vaillant;CTLV3;0709;3704
+- Scan.15 Id = 21;23;44;0020260921;0953;015178;N9
+- scan.26  = Vaillant;VR_71;0201;0503
+- Scan.26 Id = 21;23;16;0020184847;0082;016128;N6
+- scan.35  = Vaillant;VR_92;0122;9403
+- Scan.35 Id = 21;21;06;0020260925;0953;006869;N7
+- scan.76  = Vaillant;VWZIO;0202;0103
+- Scan.76 Id = 21;24;17;0010031644;0082;009808;N6
+- scan.f6  = Vaillant;NETX3;0129;0404
+- Scan.f6 Id = 21;23;22;0020292012;0933;097000;N1
+- vr_71 Clearerrorhistory = no data stored
+- vr_71 Currenterror = no data stored
+- vr_71 Errorhistory = no data stored
+- vr_71 Mc1Operation = 2;21.0;on;-25
+- vr_71 Mc2Operation = off;0.0;on;-100
+- vr_71 Mc3Operation = no data stored
+- vr_71 SensorData1 = -;17.69;23.88;-;-;-;-;41 01
+- vr_71 SensorData2 = -;-;-;-;0.00;8.00;80 54 05
+- vr_71 SetActorState = -;-;off;on;off;off;-;-;-;-;off;off;00 00
+- vwzio EnableTestHwcTemp = no data stored
+- vwzio EnableTestOutdoorTemp = no data stored
+- vwzio EnableTestThreeWayValve = no data stored
+- vwzio TestHwcTemp = no data stored
+- vwzio TestOutdoorTemp = no data stored
+- vwzio TestThreeWayValve = no data stored
+- ''
+before_registers:
+- circuit: Broadcast
+  name: Datetime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Error
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: Broadcast
+  name: HwcStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Id
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: IdAnswer
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: IdQuery
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Load
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Outsidetemp
+  fields:
+  - value
+  values:
+  - '31.062'
+  writable: false
+  has_data: true
+- circuit: Broadcast
+  name: Queryexistence
+  fields:
+  - value
+  values:
+  - (empty for 31fe07fe00 / )
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Signoflife
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Vdatetime
+  fields:
+  - value
+  values:
+  - 13:31:27;13.08.2026
+  writable: false
+  has_data: true
+- circuit: Broadcast
+  name: Vdatetime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: WaterPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: General
+  name: Valuerange
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Eeprom
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Eeprom
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Ram
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Ram
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Scan
+  name: Id
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Scan.08
+  name: Id
+  fields:
+  - value
+  values:
+  - 21;24;18;0010047380;1300;105808;N4
+  writable: false
+  has_data: true
+- circuit: Scan.15
+  name: Id
+  fields:
+  - value
+  values:
+  - 21;23;44;0020260921;0953;015178;N9
+  writable: false
+  has_data: true
+- circuit: Scan.26
+  name: Id
+  fields:
+  - value
+  values:
+  - 21;23;16;0020184847;0082;016128;N6
+  writable: false
+  has_data: true
+- circuit: Scan.35
+  name: Id
+  fields:
+  - value
+  values:
+  - 21;21;06;0020260925;0953;006869;N7
+  writable: false
+  has_data: true
+- circuit: Scan.76
+  name: Id
+  fields:
+  - value
+  values:
+  - 21;24;17;0010031644;0082;009808;N6
+  writable: false
+  has_data: true
+- circuit: Scan.f6
+  name: Id
+  fields:
+  - value
+  values:
+  - 21;23;22;0020292012;0933;097000;N1
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: AdaptHeatCurve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: CcTimer_Config
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: CcTimer_Timeframes
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: ContinuousHeating
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: CylinderChargeHyst
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: CylinderChargeOffset
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Date
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: DisplayedOutsideTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: FrostOverRideTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1AutoOffMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1CircuitType
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1CoolingEnabled
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1CoolingFlowTempMin
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1DewPointMonitoring
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1DewPointOffset
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1ExcessTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1HeatCurve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MixerMovement
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1PumpStatus
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1RoomTempModulation
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1Status
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1SummerTempLimit
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2AutoOffMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2CircuitType
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2ExcessTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2HeatCurve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MixerMovement
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2PumpStatus
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2Status
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2SummerTempLimit
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3AutoOffMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3CircuitType
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3ExcessTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3HeatCurve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MixerMovement
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3PumpStatus
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3Status
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3SummerTempLimit
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HcStorageTempBottom
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: ctlv2
+  name: HcStorageTempTop
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: ctlv2
+  name: HwcFlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcLockTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcMaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcOpMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcParallelLoading
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcSFMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcSfMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcStorageTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcStorageTempBottom
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcStorageTempTop
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HydraulicScheme
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: MaxCylinderChargeTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: MaxRoomHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: MultiRelaySetting
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: OutsideTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: OutsideTempAvg
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySum
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHcLastMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHcThisMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHwcLastMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHwcThisMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: SystemFlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: WaterPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingManualTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingOpMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingSetbackTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1DayTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1HolidayTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1NightTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1OpMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoDuration
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoEndDate
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoEndTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1RoomTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1SFMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z2RoomTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: z1RoomHumidity
+  fields:
+  - value
+  values:
+  - '50'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: AdaptHeatCurve
+  fields:
+  - value
+  values:
+  - 'yes'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: AdaptHeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Config
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Friday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Friday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Friday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Monday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Monday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Monday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Saturday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Saturday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Saturday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Sunday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Sunday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Sunday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Thursday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Timeframes
+  fields:
+  - value
+  values:
+  - 0;0;0;0;0;0;0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CcTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Tuesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Wednesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Clearerrorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: ContinuousHeating
+  fields:
+  - value
+  values:
+  - '-26'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: ContinuousHeating
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - -;-;-;-;-
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CylinderChargeHyst
+  fields:
+  - value
+  values:
+  - '7'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CylinderChargeHyst
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CylinderChargeOffset
+  fields:
+  - value
+  values:
+  - '5'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CylinderChargeOffset
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Date
+  fields:
+  - value
+  values:
+  - 13.08.2026
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Date
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: DisplayedOutsideTemp
+  fields:
+  - value
+  values:
+  - '31.125'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: FrostOverRideTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: FrostOverRideTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - '21'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1AutoOffMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1AutoOffMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1CircuitType
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1ExcessTemp
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1ExcessTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1FlowTemp
+  fields:
+  - value
+  values:
+  - '17.75'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1HeatCurve
+  fields:
+  - value
+  values:
+  - '0.4'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1HeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '50'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - '21'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - '25'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1MixerMovement
+  fields:
+  - value
+  values:
+  - '-25'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1PumpStatus
+  fields:
+  - value
+  values:
+  - '2'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1PumpStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - modulating
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1SummerTempLimit
+  fields:
+  - value
+  values:
+  - '16'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1SummerTempLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2AutoOffMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2AutoOffMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2CircuitType
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2ExcessTemp
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2ExcessTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2FlowTemp
+  fields:
+  - value
+  values:
+  - '23.875'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2HeatCurve
+  fields:
+  - value
+  values:
+  - '0.3'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2HeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '50'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - '15'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2MixerMovement
+  fields:
+  - value
+  values:
+  - '-100'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2PumpStatus
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2PumpStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - modulating
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2SummerTempLimit
+  fields:
+  - value
+  values:
+  - '16'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2SummerTempLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3AutoOffMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3AutoOffMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3CircuitType
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3ExcessTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3ExcessTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3FlowTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3HeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3HeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3MixerMovement
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3PumpStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3PumpStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3SummerTempLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3SummerTempLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HcStorageTempBottom
+  fields:
+  - value
+  values:
+  - (empty for f115b5240602000000a000 / 080000a000ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HcStorageTempTop
+  fields:
+  - value
+  values:
+  - (empty for f115b52406020000009f00 / 0800009f00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcBankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcBankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcBankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcBankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcFlowTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcLockTime
+  fields:
+  - value
+  values:
+  - '30'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcLockTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcMaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '80'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcMaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcOpMode
+  fields:
+  - value
+  values:
+  - auto
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcOpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcParallelLoading
+  fields:
+  - value
+  values:
+  - 'off'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcParallelLoading
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcSFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcSFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcStorageTemp
+  fields:
+  - value
+  values:
+  - '49.5'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcStorageTempBottom
+  fields:
+  - value
+  values:
+  - (empty for f115b52406020000009e00 / 0800009e00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcStorageTempTop
+  fields:
+  - value
+  values:
+  - (empty for f115b52406020000009d00 / 0800009d00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTempDesired
+  fields:
+  - value
+  values:
+  - '52'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Config
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Friday0
+  fields:
+  - value
+  values:
+  - 01:00;03:00;52.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcTimer_Friday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Friday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Monday0
+  fields:
+  - value
+  values:
+  - 01:00;03:00;52.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcTimer_Monday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Monday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Saturday0
+  fields:
+  - value
+  values:
+  - 01:00;03:00;52.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcTimer_Saturday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Saturday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Sunday0
+  fields:
+  - value
+  values:
+  - 01:00;03:00;52.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcTimer_Sunday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Sunday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Thursday0
+  fields:
+  - value
+  values:
+  - 01:00;03:00;52.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcTimer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Timeframes
+  fields:
+  - value
+  values:
+  - 1;1;1;1;1;1;1
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Tuesday0
+  fields:
+  - value
+  values:
+  - 01:00;03:00;52.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcTimer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Wednesday0
+  fields:
+  - value
+  values:
+  - 01:00;03:00;52.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcTimer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HydraulicScheme
+  fields:
+  - value
+  values:
+  - '8'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HydraulicScheme
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Installer1
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Installer1
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Installer2
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Installer2
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: KeyCodeforConfigMenu
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: KeyCodeforConfigMenu
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: MaintenanceDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: MaintenanceDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: MaintenanceDue
+  fields:
+  - value
+  values:
+  - 'no'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: MaxCylinderChargeTime
+  fields:
+  - value
+  values:
+  - '120'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: MaxCylinderChargeTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: MaxRoomHumidity
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: MaxRoomHumidity
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: MultiRelaySetting
+  fields:
+  - value
+  values:
+  - '4'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: MultiRelaySetting
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: OutsideTempAvg
+  fields:
+  - value
+  values:
+  - '22.1055'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: OutsideTempAvg
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PhoneNumber1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PhoneNumber1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PhoneNumber2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PhoneNumber2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHwc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHwc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHwcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHwcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHwcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHwcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHwc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHwc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHwcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHwcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHwcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHwcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PumpAdditionalTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PumpAdditionalTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: SolarYieldTotal
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: SolarYieldTotal
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: SystemFlowTemp
+  fields:
+  - value
+  values:
+  - (empty for f115b52406020000004b00 / 0800004b00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Time
+  fields:
+  - value
+  values:
+  - '12:35:01'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Time
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: WaterPressure
+  fields:
+  - value
+  values:
+  - '1.8'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: YieldTotal
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: YieldTotal
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1CoolingTemp
+  fields:
+  - value
+  values:
+  - '24'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1CoolingTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1DayTemp
+  fields:
+  - value
+  values:
+  - '21'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1HolidayTemp
+  fields:
+  - value
+  values:
+  - '20'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1NightTemp
+  fields:
+  - value
+  values:
+  - '20'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1OpMode
+  fields:
+  - value
+  values:
+  - day
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1QuickVetoEndDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1QuickVetoEndTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1RoomTemp
+  fields:
+  - value
+  values:
+  - '25.0375'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Config
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Friday0
+  fields:
+  - value
+  values:
+  - 00:00;24:00;21.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Friday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Friday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Monday0
+  fields:
+  - value
+  values:
+  - 00:00;24:00;21.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Monday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Monday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Saturday0
+  fields:
+  - value
+  values:
+  - 00:00;24:00;21.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Saturday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Saturday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Sunday0
+  fields:
+  - value
+  values:
+  - 00:00;24:00;21.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Sunday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Sunday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Thursday0
+  fields:
+  - value
+  values:
+  - 00:00;24:00;21.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Timeframes
+  fields:
+  - value
+  values:
+  - 1;1;1;1;1;1;1
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Tuesday0
+  fields:
+  - value
+  values:
+  - 00:00;24:00;21.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Wednesday0
+  fields:
+  - value
+  values:
+  - 00:00;24:00;21.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z2ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2CoolingTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2CoolingTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2DayTemp
+  fields:
+  - value
+  values:
+  - '20.5'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z2DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z2HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z2HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2HolidayTemp
+  fields:
+  - value
+  values:
+  - '20'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z2HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2NightTemp
+  fields:
+  - value
+  values:
+  - '21'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z2NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2OpMode
+  fields:
+  - value
+  values:
+  - auto
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z2OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2QuickVetoEndDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2QuickVetoEndTime
+  fields:
+  - value
+  values:
+  - 00:00:00
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z2QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2RoomTemp
+  fields:
+  - value
+  values:
+  - '27.2875'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z2RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Config
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Friday0
+  fields:
+  - value
+  values:
+  - 03:00;24:00;20.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z2Timer_Friday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Friday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Monday0
+  fields:
+  - value
+  values:
+  - 03:00;24:00;20.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z2Timer_Monday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Monday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Saturday0
+  fields:
+  - value
+  values:
+  - 03:00;24:00;20.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z2Timer_Saturday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Saturday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Sunday0
+  fields:
+  - value
+  values:
+  - 03:00;24:00;20.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z2Timer_Sunday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Sunday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Thursday0
+  fields:
+  - value
+  values:
+  - 03:00;24:00;20.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z2Timer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Timeframes
+  fields:
+  - value
+  values:
+  - 1;1;1;1;1;1;1
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z2Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Tuesday0
+  fields:
+  - value
+  values:
+  - 03:00;24:00;20.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z2Timer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Wednesday0
+  fields:
+  - value
+  values:
+  - 03:00;24:00;20.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z2Timer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3QuickVetoEndDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3QuickVetoEndTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3RoomTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Config
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Friday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Friday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Friday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Monday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Monday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Monday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Saturday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Saturday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Saturday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Sunday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Sunday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Sunday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Thursday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Timeframes
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Tuesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Wednesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: BuildingCircuitFlow
+  fields:
+  - value
+  values:
+  - '776'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: BuildingCircuitPumpSpeed
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Clearerrorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: CompressorBlocktime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: CompressorHc
+  fields:
+  - value
+  values:
+  - 187179;4337
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CompressorHc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHwc
+  fields:
+  - value
+  values:
+  - 52308;736
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CompressorHwc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHwc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CopCooling
+  fields:
+  - value
+  values:
+  - '6.8'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CopCoolingMonth
+  fields:
+  - value
+  values:
+  - '6.6'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CopHc
+  fields:
+  - value
+  values:
+  - '3.4'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CopHcMonth
+  fields:
+  - value
+  values:
+  - '1.1'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CopHwc
+  fields:
+  - value
+  values:
+  - '2.7'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CopHwcMonth
+  fields:
+  - value
+  values:
+  - '3.5'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CurrentCompressorUtil
+  fields:
+  - value
+  values:
+  - '0.00'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CurrentConsumedPower
+  fields:
+  - value
+  values:
+  - '0.5'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CurrentYieldPower
+  fields:
+  - value
+  values:
+  - '2.2'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - -;-;-;-;-
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: DateTime
+  fields:
+  - value
+  values:
+  - nosignal;-:-:-;-.-.-;-
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: EnergyIntegral
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: FlowPressure
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: FlowTemp
+  fields:
+  - value
+  values:
+  - '22.62'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: FlowTemperature
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: HoursCool
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: PowerConsumptionHmu
+  fields:
+  - value
+  values:
+  - '0.529968560'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataAirInletTemp
+  fields:
+  - value
+  values:
+  - '34.7884'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataBuildingCPumpPower
+  fields:
+  - value
+  values:
+  - '100'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataCompressorInletTemp
+  fields:
+  - value
+  values:
+  - '20.2242'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataCompressorOutletTemp
+  fields:
+  - value
+  values:
+  - '54.058'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataCompressorSpeed
+  fields:
+  - value
+  values:
+  - '30'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataEEVOutletTemp
+  fields:
+  - value
+  values:
+  - '37.5521'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataEEVPositionAbs
+  fields:
+  - value
+  values:
+  - '85'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataFan1Speed
+  fields:
+  - value
+  values:
+  - '618.952'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataFan2Speed
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataHighPressure
+  fields:
+  - value
+  values:
+  - '13.0458'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataLowPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunDataStatuscode
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStats4PortValveHours
+  fields:
+  - value
+  values:
+  - '320'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStats4PortValveSwitches
+  fields:
+  - value
+  values:
+  - '1305'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsBuildingCPumpStarts
+  fields:
+  - value
+  values:
+  - '2140'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsBuildingPumpHours
+  fields:
+  - value
+  values:
+  - '11315'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsCompressorHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunStatsCompressorHc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHours
+  fields:
+  - value
+  values:
+  - '4287'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsCompressorHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunStatsCompressorHwc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHwc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorStarts
+  fields:
+  - value
+  values:
+  - '6150'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsFan1Hours
+  fields:
+  - value
+  values:
+  - '4725'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsFan1Starts
+  fields:
+  - value
+  values:
+  - '8489'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsFan2Hours
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsFan2Starts
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsHMUHours
+  fields:
+  - value
+  values:
+  - '17725'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsHcHours
+  fields:
+  - value
+  values:
+  - '8204'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsHwcHours
+  fields:
+  - value
+  values:
+  - '914'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: SetMode
+  fields:
+  - value
+  values:
+  - auto;21.0;-;-;1;1;1;0;0;1
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: SetMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: StatElectricEnergySumCool
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatEnvironmentEnergySumCool
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: Status01
+  fields:
+  - value
+  values:
+  - 17.0;20.0;-;-;-;off
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: Status01.pumpstate
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.temp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.temp_1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.temp_2
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: Status01.temp_3
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: Status01.temp_4
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: Status02
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: Status16
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: StatusCirPump
+  fields:
+  - value
+  values:
+  - 'off'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: SupplyTempWeighted
+  fields:
+  - value
+  values:
+  - '22.00'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: TotalEnergyUsage
+  fields:
+  - value
+  values:
+  - '3517'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldCoolDay
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldCooling
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldCoolingMonth
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldHc
+  fields:
+  - value
+  values:
+  - '6225'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldHcDay
+  fields:
+  - value
+  values:
+  - '0.1'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldHcMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: YieldHwc
+  fields:
+  - value
+  values:
+  - '1857'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldHwcDay
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: YieldHwcMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: BypassPosition
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: ExhaustAirHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: ExhaustAirTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: MaxAirHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: MinAirHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: OutsideAirTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: SupplyAirTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: VentilationLevelDay
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: VentilationLevelNight
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldToday
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldTotal
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldYear
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Clearerrorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vr_71
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vr_71
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vr_71
+  name: Mc1Operation
+  fields:
+  - value
+  values:
+  - 2;21.0;on;-25
+  writable: false
+  has_data: true
+- circuit: vr_71
+  name: Mc2Operation
+  fields:
+  - value
+  values:
+  - off;0.0;on;-100
+  writable: false
+  has_data: true
+- circuit: vr_71
+  name: Mc3Operation
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vr_71
+  name: SensorData1
+  fields:
+  - value
+  values:
+  - -;17.69;23.88;-;-;-;-;41 01
+  writable: false
+  has_data: true
+- circuit: vr_71
+  name: SensorData2
+  fields:
+  - value
+  values:
+  - -;-;-;-;0.00;8.00;80 54 05
+  writable: false
+  has_data: true
+- circuit: vr_71
+  name: SetActorState
+  fields:
+  - value
+  values:
+  - -;-;off;on;off;off;-;-;-;-;off;off;00 00
+  writable: false
+  has_data: true
+- circuit: vwz
+  name: TestHwcTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: vwz
+  name: TestOutdoorTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: vwz
+  name: TestThreeWayValve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: vwzio
+  name: EnableTestHwcTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: EnableTestOutdoorTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: EnableTestThreeWayValve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: TestHwcTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: TestOutdoorTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: TestThreeWayValve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+grab:
+- '[grab] grab started'
+- '1008b5100900002affffff070004 / 0101 = 1: hmu SetMode'
+- '10feb5160301201f = 1: Broadcast Outsidetemp'
+- 1008b5110100 / 09150112326809000000 = 1
+- 1076b5110101 / 09ffff201fff630000ff = 1
+- 7108b5110107 / 0a01230081103600000000 = 4
+- '1008b5110101 / 0922280080ffff0000ff = 1: hmu Status01'
+- '1026b5230106 / 1000801a017d0100800080008000804101 = 1: vr_71 SensorData1'
+- '1026b5230107 / 0f008000800080008000008000805405 = 1: vr_71 SensorData2'
+- '1026b5230f05ffff00140000ffffffff00000000 / 0101 = 2: vr_71 SetActorState'
+- '1026b523040200022a / 0201e7 = 2: vr_71 Mc1Operation'
+- '1026b5230402010000 / 02019c = 2: vr_71 Mc2Operation'
+- 1076b512030f0101 / 071903000080ff03 = 1
+- 1076b51009000000ffffff050000 / 0101 = 1
+- f115b52406020001000f00 / 0601010f000000 = 1
+- f115b52406020003001b00 / 0601031b000000 = 1
+- f115b52406020003011b00 / 0601031b000000 = 1
+- 0376b51206130012050300 / 0200ff = 1
+- '3115b52406020003002800 / 080303280000004842 = 2: ctlv2 z1RoomHumidity'
+- '[grab stop] grab stopped'
+after_registers:
+- circuit: Broadcast
+  name: Datetime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Error
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: Broadcast
+  name: HwcStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Id
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: IdAnswer
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: IdQuery
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Load
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Outsidetemp
+  fields:
+  - value
+  values:
+  - '31.125'
+  writable: false
+  has_data: true
+- circuit: Broadcast
+  name: Queryexistence
+  fields:
+  - value
+  values:
+  - (empty for 31fe07fe00 / )
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Signoflife
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Vdatetime
+  fields:
+  - value
+  values:
+  - 13:32:27;13.08.2026
+  writable: false
+  has_data: true
+- circuit: Broadcast
+  name: Vdatetime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: WaterPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: General
+  name: Valuerange
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Eeprom
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Eeprom
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Ram
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Ram
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Scan
+  name: Id
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Scan.08
+  name: Id
+  fields:
+  - value
+  values:
+  - 21;24;18;0010047380;1300;105808;N4
+  writable: false
+  has_data: true
+- circuit: Scan.15
+  name: Id
+  fields:
+  - value
+  values:
+  - 21;23;44;0020260921;0953;015178;N9
+  writable: false
+  has_data: true
+- circuit: Scan.26
+  name: Id
+  fields:
+  - value
+  values:
+  - 21;23;16;0020184847;0082;016128;N6
+  writable: false
+  has_data: true
+- circuit: Scan.35
+  name: Id
+  fields:
+  - value
+  values:
+  - 21;21;06;0020260925;0953;006869;N7
+  writable: false
+  has_data: true
+- circuit: Scan.76
+  name: Id
+  fields:
+  - value
+  values:
+  - 21;24;17;0010031644;0082;009808;N6
+  writable: false
+  has_data: true
+- circuit: Scan.f6
+  name: Id
+  fields:
+  - value
+  values:
+  - 21;23;22;0020292012;0933;097000;N1
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: AdaptHeatCurve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: CcTimer_Config
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: CcTimer_Timeframes
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: ContinuousHeating
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: CylinderChargeHyst
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: CylinderChargeOffset
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Date
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: DisplayedOutsideTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: FrostOverRideTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1AutoOffMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1CircuitType
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1CoolingEnabled
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1CoolingFlowTempMin
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1DewPointMonitoring
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1DewPointOffset
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1ExcessTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1HeatCurve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MixerMovement
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1PumpStatus
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1RoomTempModulation
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1Status
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1SummerTempLimit
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2AutoOffMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2CircuitType
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2ExcessTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2HeatCurve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MixerMovement
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2PumpStatus
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2Status
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2SummerTempLimit
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3AutoOffMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3CircuitType
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3ExcessTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3HeatCurve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MixerMovement
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3PumpStatus
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3Status
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3SummerTempLimit
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HcStorageTempBottom
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: ctlv2
+  name: HcStorageTempTop
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: ctlv2
+  name: HwcFlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcLockTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcMaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcOpMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcParallelLoading
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcSFMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcSfMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcStorageTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcStorageTempBottom
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcStorageTempTop
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HydraulicScheme
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: MaxCylinderChargeTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: MaxRoomHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: MultiRelaySetting
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: OutsideTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: OutsideTempAvg
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySum
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHcLastMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHcThisMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHwcLastMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHwcThisMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: SystemFlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: WaterPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingManualTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingOpMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingSetbackTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1DayTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1HolidayTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1NightTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1OpMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoDuration
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoEndDate
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoEndTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1RoomTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1SFMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z2RoomTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: z1RoomHumidity
+  fields:
+  - value
+  values:
+  - '50'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: AdaptHeatCurve
+  fields:
+  - value
+  values:
+  - 'yes'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: AdaptHeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Config
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Friday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Friday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Friday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Monday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Monday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Monday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Saturday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Saturday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Saturday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Sunday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Sunday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Sunday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Thursday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Timeframes
+  fields:
+  - value
+  values:
+  - 0;0;0;0;0;0;0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CcTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Tuesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Wednesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Clearerrorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: ContinuousHeating
+  fields:
+  - value
+  values:
+  - '-26'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: ContinuousHeating
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - -;-;-;-;-
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CylinderChargeHyst
+  fields:
+  - value
+  values:
+  - '7'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CylinderChargeHyst
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CylinderChargeOffset
+  fields:
+  - value
+  values:
+  - '5'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CylinderChargeOffset
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Date
+  fields:
+  - value
+  values:
+  - 13.08.2026
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Date
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: DisplayedOutsideTemp
+  fields:
+  - value
+  values:
+  - '31.125'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: FrostOverRideTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: FrostOverRideTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - '21'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1AutoOffMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1AutoOffMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1CircuitType
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1ExcessTemp
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1ExcessTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1FlowTemp
+  fields:
+  - value
+  values:
+  - '17.75'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1HeatCurve
+  fields:
+  - value
+  values:
+  - '0.4'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1HeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '50'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - '21'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - '25'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1MixerMovement
+  fields:
+  - value
+  values:
+  - '-25'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1PumpStatus
+  fields:
+  - value
+  values:
+  - '2'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1PumpStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - modulating
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1SummerTempLimit
+  fields:
+  - value
+  values:
+  - '16'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1SummerTempLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2AutoOffMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2AutoOffMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2CircuitType
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2ExcessTemp
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2ExcessTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2FlowTemp
+  fields:
+  - value
+  values:
+  - '23.875'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2HeatCurve
+  fields:
+  - value
+  values:
+  - '0.3'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2HeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '50'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - '15'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2MixerMovement
+  fields:
+  - value
+  values:
+  - '-100'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2PumpStatus
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2PumpStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - modulating
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2SummerTempLimit
+  fields:
+  - value
+  values:
+  - '16'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2SummerTempLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3AutoOffMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3AutoOffMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3CircuitType
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3ExcessTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3ExcessTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3FlowTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3HeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3HeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3MixerMovement
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3PumpStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3PumpStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3SummerTempLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3SummerTempLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HcStorageTempBottom
+  fields:
+  - value
+  values:
+  - (empty for f115b5240602000000a000 / 080000a000ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HcStorageTempTop
+  fields:
+  - value
+  values:
+  - (empty for f115b52406020000009f00 / 0800009f00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcBankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcBankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcBankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcBankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcFlowTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcLockTime
+  fields:
+  - value
+  values:
+  - '30'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcLockTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcMaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '80'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcMaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcOpMode
+  fields:
+  - value
+  values:
+  - auto
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcOpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcParallelLoading
+  fields:
+  - value
+  values:
+  - 'off'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcParallelLoading
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcSFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcSFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcStorageTemp
+  fields:
+  - value
+  values:
+  - '49.5'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcStorageTempBottom
+  fields:
+  - value
+  values:
+  - (empty for f115b52406020000009e00 / 0800009e00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcStorageTempTop
+  fields:
+  - value
+  values:
+  - (empty for f115b52406020000009d00 / 0800009d00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTempDesired
+  fields:
+  - value
+  values:
+  - '52'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Config
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Friday0
+  fields:
+  - value
+  values:
+  - 01:00;03:00;52.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcTimer_Friday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Friday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Monday0
+  fields:
+  - value
+  values:
+  - 01:00;03:00;52.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcTimer_Monday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Monday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Saturday0
+  fields:
+  - value
+  values:
+  - 01:00;03:00;52.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcTimer_Saturday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Saturday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Sunday0
+  fields:
+  - value
+  values:
+  - 01:00;03:00;52.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcTimer_Sunday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Sunday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Thursday0
+  fields:
+  - value
+  values:
+  - 01:00;03:00;52.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcTimer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Timeframes
+  fields:
+  - value
+  values:
+  - 1;1;1;1;1;1;1
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Tuesday0
+  fields:
+  - value
+  values:
+  - 01:00;03:00;52.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcTimer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Wednesday0
+  fields:
+  - value
+  values:
+  - 01:00;03:00;52.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcTimer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HydraulicScheme
+  fields:
+  - value
+  values:
+  - '8'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HydraulicScheme
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Installer1
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Installer1
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Installer2
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Installer2
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: KeyCodeforConfigMenu
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: KeyCodeforConfigMenu
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: MaintenanceDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: MaintenanceDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: MaintenanceDue
+  fields:
+  - value
+  values:
+  - 'no'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: MaxCylinderChargeTime
+  fields:
+  - value
+  values:
+  - '120'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: MaxCylinderChargeTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: MaxRoomHumidity
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: MaxRoomHumidity
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: MultiRelaySetting
+  fields:
+  - value
+  values:
+  - '4'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: MultiRelaySetting
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: OutsideTempAvg
+  fields:
+  - value
+  values:
+  - '22.1055'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: OutsideTempAvg
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PhoneNumber1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PhoneNumber1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PhoneNumber2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PhoneNumber2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHwc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHwc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHwcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHwcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHwcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHwcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHwc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHwc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHwcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHwcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHwcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHwcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PumpAdditionalTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PumpAdditionalTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: SolarYieldTotal
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: SolarYieldTotal
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: SystemFlowTemp
+  fields:
+  - value
+  values:
+  - (empty for f115b52406020000004b00 / 0800004b00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Time
+  fields:
+  - value
+  values:
+  - '12:35:01'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Time
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: WaterPressure
+  fields:
+  - value
+  values:
+  - '1.8'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: YieldTotal
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: YieldTotal
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1CoolingTemp
+  fields:
+  - value
+  values:
+  - '24'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1CoolingTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1DayTemp
+  fields:
+  - value
+  values:
+  - '21'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1HolidayTemp
+  fields:
+  - value
+  values:
+  - '20'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1NightTemp
+  fields:
+  - value
+  values:
+  - '20'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1OpMode
+  fields:
+  - value
+  values:
+  - day
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1QuickVetoEndDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1QuickVetoEndTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1RoomTemp
+  fields:
+  - value
+  values:
+  - '25.0375'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Config
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Friday0
+  fields:
+  - value
+  values:
+  - 00:00;24:00;21.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Friday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Friday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Monday0
+  fields:
+  - value
+  values:
+  - 00:00;24:00;21.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Monday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Monday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Saturday0
+  fields:
+  - value
+  values:
+  - 00:00;24:00;21.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Saturday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Saturday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Sunday0
+  fields:
+  - value
+  values:
+  - 00:00;24:00;21.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Sunday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Sunday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Thursday0
+  fields:
+  - value
+  values:
+  - 00:00;24:00;21.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Timeframes
+  fields:
+  - value
+  values:
+  - 1;1;1;1;1;1;1
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Tuesday0
+  fields:
+  - value
+  values:
+  - 00:00;24:00;21.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Wednesday0
+  fields:
+  - value
+  values:
+  - 00:00;24:00;21.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z2ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2CoolingTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2CoolingTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2DayTemp
+  fields:
+  - value
+  values:
+  - '20.5'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z2DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z2HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z2HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2HolidayTemp
+  fields:
+  - value
+  values:
+  - '20'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z2HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2NightTemp
+  fields:
+  - value
+  values:
+  - '21'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z2NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2OpMode
+  fields:
+  - value
+  values:
+  - auto
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z2OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2QuickVetoEndDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2QuickVetoEndTime
+  fields:
+  - value
+  values:
+  - 00:00:00
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z2QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2RoomTemp
+  fields:
+  - value
+  values:
+  - '27.2875'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z2RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Config
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Friday0
+  fields:
+  - value
+  values:
+  - 03:00;24:00;20.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z2Timer_Friday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Friday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Monday0
+  fields:
+  - value
+  values:
+  - 03:00;24:00;20.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z2Timer_Monday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Monday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Saturday0
+  fields:
+  - value
+  values:
+  - 03:00;24:00;20.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z2Timer_Saturday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Saturday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Sunday0
+  fields:
+  - value
+  values:
+  - 03:00;24:00;20.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z2Timer_Sunday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Sunday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Thursday0
+  fields:
+  - value
+  values:
+  - 03:00;24:00;20.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z2Timer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Timeframes
+  fields:
+  - value
+  values:
+  - 1;1;1;1;1;1;1
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z2Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Tuesday0
+  fields:
+  - value
+  values:
+  - 03:00;24:00;20.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z2Timer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Wednesday0
+  fields:
+  - value
+  values:
+  - 03:00;24:00;20.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z2Timer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3QuickVetoEndDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3QuickVetoEndTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3RoomTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Config
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Friday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Friday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Friday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Monday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Monday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Monday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Saturday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Saturday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Saturday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Sunday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Sunday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Sunday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Thursday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Timeframes
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Tuesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Wednesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: BuildingCircuitFlow
+  fields:
+  - value
+  values:
+  - '776'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: BuildingCircuitPumpSpeed
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Clearerrorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: CompressorBlocktime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: CompressorHc
+  fields:
+  - value
+  values:
+  - 187179;4337
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CompressorHc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHwc
+  fields:
+  - value
+  values:
+  - 52308;736
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CompressorHwc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHwc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CopCooling
+  fields:
+  - value
+  values:
+  - '6.8'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CopCoolingMonth
+  fields:
+  - value
+  values:
+  - '6.6'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CopHc
+  fields:
+  - value
+  values:
+  - '3.4'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CopHcMonth
+  fields:
+  - value
+  values:
+  - '1.1'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CopHwc
+  fields:
+  - value
+  values:
+  - '2.7'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CopHwcMonth
+  fields:
+  - value
+  values:
+  - '3.5'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CurrentCompressorUtil
+  fields:
+  - value
+  values:
+  - '0.00'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CurrentConsumedPower
+  fields:
+  - value
+  values:
+  - '0.5'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CurrentYieldPower
+  fields:
+  - value
+  values:
+  - '2.2'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - -;-;-;-;-
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: DateTime
+  fields:
+  - value
+  values:
+  - nosignal;-:-:-;-.-.-;-
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: EnergyIntegral
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: FlowPressure
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: FlowTemp
+  fields:
+  - value
+  values:
+  - '22.62'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: FlowTemperature
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: HoursCool
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: PowerConsumptionHmu
+  fields:
+  - value
+  values:
+  - '0.537904024'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataAirInletTemp
+  fields:
+  - value
+  values:
+  - '34.7884'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataBuildingCPumpPower
+  fields:
+  - value
+  values:
+  - '100'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataCompressorInletTemp
+  fields:
+  - value
+  values:
+  - '20.2242'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataCompressorOutletTemp
+  fields:
+  - value
+  values:
+  - '54.058'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataCompressorSpeed
+  fields:
+  - value
+  values:
+  - '30'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataEEVOutletTemp
+  fields:
+  - value
+  values:
+  - '37.5521'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataEEVPositionAbs
+  fields:
+  - value
+  values:
+  - '85'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataFan1Speed
+  fields:
+  - value
+  values:
+  - '618.952'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataFan2Speed
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataHighPressure
+  fields:
+  - value
+  values:
+  - '13.0458'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataLowPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunDataStatuscode
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStats4PortValveHours
+  fields:
+  - value
+  values:
+  - '320'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStats4PortValveSwitches
+  fields:
+  - value
+  values:
+  - '1305'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsBuildingCPumpStarts
+  fields:
+  - value
+  values:
+  - '2140'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsBuildingPumpHours
+  fields:
+  - value
+  values:
+  - '11315'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsCompressorHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunStatsCompressorHc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHours
+  fields:
+  - value
+  values:
+  - '4287'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsCompressorHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunStatsCompressorHwc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHwc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorStarts
+  fields:
+  - value
+  values:
+  - '6150'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsFan1Hours
+  fields:
+  - value
+  values:
+  - '4725'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsFan1Starts
+  fields:
+  - value
+  values:
+  - '8489'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsFan2Hours
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsFan2Starts
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsHMUHours
+  fields:
+  - value
+  values:
+  - '17725'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsHcHours
+  fields:
+  - value
+  values:
+  - '8204'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsHwcHours
+  fields:
+  - value
+  values:
+  - '914'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: SetMode
+  fields:
+  - value
+  values:
+  - auto;21.0;-;-;1;1;1;0;0;1
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: SetMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: StatElectricEnergySumCool
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatEnvironmentEnergySumCool
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: Status01
+  fields:
+  - value
+  values:
+  - 17.0;20.0;-;-;-;off
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: Status01.pumpstate
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.temp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.temp_1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.temp_2
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: Status01.temp_3
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: Status01.temp_4
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: Status02
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: Status16
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: StatusCirPump
+  fields:
+  - value
+  values:
+  - 'off'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: SupplyTempWeighted
+  fields:
+  - value
+  values:
+  - '22.00'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: TotalEnergyUsage
+  fields:
+  - value
+  values:
+  - '3517'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldCoolDay
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldCooling
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldCoolingMonth
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldHc
+  fields:
+  - value
+  values:
+  - '6225'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldHcDay
+  fields:
+  - value
+  values:
+  - '0.1'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldHcMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: YieldHwc
+  fields:
+  - value
+  values:
+  - '1857'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldHwcDay
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: YieldHwcMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: BypassPosition
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: ExhaustAirHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: ExhaustAirTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: MaxAirHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: MinAirHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: OutsideAirTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: SupplyAirTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: VentilationLevelDay
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: VentilationLevelNight
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldToday
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldTotal
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldYear
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Clearerrorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vr_71
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vr_71
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vr_71
+  name: Mc1Operation
+  fields:
+  - value
+  values:
+  - 2;21.0;on;-25
+  writable: false
+  has_data: true
+- circuit: vr_71
+  name: Mc2Operation
+  fields:
+  - value
+  values:
+  - off;0.0;on;-100
+  writable: false
+  has_data: true
+- circuit: vr_71
+  name: Mc3Operation
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vr_71
+  name: SensorData1
+  fields:
+  - value
+  values:
+  - -;17.62;23.81;-;-;-;-;41 01
+  writable: false
+  has_data: true
+- circuit: vr_71
+  name: SensorData2
+  fields:
+  - value
+  values:
+  - -;-;-;-;0.00;8.00;80 54 05
+  writable: false
+  has_data: true
+- circuit: vr_71
+  name: SetActorState
+  fields:
+  - value
+  values:
+  - -;-;off;on;off;off;-;-;-;-;off;off;00 00
+  writable: false
+  has_data: true
+- circuit: vwz
+  name: TestHwcTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: vwz
+  name: TestOutdoorTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: vwz
+  name: TestThreeWayValve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: vwzio
+  name: EnableTestHwcTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: EnableTestOutdoorTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: EnableTestThreeWayValve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: TestHwcTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: TestOutdoorTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: TestThreeWayValve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+raw_find_lines_after:
+- Broadcast Datetime = no data stored
+- Broadcast Error = no data stored
+- Broadcast HwcStatus = no data stored
+- Broadcast Id = no data stored
+- Broadcast IdAnswer = no data stored
+- Broadcast IdQuery = no data stored
+- Broadcast Load = no data stored
+- Broadcast Outsidetemp = 31.125
+- Broadcast Queryexistence =  (empty for 31fe07fe00 / )
+- Broadcast Signoflife = no data stored
+- Broadcast Vdatetime = 13:32:27;13.08.2026
+- Broadcast Vdatetime = no data stored
+- ctlv2 z1RoomHumidity = 50
+- ctlv3 AdaptHeatCurve = yes
+- ctlv3 AdaptHeatCurve = no data stored
+- ctlv3 CcTimer_Config = no data stored
+- ctlv3 CcTimer_Friday0 = no data stored
+- ctlv3 CcTimer_Friday1 = no data stored
+- ctlv3 CcTimer_Friday2 = no data stored
+- ctlv3 CcTimer_Friday = no data stored
+- ctlv3 CcTimer_Monday0 = no data stored
+- ctlv3 CcTimer_Monday1 = no data stored
+- ctlv3 CcTimer_Monday2 = no data stored
+- ctlv3 CcTimer_Monday = no data stored
+- ctlv3 CcTimer_Saturday0 = no data stored
+- ctlv3 CcTimer_Saturday1 = no data stored
+- ctlv3 CcTimer_Saturday2 = no data stored
+- ctlv3 CcTimer_Saturday = no data stored
+- ctlv3 CcTimer_Sunday0 = no data stored
+- ctlv3 CcTimer_Sunday1 = no data stored
+- ctlv3 CcTimer_Sunday2 = no data stored
+- ctlv3 CcTimer_Sunday = no data stored
+- ctlv3 CcTimer_Thursday0 = no data stored
+- ctlv3 CcTimer_Thursday1 = no data stored
+- ctlv3 CcTimer_Thursday2 = no data stored
+- ctlv3 CcTimer_Thursday = no data stored
+- ctlv3 CcTimer_Timeframes = 0;0;0;0;0;0;0
+- ctlv3 CcTimer_Tuesday0 = no data stored
+- ctlv3 CcTimer_Tuesday1 = no data stored
+- ctlv3 CcTimer_Tuesday2 = no data stored
+- ctlv3 CcTimer_Tuesday = no data stored
+- ctlv3 CcTimer_Wednesday0 = no data stored
+- ctlv3 CcTimer_Wednesday1 = no data stored
+- ctlv3 CcTimer_Wednesday2 = no data stored
+- ctlv3 CcTimer_Wednesday = no data stored
+- ctlv3 Clearerrorhistory = no data stored
+- ctlv3 ContinuousHeating = -26
+- ctlv3 ContinuousHeating = no data stored
+- ctlv3 Currenterror = -;-;-;-;-
+- ctlv3 CylinderChargeHyst = 7
+- ctlv3 CylinderChargeHyst = no data stored
+- ctlv3 CylinderChargeOffset = 5
+- ctlv3 CylinderChargeOffset = no data stored
+- ctlv3 Date = 13.08.2026
+- ctlv3 Date = no data stored
+- ctlv3 DisplayedOutsideTemp = 31.125
+- ctlv3 Errorhistory = no data stored
+- ctlv3 FrostOverRideTime = no data stored
+- ctlv3 FrostOverRideTime = no data stored
+- ctlv3 Hc1ActualFlowTempDesired = 21
+- ctlv3 Hc1AutoOffMode = no data stored
+- ctlv3 Hc1AutoOffMode = no data stored
+- ctlv3 Hc1CircuitType = no data stored
+- ctlv3 Hc1ExcessTemp = 0.0
+- ctlv3 Hc1ExcessTemp = no data stored
+- ctlv3 Hc1FlowTemp = 17.75
+- ctlv3 Hc1HeatCurve = 0.4
+- ctlv3 Hc1HeatCurve = no data stored
+- ctlv3 Hc1HeatCurveAdaption = 0.0
+- ctlv3 Hc1MaxFlowTempDesired = 50
+- ctlv3 Hc1MaxFlowTempDesired = no data stored
+- ctlv3 Hc1MinCoolingTempDesired = 21
+- ctlv3 Hc1MinCoolingTempDesired = no data stored
+- ctlv3 Hc1MinFlowTempDesired = 25
+- ctlv3 Hc1MinFlowTempDesired = no data stored
+- ctlv3 Hc1MixerMovement = -25
+- ctlv3 Hc1PumpStatus = 2
+- ctlv3 Hc1PumpStatus = no data stored
+- ctlv3 Hc1RoomTempSwitchOn = modulating
+- ctlv3 Hc1RoomTempSwitchOn = no data stored
+- ctlv3 Hc1Status = no data stored
+- ctlv3 Hc1Status = no data stored
+- ctlv3 Hc1SummerTempLimit = 16
+- ctlv3 Hc1SummerTempLimit = no data stored
+- ctlv3 Hc2ActualFlowTempDesired = 0.0
+- ctlv3 Hc2AutoOffMode = no data stored
+- ctlv3 Hc2AutoOffMode = no data stored
+- ctlv3 Hc2CircuitType = no data stored
+- ctlv3 Hc2ExcessTemp = 0.0
+- ctlv3 Hc2ExcessTemp = no data stored
+- ctlv3 Hc2FlowTemp = 23.875
+- ctlv3 Hc2HeatCurve = 0.3
+- ctlv3 Hc2HeatCurve = no data stored
+- ctlv3 Hc2HeatCurveAdaption = 0.0
+- ctlv3 Hc2MaxFlowTempDesired = 50
+- ctlv3 Hc2MaxFlowTempDesired = no data stored
+- ctlv3 Hc2MinCoolingTempDesired = no data stored
+- ctlv3 Hc2MinCoolingTempDesired = no data stored
+- ctlv3 Hc2MinFlowTempDesired = 15
+- ctlv3 Hc2MinFlowTempDesired = no data stored
+- ctlv3 Hc2MixerMovement = -100
+- ctlv3 Hc2PumpStatus = 0
+- ctlv3 Hc2PumpStatus = no data stored
+- ctlv3 Hc2RoomTempSwitchOn = modulating
+- ctlv3 Hc2RoomTempSwitchOn = no data stored
+- ctlv3 Hc2Status = no data stored
+- ctlv3 Hc2Status = no data stored
+- ctlv3 Hc2SummerTempLimit = 16
+- ctlv3 Hc2SummerTempLimit = no data stored
+- ctlv3 Hc3ActualFlowTempDesired = no data stored
+- ctlv3 Hc3AutoOffMode = no data stored
+- ctlv3 Hc3AutoOffMode = no data stored
+- ctlv3 Hc3CircuitType = no data stored
+- ctlv3 Hc3ExcessTemp = no data stored
+- ctlv3 Hc3ExcessTemp = no data stored
+- ctlv3 Hc3FlowTemp = no data stored
+- ctlv3 Hc3HeatCurve = no data stored
+- ctlv3 Hc3HeatCurve = no data stored
+- ctlv3 Hc3HeatCurveAdaption = no data stored
+- ctlv3 Hc3MaxFlowTempDesired = no data stored
+- ctlv3 Hc3MaxFlowTempDesired = no data stored
+- ctlv3 Hc3MinCoolingTempDesired = no data stored
+- ctlv3 Hc3MinCoolingTempDesired = no data stored
+- ctlv3 Hc3MinFlowTempDesired = no data stored
+- ctlv3 Hc3MinFlowTempDesired = no data stored
+- ctlv3 Hc3MixerMovement = no data stored
+- ctlv3 Hc3PumpStatus = no data stored
+- ctlv3 Hc3PumpStatus = no data stored
+- ctlv3 Hc3RoomTempSwitchOn = no data stored
+- ctlv3 Hc3RoomTempSwitchOn = no data stored
+- ctlv3 Hc3Status = no data stored
+- ctlv3 Hc3Status = no data stored
+- ctlv3 Hc3SummerTempLimit = no data stored
+- ctlv3 Hc3SummerTempLimit = no data stored
+- ctlv3 HcStorageTempBottom =  (empty for f115b5240602000000a000 / 080000a000ffffff7f)
+- ctlv3 HcStorageTempTop =  (empty for f115b52406020000009f00 / 0800009f00ffffff7f)
+- ctlv3 HwcBankHolidayEndPeriod = no data stored
+- ctlv3 HwcBankHolidayEndPeriod = no data stored
+- ctlv3 HwcBankHolidayStartPeriod = no data stored
+- ctlv3 HwcBankHolidayStartPeriod = no data stored
+- ctlv3 HwcFlowTemp = no data stored
+- ctlv3 HwcHolidayEndPeriod = 01.01.2019
+- ctlv3 HwcHolidayEndPeriod = no data stored
+- ctlv3 HwcHolidayStartPeriod = 01.01.2019
+- ctlv3 HwcHolidayStartPeriod = no data stored
+- ctlv3 HwcLockTime = 30
+- ctlv3 HwcLockTime = no data stored
+- ctlv3 HwcMaxFlowTempDesired = 80
+- ctlv3 HwcMaxFlowTempDesired = no data stored
+- ctlv3 HwcOpMode = auto
+- ctlv3 HwcOpMode = no data stored
+- ctlv3 HwcParallelLoading = off
+- ctlv3 HwcParallelLoading = no data stored
+- ctlv3 HwcSFMode = no data stored
+- ctlv3 HwcSFMode = no data stored
+- ctlv3 HwcStorageTemp = 49.5
+- ctlv3 HwcStorageTempBottom =  (empty for f115b52406020000009e00 / 0800009e00ffffff7f)
+- ctlv3 HwcStorageTempTop =  (empty for f115b52406020000009d00 / 0800009d00ffffff7f)
+- ctlv3 HwcTempDesired = 52
+- ctlv3 HwcTempDesired = no data stored
+- ctlv3 HwcTimer_Config = no data stored
+- ctlv3 HwcTimer_Friday0 = 01:00;03:00;52.0
+- ctlv3 HwcTimer_Friday1 = no data stored
+- ctlv3 HwcTimer_Friday2 = no data stored
+- ctlv3 HwcTimer_Friday = no data stored
+- ctlv3 HwcTimer_Monday0 = 01:00;03:00;52.0
+- ctlv3 HwcTimer_Monday1 = no data stored
+- ctlv3 HwcTimer_Monday2 = no data stored
+- ctlv3 HwcTimer_Monday = no data stored
+- ctlv3 HwcTimer_Saturday0 = 01:00;03:00;52.0
+- ctlv3 HwcTimer_Saturday1 = no data stored
+- ctlv3 HwcTimer_Saturday2 = no data stored
+- ctlv3 HwcTimer_Saturday = no data stored
+- ctlv3 HwcTimer_Sunday0 = 01:00;03:00;52.0
+- ctlv3 HwcTimer_Sunday1 = no data stored
+- ctlv3 HwcTimer_Sunday2 = no data stored
+- ctlv3 HwcTimer_Sunday = no data stored
+- ctlv3 HwcTimer_Thursday0 = 01:00;03:00;52.0
+- ctlv3 HwcTimer_Thursday1 = no data stored
+- ctlv3 HwcTimer_Thursday2 = no data stored
+- ctlv3 HwcTimer_Thursday = no data stored
+- ctlv3 HwcTimer_Timeframes = 1;1;1;1;1;1;1
+- ctlv3 HwcTimer_Tuesday0 = 01:00;03:00;52.0
+- ctlv3 HwcTimer_Tuesday1 = no data stored
+- ctlv3 HwcTimer_Tuesday2 = no data stored
+- ctlv3 HwcTimer_Tuesday = no data stored
+- ctlv3 HwcTimer_Wednesday0 = 01:00;03:00;52.0
+- ctlv3 HwcTimer_Wednesday1 = no data stored
+- ctlv3 HwcTimer_Wednesday2 = no data stored
+- ctlv3 HwcTimer_Wednesday = no data stored
+- ctlv3 HydraulicScheme = 8
+- ctlv3 HydraulicScheme = no data stored
+- ctlv3 Installer1 = no data stored
+- ctlv3 Installer1 = no data stored
+- ctlv3 Installer2 = no data stored
+- ctlv3 Installer2 = no data stored
+- ctlv3 KeyCodeforConfigMenu = no data stored
+- ctlv3 KeyCodeforConfigMenu = no data stored
+- ctlv3 MaintenanceDate = no data stored
+- ctlv3 MaintenanceDate = no data stored
+- ctlv3 MaintenanceDue = no
+- ctlv3 MaxCylinderChargeTime = 120
+- ctlv3 MaxCylinderChargeTime = no data stored
+- ctlv3 MaxRoomHumidity = no data stored
+- ctlv3 MaxRoomHumidity = no data stored
+- ctlv3 MultiRelaySetting = 4
+- ctlv3 MultiRelaySetting = no data stored
+- ctlv3 OutsideTempAvg = 22.1055
+- ctlv3 OutsideTempAvg = no data stored
+- ctlv3 PhoneNumber1 = no data stored
+- ctlv3 PhoneNumber1 = no data stored
+- ctlv3 PhoneNumber2 = no data stored
+- ctlv3 PhoneNumber2 = no data stored
+- ctlv3 PrEnergySum = no data stored
+- ctlv3 PrEnergySum = no data stored
+- ctlv3 PrEnergySumHc = no data stored
+- ctlv3 PrEnergySumHc = no data stored
+- ctlv3 PrEnergySumHcLastMonth = no data stored
+- ctlv3 PrEnergySumHcLastMonth = no data stored
+- ctlv3 PrEnergySumHcThisMonth = no data stored
+- ctlv3 PrEnergySumHcThisMonth = no data stored
+- ctlv3 PrEnergySumHwc = no data stored
+- ctlv3 PrEnergySumHwc = no data stored
+- ctlv3 PrEnergySumHwcLastMonth = no data stored
+- ctlv3 PrEnergySumHwcLastMonth = no data stored
+- ctlv3 PrEnergySumHwcThisMonth = no data stored
+- ctlv3 PrEnergySumHwcThisMonth = no data stored
+- ctlv3 PrFuelSum = no data stored
+- ctlv3 PrFuelSum = no data stored
+- ctlv3 PrFuelSumHc = no data stored
+- ctlv3 PrFuelSumHc = no data stored
+- ctlv3 PrFuelSumHcLastMonth = no data stored
+- ctlv3 PrFuelSumHcLastMonth = no data stored
+- ctlv3 PrFuelSumHcThisMonth = no data stored
+- ctlv3 PrFuelSumHcThisMonth = no data stored
+- ctlv3 PrFuelSumHwc = no data stored
+- ctlv3 PrFuelSumHwc = no data stored
+- ctlv3 PrFuelSumHwcLastMonth = no data stored
+- ctlv3 PrFuelSumHwcLastMonth = no data stored
+- ctlv3 PrFuelSumHwcThisMonth = no data stored
+- ctlv3 PrFuelSumHwcThisMonth = no data stored
+- ctlv3 PumpAdditionalTime = no data stored
+- ctlv3 PumpAdditionalTime = no data stored
+- ctlv3 SolarYieldTotal = no data stored
+- ctlv3 SolarYieldTotal = no data stored
+- ctlv3 SystemFlowTemp =  (empty for f115b52406020000004b00 / 0800004b00ffffff7f)
+- ctlv3 Time = 12:35:01
+- ctlv3 Time = no data stored
+- ctlv3 WaterPressure = 1.8
+- ctlv3 YieldTotal = no data stored
+- ctlv3 YieldTotal = no data stored
+- ctlv3 Z1ActualRoomTempDesired = 0.0
+- ctlv3 Z1ActualRoomTempDesired = no data stored
+- ctlv3 Z1BankHolidayEndPeriod = no data stored
+- ctlv3 Z1BankHolidayEndPeriod = no data stored
+- ctlv3 Z1BankHolidayStartPeriod = no data stored
+- ctlv3 Z1BankHolidayStartPeriod = no data stored
+- ctlv3 Z1CoolingTemp = 24
+- ctlv3 Z1CoolingTemp = no data stored
+- ctlv3 Z1DayTemp = 21
+- ctlv3 Z1DayTemp = no data stored
+- ctlv3 Z1HolidayEndPeriod = 01.01.2019
+- ctlv3 Z1HolidayEndPeriod = no data stored
+- ctlv3 Z1HolidayStartPeriod = 01.01.2019
+- ctlv3 Z1HolidayStartPeriod = no data stored
+- ctlv3 Z1HolidayTemp = 20
+- ctlv3 Z1HolidayTemp = no data stored
+- ctlv3 Z1Name1 = no data stored
+- ctlv3 Z1Name1 = no data stored
+- ctlv3 Z1Name2 = no data stored
+- ctlv3 Z1Name2 = no data stored
+- ctlv3 Z1NightTemp = 20
+- ctlv3 Z1NightTemp = no data stored
+- ctlv3 Z1OpMode = day
+- ctlv3 Z1OpMode = no data stored
+- ctlv3 Z1QuickVetoDuration = no data stored
+- ctlv3 Z1QuickVetoDuration = no data stored
+- ctlv3 Z1QuickVetoEndDate = no data stored
+- ctlv3 Z1QuickVetoEndTime = no data stored
+- ctlv3 Z1QuickVetoTemp = no data stored
+- ctlv3 Z1QuickVetoTemp = no data stored
+- ctlv3 Z1RoomTemp = 25.0375
+- ctlv3 Z1RoomZoneMapping = no data stored
+- ctlv3 Z1RoomZoneMapping = no data stored
+- ctlv3 Z1SFMode = no data stored
+- ctlv3 Z1SFMode = no data stored
+- ctlv3 Z1Shortname = no data stored
+- ctlv3 Z1Shortname = no data stored
+- ctlv3 Z1Timer_Config = no data stored
+- ctlv3 Z1Timer_Friday0 = 00:00;24:00;21.0
+- ctlv3 Z1Timer_Friday1 = no data stored
+- ctlv3 Z1Timer_Friday2 = no data stored
+- ctlv3 Z1Timer_Friday = no data stored
+- ctlv3 Z1Timer_Monday0 = 00:00;24:00;21.0
+- ctlv3 Z1Timer_Monday1 = no data stored
+- ctlv3 Z1Timer_Monday2 = no data stored
+- ctlv3 Z1Timer_Monday = no data stored
+- ctlv3 Z1Timer_Saturday0 = 00:00;24:00;21.0
+- ctlv3 Z1Timer_Saturday1 = no data stored
+- ctlv3 Z1Timer_Saturday2 = no data stored
+- ctlv3 Z1Timer_Saturday = no data stored
+- ctlv3 Z1Timer_Sunday0 = 00:00;24:00;21.0
+- ctlv3 Z1Timer_Sunday1 = no data stored
+- ctlv3 Z1Timer_Sunday2 = no data stored
+- ctlv3 Z1Timer_Sunday = no data stored
+- ctlv3 Z1Timer_Thursday0 = 00:00;24:00;21.0
+- ctlv3 Z1Timer_Thursday1 = no data stored
+- ctlv3 Z1Timer_Thursday2 = no data stored
+- ctlv3 Z1Timer_Thursday = no data stored
+- ctlv3 Z1Timer_Timeframes = 1;1;1;1;1;1;1
+- ctlv3 Z1Timer_Tuesday0 = 00:00;24:00;21.0
+- ctlv3 Z1Timer_Tuesday1 = no data stored
+- ctlv3 Z1Timer_Tuesday2 = no data stored
+- ctlv3 Z1Timer_Tuesday = no data stored
+- ctlv3 Z1Timer_Wednesday0 = 00:00;24:00;21.0
+- ctlv3 Z1Timer_Wednesday1 = no data stored
+- ctlv3 Z1Timer_Wednesday2 = no data stored
+- ctlv3 Z1Timer_Wednesday = no data stored
+- ctlv3 Z1ValveStatus = no data stored
+- ctlv3 Z1ValveStatus = no data stored
+- ctlv3 Z2ActualRoomTempDesired = 0.0
+- ctlv3 Z2ActualRoomTempDesired = no data stored
+- ctlv3 Z2BankHolidayEndPeriod = no data stored
+- ctlv3 Z2BankHolidayEndPeriod = no data stored
+- ctlv3 Z2BankHolidayStartPeriod = no data stored
+- ctlv3 Z2BankHolidayStartPeriod = no data stored
+- ctlv3 Z2CoolingTemp = no data stored
+- ctlv3 Z2CoolingTemp = no data stored
+- ctlv3 Z2DayTemp = 20.5
+- ctlv3 Z2DayTemp = no data stored
+- ctlv3 Z2HolidayEndPeriod = 01.01.2019
+- ctlv3 Z2HolidayEndPeriod = no data stored
+- ctlv3 Z2HolidayStartPeriod = 01.01.2019
+- ctlv3 Z2HolidayStartPeriod = no data stored
+- ctlv3 Z2HolidayTemp = 20
+- ctlv3 Z2HolidayTemp = no data stored
+- ctlv3 Z2Name1 = no data stored
+- ctlv3 Z2Name1 = no data stored
+- ctlv3 Z2Name2 = no data stored
+- ctlv3 Z2Name2 = no data stored
+- ctlv3 Z2NightTemp = 21
+- ctlv3 Z2NightTemp = no data stored
+- ctlv3 Z2OpMode = auto
+- ctlv3 Z2OpMode = no data stored
+- ctlv3 Z2QuickVetoDuration = no data stored
+- ctlv3 Z2QuickVetoDuration = no data stored
+- ctlv3 Z2QuickVetoEndDate = no data stored
+- ctlv3 Z2QuickVetoEndTime = 00:00:00
+- ctlv3 Z2QuickVetoTemp = no data stored
+- ctlv3 Z2QuickVetoTemp = no data stored
+- ctlv3 Z2RoomTemp = 27.2875
+- ctlv3 Z2RoomZoneMapping = no data stored
+- ctlv3 Z2RoomZoneMapping = no data stored
+- ctlv3 Z2SFMode = no data stored
+- ctlv3 Z2SFMode = no data stored
+- ctlv3 Z2Shortname = no data stored
+- ctlv3 Z2Shortname = no data stored
+- ctlv3 Z2Timer_Config = no data stored
+- ctlv3 Z2Timer_Friday0 = 03:00;24:00;20.0
+- ctlv3 Z2Timer_Friday1 = no data stored
+- ctlv3 Z2Timer_Friday2 = no data stored
+- ctlv3 Z2Timer_Friday = no data stored
+- ctlv3 Z2Timer_Monday0 = 03:00;24:00;20.0
+- ctlv3 Z2Timer_Monday1 = no data stored
+- ctlv3 Z2Timer_Monday2 = no data stored
+- ctlv3 Z2Timer_Monday = no data stored
+- ctlv3 Z2Timer_Saturday0 = 03:00;24:00;20.0
+- ctlv3 Z2Timer_Saturday1 = no data stored
+- ctlv3 Z2Timer_Saturday2 = no data stored
+- ctlv3 Z2Timer_Saturday = no data stored
+- ctlv3 Z2Timer_Sunday0 = 03:00;24:00;20.0
+- ctlv3 Z2Timer_Sunday1 = no data stored
+- ctlv3 Z2Timer_Sunday2 = no data stored
+- ctlv3 Z2Timer_Sunday = no data stored
+- ctlv3 Z2Timer_Thursday0 = 03:00;24:00;20.0
+- ctlv3 Z2Timer_Thursday1 = no data stored
+- ctlv3 Z2Timer_Thursday2 = no data stored
+- ctlv3 Z2Timer_Thursday = no data stored
+- ctlv3 Z2Timer_Timeframes = 1;1;1;1;1;1;1
+- ctlv3 Z2Timer_Tuesday0 = 03:00;24:00;20.0
+- ctlv3 Z2Timer_Tuesday1 = no data stored
+- ctlv3 Z2Timer_Tuesday2 = no data stored
+- ctlv3 Z2Timer_Tuesday = no data stored
+- ctlv3 Z2Timer_Wednesday0 = 03:00;24:00;20.0
+- ctlv3 Z2Timer_Wednesday1 = no data stored
+- ctlv3 Z2Timer_Wednesday2 = no data stored
+- ctlv3 Z2Timer_Wednesday = no data stored
+- ctlv3 Z2ValveStatus = no data stored
+- ctlv3 Z2ValveStatus = no data stored
+- ctlv3 Z3ActualRoomTempDesired = no data stored
+- ctlv3 Z3ActualRoomTempDesired = no data stored
+- ctlv3 Z3BankHolidayEndPeriod = no data stored
+- ctlv3 Z3BankHolidayEndPeriod = no data stored
+- ctlv3 Z3BankHolidayStartPeriod = no data stored
+- ctlv3 Z3BankHolidayStartPeriod = no data stored
+- ctlv3 Z3DayTemp = no data stored
+- ctlv3 Z3DayTemp = no data stored
+- ctlv3 Z3HolidayEndPeriod = no data stored
+- ctlv3 Z3HolidayEndPeriod = no data stored
+- ctlv3 Z3HolidayStartPeriod = no data stored
+- ctlv3 Z3HolidayStartPeriod = no data stored
+- ctlv3 Z3HolidayTemp = no data stored
+- ctlv3 Z3HolidayTemp = no data stored
+- ctlv3 Z3Name1 = no data stored
+- ctlv3 Z3Name1 = no data stored
+- ctlv3 Z3Name2 = no data stored
+- ctlv3 Z3Name2 = no data stored
+- ctlv3 Z3NightTemp = no data stored
+- ctlv3 Z3NightTemp = no data stored
+- ctlv3 Z3OpMode = no data stored
+- ctlv3 Z3OpMode = no data stored
+- ctlv3 Z3QuickVetoDuration = no data stored
+- ctlv3 Z3QuickVetoDuration = no data stored
+- ctlv3 Z3QuickVetoEndDate = no data stored
+- ctlv3 Z3QuickVetoEndTime = no data stored
+- ctlv3 Z3QuickVetoTemp = no data stored
+- ctlv3 Z3QuickVetoTemp = no data stored
+- ctlv3 Z3RoomTemp = no data stored
+- ctlv3 Z3RoomZoneMapping = no data stored
+- ctlv3 Z3RoomZoneMapping = no data stored
+- ctlv3 Z3SFMode = no data stored
+- ctlv3 Z3SFMode = no data stored
+- ctlv3 Z3Shortname = no data stored
+- ctlv3 Z3Shortname = no data stored
+- ctlv3 Z3Timer_Config = no data stored
+- ctlv3 Z3Timer_Friday0 = no data stored
+- ctlv3 Z3Timer_Friday1 = no data stored
+- ctlv3 Z3Timer_Friday2 = no data stored
+- ctlv3 Z3Timer_Friday = no data stored
+- ctlv3 Z3Timer_Monday0 = no data stored
+- ctlv3 Z3Timer_Monday1 = no data stored
+- ctlv3 Z3Timer_Monday2 = no data stored
+- ctlv3 Z3Timer_Monday = no data stored
+- ctlv3 Z3Timer_Saturday0 = no data stored
+- ctlv3 Z3Timer_Saturday1 = no data stored
+- ctlv3 Z3Timer_Saturday2 = no data stored
+- ctlv3 Z3Timer_Saturday = no data stored
+- ctlv3 Z3Timer_Sunday0 = no data stored
+- ctlv3 Z3Timer_Sunday1 = no data stored
+- ctlv3 Z3Timer_Sunday2 = no data stored
+- ctlv3 Z3Timer_Sunday = no data stored
+- ctlv3 Z3Timer_Thursday0 = no data stored
+- ctlv3 Z3Timer_Thursday1 = no data stored
+- ctlv3 Z3Timer_Thursday2 = no data stored
+- ctlv3 Z3Timer_Thursday = no data stored
+- ctlv3 Z3Timer_Timeframes = no data stored
+- ctlv3 Z3Timer_Tuesday0 = no data stored
+- ctlv3 Z3Timer_Tuesday1 = no data stored
+- ctlv3 Z3Timer_Tuesday2 = no data stored
+- ctlv3 Z3Timer_Tuesday = no data stored
+- ctlv3 Z3Timer_Wednesday0 = no data stored
+- ctlv3 Z3Timer_Wednesday1 = no data stored
+- ctlv3 Z3Timer_Wednesday2 = no data stored
+- ctlv3 Z3Timer_Wednesday = no data stored
+- ctlv3 Z3ValveStatus = no data stored
+- ctlv3 Z3ValveStatus = no data stored
+- General Valuerange = no data stored
+- hmu BuildingCircuitFlow = 776
+- hmu Clearerrorhistory = no data stored
+- hmu CompressorBlocktime = no data stored
+- hmu CompressorHc = 187179;4337
+- hmu CompressorHwc = 52308;736
+- hmu CopCooling = 6.8
+- hmu CopCoolingMonth = 6.6
+- hmu CopHc = 3.4
+- hmu CopHcMonth = 1.1
+- hmu CopHwc = 2.7
+- hmu CopHwcMonth = 3.5
+- hmu CurrentCompressorUtil = 0.00
+- hmu CurrentConsumedPower = 0.5
+- hmu Currenterror = -;-;-;-;-
+- hmu CurrentYieldPower = 2.2
+- hmu DateTime = nosignal;-:-:-;-.-.-;-
+- hmu EnergyIntegral = no data stored
+- hmu Errorhistory = no data stored
+- hmu FlowPressure = no data stored
+- hmu FlowTemp = 22.62
+- hmu PowerConsumptionHmu = 0.537904024
+- hmu RunDataAirInletTemp = 34.7884
+- hmu RunDataBuildingCPumpPower = 100
+- hmu RunDataCompressorInletTemp = 20.2242
+- hmu RunDataCompressorOutletTemp = 54.058
+- hmu RunDataCompressorSpeed = 30
+- hmu RunDataEEVOutletTemp = 37.5521
+- hmu RunDataEEVPositionAbs = 85
+- hmu RunDataFan1Speed = 618.952
+- hmu RunDataFan2Speed = 0.0
+- hmu RunDataHighPressure = 13.0458
+- hmu RunDataStatuscode = cool_compressor_active
+- hmu RunStats4PortValveHours = 320
+- hmu RunStats4PortValveSwitches = 1305
+- hmu RunStatsBuildingCPumpStarts = 2140
+- hmu RunStatsBuildingPumpHours = 11315
+- hmu RunStatsCompressorHours = 4287
+- hmu RunStatsCompressorStarts = 6150
+- hmu RunStatsFan1Hours = 4725
+- hmu RunStatsFan1Starts = 8489
+- hmu RunStatsFan2Hours = 0
+- hmu RunStatsFan2Starts = 0
+- hmu RunStatsHcHours = 8204
+- hmu RunStatsHMUHours = 17725
+- hmu RunStatsHwcHours = 914
+- hmu SetMode = auto;21.0;-;-;1;1;1;0;0;1
+- hmu SetMode = no data stored
+- hmu Status01 = 17.0;20.0;-;-;-;off
+- hmu Status02 = no data stored
+- hmu Status16 = no data stored
+- hmu Status = no data stored
+- hmu StatusCirPump = off
+- hmu SupplyTempWeighted = 22.00
+- hmu TotalEnergyUsage = 3517
+- hmu YieldCoolDay = 0.0
+- hmu YieldCooling = 0.0
+- hmu YieldCoolingMonth = 0.0
+- hmu YieldHc = 6225
+- hmu YieldHcDay = 0.1
+- hmu YieldHcMonth = no data stored
+- hmu YieldHwc = 1857
+- hmu YieldHwcDay = no data stored
+- hmu YieldHwcMonth = no data stored
+- Memory Eeprom = no data stored
+- Memory Eeprom = no data stored
+- Memory Ram = no data stored
+- Memory Ram = no data stored
+- Scan Id = no data stored
+- scan.08  = Vaillant;HMU00;0902;5103
+- Scan.08 Id = 21;24;18;0010047380;1300;105808;N4
+- scan.15  = Vaillant;CTLV3;0709;3704
+- Scan.15 Id = 21;23;44;0020260921;0953;015178;N9
+- scan.26  = Vaillant;VR_71;0201;0503
+- Scan.26 Id = 21;23;16;0020184847;0082;016128;N6
+- scan.35  = Vaillant;VR_92;0122;9403
+- Scan.35 Id = 21;21;06;0020260925;0953;006869;N7
+- scan.76  = Vaillant;VWZIO;0202;0103
+- Scan.76 Id = 21;24;17;0010031644;0082;009808;N6
+- scan.f6  = Vaillant;NETX3;0129;0404
+- Scan.f6 Id = 21;23;22;0020292012;0933;097000;N1
+- vr_71 Clearerrorhistory = no data stored
+- vr_71 Currenterror = no data stored
+- vr_71 Errorhistory = no data stored
+- vr_71 Mc1Operation = 2;21.0;on;-25
+- vr_71 Mc2Operation = off;0.0;on;-100
+- vr_71 Mc3Operation = no data stored
+- vr_71 SensorData1 = -;17.62;23.81;-;-;-;-;41 01
+- vr_71 SensorData2 = -;-;-;-;0.00;8.00;80 54 05
+- vr_71 SetActorState = -;-;off;on;off;off;-;-;-;-;off;off;00 00
+- vwzio EnableTestHwcTemp = no data stored
+- vwzio EnableTestOutdoorTemp = no data stored
+- vwzio EnableTestThreeWayValve = no data stored
+- vwzio TestHwcTemp = no data stored
+- vwzio TestOutdoorTemp = no data stored
+- vwzio TestThreeWayValve = no data stored
+- ''

--- a/tests/fixtures/community/arotherm_plus_ctlv2_cooling_discovery.yaml
+++ b/tests/fixtures/community/arotherm_plus_ctlv2_cooling_discovery.yaml
@@ -1,0 +1,12047 @@
+# Discovery dump for vaillant_ebus
+# Review this file for sensitive information before sharing
+metadata:
+  timestamp: '2026-08-14T10:28:20.040940'
+  ebusd_version: null
+  register_count: 656
+  grab_duration: 60
+  dump_version: 3
+raw_find_lines:
+- Broadcast Datetime = no data stored
+- Broadcast Error = no data stored
+- Broadcast HwcStatus = no data stored
+- Broadcast Id = no data stored
+- Broadcast IdAnswer = no data stored
+- Broadcast IdQuery = no data stored
+- Broadcast Load = no data stored
+- Broadcast Outsidetemp = 26.898
+- Broadcast Queryexistence = no data stored
+- Broadcast Signoflife = no data stored
+- Broadcast Vdatetime = 10:26:15;14.08.2026
+- Broadcast Vdatetime = no data stored
+- ctlv2 AdaptHeatCurve = yes
+- ctlv2 AdaptHeatCurve = no data stored
+- ctlv2 CcTimer_Config = 00 03 0a 00 00 00 ff ff 00
+- ctlv2 CcTimer_Friday0 = 08:30;22:00
+- ctlv2 CcTimer_Friday1 = no data stored
+- ctlv2 CcTimer_Friday2 = no data stored
+- ctlv2 CcTimer_Friday = no data stored
+- ctlv2 CcTimer_Monday0 = 08:30;22:00
+- ctlv2 CcTimer_Monday1 = no data stored
+- ctlv2 CcTimer_Monday2 = no data stored
+- ctlv2 CcTimer_Monday = no data stored
+- ctlv2 CcTimer_Saturday0 = 08:30;22:00
+- ctlv2 CcTimer_Saturday1 = no data stored
+- ctlv2 CcTimer_Saturday2 = no data stored
+- ctlv2 CcTimer_Saturday = no data stored
+- ctlv2 CcTimer_Sunday0 = 08:30;22:00
+- ctlv2 CcTimer_Sunday1 = no data stored
+- ctlv2 CcTimer_Sunday2 = no data stored
+- ctlv2 CcTimer_Sunday = no data stored
+- ctlv2 CcTimer_Thursday0 = 08:30;22:00
+- ctlv2 CcTimer_Thursday1 = no data stored
+- ctlv2 CcTimer_Thursday2 = no data stored
+- ctlv2 CcTimer_Thursday = no data stored
+- ctlv2 CcTimer_Timeframes = 1;1;1;1;1;1;1
+- ctlv2 CcTimer_Tuesday0 = 08:30;22:00
+- ctlv2 CcTimer_Tuesday1 = no data stored
+- ctlv2 CcTimer_Tuesday2 = no data stored
+- ctlv2 CcTimer_Tuesday = no data stored
+- ctlv2 CcTimer_Wednesday0 = 08:30;22:00
+- ctlv2 CcTimer_Wednesday1 = no data stored
+- ctlv2 CcTimer_Wednesday2 = no data stored
+- ctlv2 CcTimer_Wednesday = no data stored
+- ctlv2 Clearerrorhistory = no data stored
+- ctlv2 ContinuousHeating = -26
+- ctlv2 ContinuousHeating = no data stored
+- ctlv2 Currenterror = -;-;-;-;-
+- ctlv2 CylinderChargeHyst = 5
+- ctlv2 CylinderChargeHyst = no data stored
+- ctlv2 CylinderChargeOffset = 8
+- ctlv2 CylinderChargeOffset = no data stored
+- ctlv2 Date = 14.08.2026
+- ctlv2 Date = no data stored
+- ctlv2 DisplayedOutsideTemp = 26.9492
+- ctlv2 Errorhistory = no data stored
+- ctlv2 FrostOverRideTime = 4
+- ctlv2 FrostOverRideTime = no data stored
+- ctlv2 Hc1ActualFlowTempDesired = 17
+- ctlv2 Hc1AutoOffMode = eco
+- ctlv2 Hc1AutoOffMode = no data stored
+- ctlv2 Hc1CircuitType = mixer
+- ctlv2 Hc1ExcessTemp = 0.0
+- ctlv2 Hc1ExcessTemp = no data stored
+- ctlv2 Hc1FlowTemp = 16.5
+- ctlv2 Hc1HeatCurve = 0.35
+- ctlv2 Hc1HeatCurve = no data stored
+- ctlv2 Hc1HeatCurveAdaption = 0.0
+- ctlv2 Hc1MaxFlowTempDesired = 45
+- ctlv2 Hc1MaxFlowTempDesired = no data stored
+- ctlv2 Hc1MinCoolingTempDesired = 17
+- ctlv2 Hc1MinCoolingTempDesired = no data stored
+- ctlv2 Hc1MinFlowTempDesired = 20
+- ctlv2 Hc1MinFlowTempDesired = no data stored
+- ctlv2 Hc1MixerMovement = 0.0
+- ctlv2 Hc1PumpStatus = 2
+- ctlv2 Hc1PumpStatus = no data stored
+- ctlv2 Hc1RoomTempSwitchOn = modulating
+- ctlv2 Hc1RoomTempSwitchOn = no data stored
+- ctlv2 Hc1Status = 0
+- ctlv2 Hc1Status = no data stored
+- ctlv2 Hc1SummerTempLimit = 19
+- ctlv2 Hc1SummerTempLimit = no data stored
+- ctlv2 Hc2ActualFlowTempDesired = 0.0
+- ctlv2 Hc2AutoOffMode = eco
+- ctlv2 Hc2AutoOffMode = no data stored
+- ctlv2 Hc2CircuitType = inactive
+- ctlv2 Hc2ExcessTemp = 0.0
+- ctlv2 Hc2ExcessTemp = no data stored
+- ctlv2 Hc2FlowTemp =  (empty for 3115b52406020002010800 / 0800020800ffffff7f)
+- ctlv2 Hc2HeatCurve = 0.1
+- ctlv2 Hc2HeatCurve = no data stored
+- ctlv2 Hc2HeatCurveAdaption = 0.0
+- ctlv2 Hc2MaxFlowTempDesired = 55
+- ctlv2 Hc2MaxFlowTempDesired = no data stored
+- ctlv2 Hc2MinCoolingTempDesired = 20
+- ctlv2 Hc2MinCoolingTempDesired = no data stored
+- ctlv2 Hc2MinFlowTempDesired = 15
+- ctlv2 Hc2MinFlowTempDesired = no data stored
+- ctlv2 Hc2MixerMovement = 0.0
+- ctlv2 Hc2PumpStatus = 0
+- ctlv2 Hc2PumpStatus = no data stored
+- ctlv2 Hc2RoomTempSwitchOn = off
+- ctlv2 Hc2RoomTempSwitchOn = no data stored
+- ctlv2 Hc2Status = 0
+- ctlv2 Hc2Status = no data stored
+- ctlv2 Hc2SummerTempLimit = 21
+- ctlv2 Hc2SummerTempLimit = no data stored
+- ctlv2 Hc3ActualFlowTempDesired = 0.0
+- ctlv2 Hc3AutoOffMode = eco
+- ctlv2 Hc3AutoOffMode = no data stored
+- ctlv2 Hc3CircuitType = inactive
+- ctlv2 Hc3ExcessTemp = 0.0
+- ctlv2 Hc3ExcessTemp = no data stored
+- ctlv2 Hc3FlowTemp =  (empty for 3115b52406020002020800 / 0800020800ffffff7f)
+- ctlv2 Hc3HeatCurve = 0.6
+- ctlv2 Hc3HeatCurve = no data stored
+- ctlv2 Hc3HeatCurveAdaption = 0.0
+- ctlv2 Hc3MaxFlowTempDesired = 55
+- ctlv2 Hc3MaxFlowTempDesired = no data stored
+- ctlv2 Hc3MinCoolingTempDesired = 20
+- ctlv2 Hc3MinCoolingTempDesired = no data stored
+- ctlv2 Hc3MinFlowTempDesired = 15
+- ctlv2 Hc3MinFlowTempDesired = no data stored
+- ctlv2 Hc3MixerMovement = 0.0
+- ctlv2 Hc3PumpStatus = 0
+- ctlv2 Hc3PumpStatus = no data stored
+- ctlv2 Hc3RoomTempSwitchOn = off
+- ctlv2 Hc3RoomTempSwitchOn = no data stored
+- ctlv2 Hc3Status = 0
+- ctlv2 Hc3Status = no data stored
+- ctlv2 Hc3SummerTempLimit = 21
+- ctlv2 Hc3SummerTempLimit = no data stored
+- ctlv2 HcStorageTempBottom =  (empty for f115b5240602000000a000 / 080000a000ffffff7f)
+- ctlv2 HcStorageTempTop =  (empty for f115b52406020000009f00 / 0800009f00ffffff7f)
+- ctlv2 HwcBankHolidayEndPeriod = no data stored
+- ctlv2 HwcBankHolidayEndPeriod = no data stored
+- ctlv2 HwcBankHolidayStartPeriod = no data stored
+- ctlv2 HwcBankHolidayStartPeriod = no data stored
+- ctlv2 HwcFlowTemp = 0.0
+- ctlv2 HwcHolidayEndPeriod = 01.01.2015
+- ctlv2 HwcHolidayEndPeriod = no data stored
+- ctlv2 HwcHolidayStartPeriod = 01.01.2015
+- ctlv2 HwcHolidayStartPeriod = no data stored
+- ctlv2 HwcLockTime = 30
+- ctlv2 HwcLockTime = no data stored
+- ctlv2 HwcMaxFlowTempDesired = 80
+- ctlv2 HwcMaxFlowTempDesired = no data stored
+- ctlv2 HwcOpMode = day
+- ctlv2 HwcOpMode = no data stored
+- ctlv2 HwcParallelLoading = off
+- ctlv2 HwcParallelLoading = no data stored
+- ctlv2 HwcSFMode = auto
+- ctlv2 HwcSFMode = no data stored
+- ctlv2 HwcStorageTemp = 40.5
+- ctlv2 HwcStorageTempBottom =  (empty for f115b52406020000009e00 / 0800009e00ffffff7f)
+- ctlv2 HwcStorageTempTop =  (empty for f115b52406020000009d00 / 0800009d00ffffff7f)
+- ctlv2 HwcTempDesired = 35
+- ctlv2 HwcTempDesired = no data stored
+- ctlv2 HwcTimer_Config = no data stored
+- ctlv2 HwcTimer_Friday0 = 13:30;15:00;35.0
+- ctlv2 HwcTimer_Friday1 = no data stored
+- ctlv2 HwcTimer_Friday2 = no data stored
+- ctlv2 HwcTimer_Friday = no data stored
+- ctlv2 HwcTimer_Monday0 = 13:30;15:00;35.0
+- ctlv2 HwcTimer_Monday1 = no data stored
+- ctlv2 HwcTimer_Monday2 = no data stored
+- ctlv2 HwcTimer_Monday = no data stored
+- ctlv2 HwcTimer_Saturday0 = 13:30;15:00;35.0
+- ctlv2 HwcTimer_Saturday1 = no data stored
+- ctlv2 HwcTimer_Saturday2 = no data stored
+- ctlv2 HwcTimer_Saturday = no data stored
+- ctlv2 HwcTimer_Sunday0 = 13:30;15:00;35.0
+- ctlv2 HwcTimer_Sunday1 = no data stored
+- ctlv2 HwcTimer_Sunday2 = no data stored
+- ctlv2 HwcTimer_Sunday = no data stored
+- ctlv2 HwcTimer_Thursday0 = 13:30;15:00;35.0
+- ctlv2 HwcTimer_Thursday1 = no data stored
+- ctlv2 HwcTimer_Thursday2 = no data stored
+- ctlv2 HwcTimer_Thursday = no data stored
+- ctlv2 HwcTimer_Timeframes = 1;1;1;1;1;1;1
+- ctlv2 HwcTimer_Tuesday0 = 13:30;15:00;35.0
+- ctlv2 HwcTimer_Tuesday1 = no data stored
+- ctlv2 HwcTimer_Tuesday2 = no data stored
+- ctlv2 HwcTimer_Tuesday = no data stored
+- ctlv2 HwcTimer_Wednesday0 = 13:30;15:00;35.0
+- ctlv2 HwcTimer_Wednesday1 = no data stored
+- ctlv2 HwcTimer_Wednesday2 = no data stored
+- ctlv2 HwcTimer_Wednesday = no data stored
+- ctlv2 HydraulicScheme = 8
+- ctlv2 HydraulicScheme = no data stored
+- ctlv2 Installer1 = no data stored
+- ctlv2 Installer1 = no data stored
+- ctlv2 Installer2 = no data stored
+- ctlv2 Installer2 = no data stored
+- ctlv2 KeyCodeforConfigMenu = no data stored
+- ctlv2 KeyCodeforConfigMenu = no data stored
+- ctlv2 MaintenanceDate = no data stored
+- ctlv2 MaintenanceDate = no data stored
+- ctlv2 MaintenanceDue = no data stored
+- ctlv2 MaxCylinderChargeTime = 120
+- ctlv2 MaxCylinderChargeTime = no data stored
+- ctlv2 MaxRoomHumidity = 70
+- ctlv2 MaxRoomHumidity = no data stored
+- ctlv2 MultiRelaySetting = 4
+- ctlv2 MultiRelaySetting = no data stored
+- ctlv2 OutsideTempAvg = 31.3828
+- ctlv2 OutsideTempAvg = no data stored
+- ctlv2 PhoneNumber1 = no data stored
+- ctlv2 PhoneNumber1 = no data stored
+- ctlv2 PhoneNumber2 = no data stored
+- ctlv2 PhoneNumber2 = no data stored
+- 'ctlv2 PrEnergySum =  (ERR: invalid position for 3115b52406020000005c00 / 00)'
+- ctlv2 PrEnergySum = no data stored
+- ctlv2 PrEnergySumHc = 4343
+- ctlv2 PrEnergySumHc = no data stored
+- ctlv2 PrEnergySumHcLastMonth = 8
+- ctlv2 PrEnergySumHcLastMonth = no data stored
+- ctlv2 PrEnergySumHcThisMonth = 3
+- ctlv2 PrEnergySumHcThisMonth = no data stored
+- ctlv2 PrEnergySumHwc = 4232
+- ctlv2 PrEnergySumHwc = no data stored
+- ctlv2 PrEnergySumHwcLastMonth = 77
+- ctlv2 PrEnergySumHwcLastMonth = no data stored
+- ctlv2 PrEnergySumHwcThisMonth = 15
+- ctlv2 PrEnergySumHwcThisMonth = no data stored
+- ctlv2 PrFuelSum = no data stored
+- ctlv2 PrFuelSum = no data stored
+- ctlv2 PrFuelSumHc = no data stored
+- ctlv2 PrFuelSumHc = no data stored
+- ctlv2 PrFuelSumHcLastMonth = no data stored
+- ctlv2 PrFuelSumHcLastMonth = no data stored
+- ctlv2 PrFuelSumHcThisMonth = no data stored
+- ctlv2 PrFuelSumHcThisMonth = no data stored
+- ctlv2 PrFuelSumHwc = no data stored
+- ctlv2 PrFuelSumHwc = no data stored
+- ctlv2 PrFuelSumHwcLastMonth = no data stored
+- ctlv2 PrFuelSumHwcLastMonth = no data stored
+- ctlv2 PrFuelSumHwcThisMonth = no data stored
+- ctlv2 PrFuelSumHwcThisMonth = no data stored
+- ctlv2 PumpAdditionalTime = no data stored
+- ctlv2 PumpAdditionalTime = no data stored
+- ctlv2 SolarYieldTotal = no data stored
+- ctlv2 SolarYieldTotal = no data stored
+- ctlv2 SystemFlowTemp =  (empty for f115b52406020000004b00 / 0800004b00ffffff7f)
+- ctlv2 Time = 09:50:46
+- ctlv2 Time = no data stored
+- ctlv2 WaterPressure = 1.7
+- ctlv2 YieldTotal = no data stored
+- ctlv2 YieldTotal = no data stored
+- ctlv2 Z1ActualRoomTempDesired = 0.0
+- ctlv2 Z1ActualRoomTempDesired = no data stored
+- ctlv2 Z1BankHolidayEndPeriod = no data stored
+- ctlv2 Z1BankHolidayEndPeriod = no data stored
+- ctlv2 Z1BankHolidayStartPeriod = no data stored
+- ctlv2 Z1BankHolidayStartPeriod = no data stored
+- ctlv2 Z1CoolingTemp = 20
+- ctlv2 Z1CoolingTemp = no data stored
+- ctlv2 Z1DayTemp = 20
+- ctlv2 Z1DayTemp = no data stored
+- ctlv2 Z1HolidayEndPeriod = 01.01.2015
+- ctlv2 Z1HolidayEndPeriod = no data stored
+- ctlv2 Z1HolidayStartPeriod = 01.01.2015
+- ctlv2 Z1HolidayStartPeriod = no data stored
+- ctlv2 Z1HolidayTemp = 15
+- ctlv2 Z1HolidayTemp = no data stored
+- ctlv2 Z1Name1 = Thuis
+- ctlv2 Z1Name1 = no data stored
+- 'ctlv2 Z1Name2 =  (ERR: invalid position for f115b52406020003001800 / 050303180000)'
+- ctlv2 Z1Name2 = no data stored
+- ctlv2 Z1NightTemp = 18
+- ctlv2 Z1NightTemp = no data stored
+- ctlv2 Z1OpMode = auto
+- ctlv2 Z1OpMode = no data stored
+- ctlv2 Z1QuickVetoDuration = 3
+- ctlv2 Z1QuickVetoDuration = no data stored
+- ctlv2 Z1QuickVetoEndDate = 28.07.2026
+- ctlv2 Z1QuickVetoEndTime = 11:16:00
+- ctlv2 Z1QuickVetoTemp = 20
+- ctlv2 Z1QuickVetoTemp = no data stored
+- ctlv2 z1RoomHumidity = 46
+- ctlv2 Z1RoomTemp = 22.975
+- ctlv2 Z1RoomZoneMapping = VRC700
+- ctlv2 Z1RoomZoneMapping = no data stored
+- ctlv2 Z1SFMode = auto
+- ctlv2 Z1SFMode = no data stored
+- ctlv2 Z1Shortname = no data stored
+- ctlv2 Z1Shortname = no data stored
+- ctlv2 Z1Timer_Config = no data stored
+- ctlv2 Z1Timer_Friday0 = 06:00;22:00;20.0
+- ctlv2 Z1Timer_Friday1 = no data stored
+- ctlv2 Z1Timer_Friday2 = no data stored
+- ctlv2 Z1Timer_Friday = no data stored
+- ctlv2 Z1Timer_Monday0 = 06:00;22:00;20.0
+- ctlv2 Z1Timer_Monday1 = no data stored
+- ctlv2 Z1Timer_Monday2 = no data stored
+- ctlv2 Z1Timer_Monday = no data stored
+- ctlv2 Z1Timer_Saturday0 = 06:00;22:00;20.0
+- ctlv2 Z1Timer_Saturday1 = no data stored
+- ctlv2 Z1Timer_Saturday2 = no data stored
+- ctlv2 Z1Timer_Saturday = no data stored
+- ctlv2 Z1Timer_Sunday0 = 06:00;22:00;20.0
+- ctlv2 Z1Timer_Sunday1 = no data stored
+- ctlv2 Z1Timer_Sunday2 = no data stored
+- ctlv2 Z1Timer_Sunday = no data stored
+- ctlv2 Z1Timer_Thursday0 = 06:00;22:00;20.0
+- ctlv2 Z1Timer_Thursday1 = no data stored
+- ctlv2 Z1Timer_Thursday2 = no data stored
+- ctlv2 Z1Timer_Thursday = no data stored
+- ctlv2 Z1Timer_Timeframes = 1;1;1;1;1;1;1
+- ctlv2 Z1Timer_Tuesday0 = 06:00;22:00;20.0
+- ctlv2 Z1Timer_Tuesday1 = no data stored
+- ctlv2 Z1Timer_Tuesday2 = no data stored
+- ctlv2 Z1Timer_Tuesday = no data stored
+- ctlv2 Z1Timer_Wednesday0 = 06:00;22:00;20.0
+- ctlv2 Z1Timer_Wednesday1 = no data stored
+- ctlv2 Z1Timer_Wednesday2 = no data stored
+- ctlv2 Z1Timer_Wednesday = no data stored
+- ctlv2 Z1ValveStatus = no data stored
+- ctlv2 Z1ValveStatus = no data stored
+- ctlv2 Z2ActualRoomTempDesired = no data stored
+- ctlv2 Z2ActualRoomTempDesired = no data stored
+- ctlv2 Z2BankHolidayEndPeriod = no data stored
+- ctlv2 Z2BankHolidayEndPeriod = no data stored
+- ctlv2 Z2BankHolidayStartPeriod = no data stored
+- ctlv2 Z2BankHolidayStartPeriod = no data stored
+- ctlv2 Z2CoolingTemp = no data stored
+- ctlv2 Z2CoolingTemp = no data stored
+- ctlv2 Z2DayTemp = no data stored
+- ctlv2 Z2DayTemp = no data stored
+- ctlv2 Z2HolidayEndPeriod = no data stored
+- ctlv2 Z2HolidayEndPeriod = no data stored
+- ctlv2 Z2HolidayStartPeriod = no data stored
+- ctlv2 Z2HolidayStartPeriod = no data stored
+- ctlv2 Z2HolidayTemp = no data stored
+- ctlv2 Z2HolidayTemp = no data stored
+- ctlv2 Z2Name1 = no data stored
+- ctlv2 Z2Name1 = no data stored
+- ctlv2 Z2Name2 = no data stored
+- ctlv2 Z2Name2 = no data stored
+- ctlv2 Z2NightTemp = no data stored
+- ctlv2 Z2NightTemp = no data stored
+- ctlv2 Z2OpMode = no data stored
+- ctlv2 Z2OpMode = no data stored
+- ctlv2 Z2QuickVetoDuration = no data stored
+- ctlv2 Z2QuickVetoDuration = no data stored
+- ctlv2 Z2QuickVetoEndDate = no data stored
+- ctlv2 Z2QuickVetoEndTime = no data stored
+- ctlv2 Z2QuickVetoTemp = no data stored
+- ctlv2 Z2QuickVetoTemp = no data stored
+- ctlv2 Z2RoomTemp =  (empty for 3115b52406020003010f00 / 0800030f00ffffff7f)
+- ctlv2 Z2RoomZoneMapping = none
+- ctlv2 Z2RoomZoneMapping = no data stored
+- ctlv2 Z2SFMode = no data stored
+- ctlv2 Z2SFMode = no data stored
+- ctlv2 Z2Shortname = no data stored
+- ctlv2 Z2Shortname = no data stored
+- ctlv2 Z2Timer_Config = no data stored
+- ctlv2 Z2Timer_Friday0 = no data stored
+- ctlv2 Z2Timer_Friday1 = no data stored
+- ctlv2 Z2Timer_Friday2 = no data stored
+- ctlv2 Z2Timer_Friday = no data stored
+- ctlv2 Z2Timer_Monday0 = no data stored
+- ctlv2 Z2Timer_Monday1 = no data stored
+- ctlv2 Z2Timer_Monday2 = no data stored
+- ctlv2 Z2Timer_Monday = no data stored
+- ctlv2 Z2Timer_Saturday0 = no data stored
+- ctlv2 Z2Timer_Saturday1 = no data stored
+- ctlv2 Z2Timer_Saturday2 = no data stored
+- ctlv2 Z2Timer_Saturday = no data stored
+- ctlv2 Z2Timer_Sunday0 = no data stored
+- ctlv2 Z2Timer_Sunday1 = no data stored
+- ctlv2 Z2Timer_Sunday2 = no data stored
+- ctlv2 Z2Timer_Sunday = no data stored
+- ctlv2 Z2Timer_Thursday0 = no data stored
+- ctlv2 Z2Timer_Thursday1 = no data stored
+- ctlv2 Z2Timer_Thursday2 = no data stored
+- ctlv2 Z2Timer_Thursday = no data stored
+- ctlv2 Z2Timer_Timeframes = no data stored
+- ctlv2 Z2Timer_Tuesday0 = no data stored
+- ctlv2 Z2Timer_Tuesday1 = no data stored
+- ctlv2 Z2Timer_Tuesday2 = no data stored
+- ctlv2 Z2Timer_Tuesday = no data stored
+- ctlv2 Z2Timer_Wednesday0 = no data stored
+- ctlv2 Z2Timer_Wednesday1 = no data stored
+- ctlv2 Z2Timer_Wednesday2 = no data stored
+- ctlv2 Z2Timer_Wednesday = no data stored
+- ctlv2 Z2ValveStatus = no data stored
+- ctlv2 Z2ValveStatus = no data stored
+- ctlv2 Z3ActualRoomTempDesired = no data stored
+- ctlv2 Z3ActualRoomTempDesired = no data stored
+- ctlv2 Z3BankHolidayEndPeriod = no data stored
+- ctlv2 Z3BankHolidayEndPeriod = no data stored
+- ctlv2 Z3BankHolidayStartPeriod = no data stored
+- ctlv2 Z3BankHolidayStartPeriod = no data stored
+- ctlv2 Z3DayTemp = no data stored
+- ctlv2 Z3DayTemp = no data stored
+- ctlv2 Z3HolidayEndPeriod = no data stored
+- ctlv2 Z3HolidayEndPeriod = no data stored
+- ctlv2 Z3HolidayStartPeriod = no data stored
+- ctlv2 Z3HolidayStartPeriod = no data stored
+- ctlv2 Z3HolidayTemp = no data stored
+- ctlv2 Z3HolidayTemp = no data stored
+- ctlv2 Z3Name1 = no data stored
+- ctlv2 Z3Name1 = no data stored
+- ctlv2 Z3Name2 = no data stored
+- ctlv2 Z3Name2 = no data stored
+- ctlv2 Z3NightTemp = no data stored
+- ctlv2 Z3NightTemp = no data stored
+- ctlv2 Z3OpMode = no data stored
+- ctlv2 Z3OpMode = no data stored
+- ctlv2 Z3QuickVetoDuration = no data stored
+- ctlv2 Z3QuickVetoDuration = no data stored
+- ctlv2 Z3QuickVetoEndDate = no data stored
+- ctlv2 Z3QuickVetoEndTime = no data stored
+- ctlv2 Z3QuickVetoTemp = no data stored
+- ctlv2 Z3QuickVetoTemp = no data stored
+- ctlv2 Z3RoomTemp = no data stored
+- ctlv2 Z3RoomZoneMapping = none
+- ctlv2 Z3RoomZoneMapping = no data stored
+- ctlv2 Z3SFMode = no data stored
+- ctlv2 Z3SFMode = no data stored
+- ctlv2 Z3Shortname = no data stored
+- ctlv2 Z3Shortname = no data stored
+- ctlv2 Z3Timer_Config = no data stored
+- ctlv2 Z3Timer_Friday0 = no data stored
+- ctlv2 Z3Timer_Friday1 = no data stored
+- ctlv2 Z3Timer_Friday2 = no data stored
+- ctlv2 Z3Timer_Friday = no data stored
+- ctlv2 Z3Timer_Monday0 = no data stored
+- ctlv2 Z3Timer_Monday1 = no data stored
+- ctlv2 Z3Timer_Monday2 = no data stored
+- ctlv2 Z3Timer_Monday = no data stored
+- ctlv2 Z3Timer_Saturday0 = no data stored
+- ctlv2 Z3Timer_Saturday1 = no data stored
+- ctlv2 Z3Timer_Saturday2 = no data stored
+- ctlv2 Z3Timer_Saturday = no data stored
+- ctlv2 Z3Timer_Sunday0 = no data stored
+- ctlv2 Z3Timer_Sunday1 = no data stored
+- ctlv2 Z3Timer_Sunday2 = no data stored
+- ctlv2 Z3Timer_Sunday = no data stored
+- ctlv2 Z3Timer_Thursday0 = no data stored
+- ctlv2 Z3Timer_Thursday1 = no data stored
+- ctlv2 Z3Timer_Thursday2 = no data stored
+- ctlv2 Z3Timer_Thursday = no data stored
+- ctlv2 Z3Timer_Timeframes = no data stored
+- ctlv2 Z3Timer_Tuesday0 = no data stored
+- ctlv2 Z3Timer_Tuesday1 = no data stored
+- ctlv2 Z3Timer_Tuesday2 = no data stored
+- ctlv2 Z3Timer_Tuesday = no data stored
+- ctlv2 Z3Timer_Wednesday0 = no data stored
+- ctlv2 Z3Timer_Wednesday1 = no data stored
+- ctlv2 Z3Timer_Wednesday2 = no data stored
+- ctlv2 Z3Timer_Wednesday = no data stored
+- ctlv2 Z3ValveStatus = no data stored
+- ctlv2 Z3ValveStatus = no data stored
+- General Valuerange = no data stored
+- hmu BuildingCircuitFlow = 0
+- hmu Clearerrorhistory = no data stored
+- hmu CompressorBlocktime = no data stored
+- hmu CompressorHc = no data stored (message not available due to condition)
+- hmu CompressorHwc = no data stored (message not available due to condition)
+- hmu CopCooling = 7.8
+- hmu CopCoolingMonth = 8.0
+- hmu CopHc = 5.7
+- hmu CopHcMonth = 1.0
+- hmu CopHwc = 2.9
+- hmu CopHwcMonth = 3.5
+- hmu CurrentCompressorUtil = 0.00
+- hmu CurrentConsumedPower = 0.0
+- hmu Currenterror = -;-;-;-;-
+- hmu CurrentYieldPower = 0.0
+- hmu DateTime = nosignal;-:-:-;-.-.-;-
+- hmu EnergyIntegral = no data stored
+- hmu Errorhistory = no data stored
+- hmu FlowPressure = no data stored (message not available due to condition)
+- hmu FlowTemp = 42.06
+- hmu PowerConsumptionHmu = no data stored
+- hmu RunDataAirInletTemp = 27.5728
+- hmu RunDataBuildingCPumpPower = 72.8297
+- hmu RunDataCompressorInletTemp = 28.4709
+- hmu RunDataCompressorOutletTemp = 29.875
+- hmu RunDataCompressorSpeed = 29.9967
+- hmu RunDataEEVOutletTemp = 27.6724
+- hmu RunDataEEVPositionAbs = 179
+- hmu RunDataFan1Speed = 0.0
+- hmu RunDataFan2Speed = 0.0
+- hmu RunDataHighPressure = 15.1236
+- hmu RunDataStatuscode = cool_compressor_active
+- hmu RunStats4PortValveHours = 354
+- hmu RunStats4PortValveSwitches = 1525
+- hmu RunStatsBuildingCPumpStarts = 2109
+- hmu RunStatsBuildingPumpHours = 19812
+- hmu RunStatsCompressorHours = 8171
+- hmu RunStatsCompressorStarts = 14019
+- hmu RunStatsFan1Hours = 9257
+- hmu RunStatsFan1Starts = 15862
+- hmu RunStatsFan2Hours = 0
+- hmu RunStatsFan2Starts = 0
+- hmu RunStatsHcHours = 16913
+- hmu RunStatsHMUHours = 34298
+- hmu RunStatsHwcHours = 1664
+- hmu SetMode = auto;17.0;-;-;1;1;1;0;0;1
+- hmu SetMode = no data stored
+- hmu Status01 = 16.5;20.0;-;-;-;off
+- hmu Status02 = no data stored
+- hmu Status16 = no data stored
+- hmu Status = no data stored
+- hmu StatusCirPump = on
+- hmu SupplyTempWeighted = 20.00
+- hmu TotalEnergyUsage = 7667
+- hmu YieldCoolDay = 14.8
+- hmu YieldCooling = 115.7
+- hmu YieldCoolingMonth = 90.6
+- hmu YieldHc = 21711
+- hmu YieldHcDay = 0.0
+- hmu YieldHcMonth = no data stored
+- hmu YieldHwc = 6523
+- hmu YieldHwcDay = no data stored
+- hmu YieldHwcMonth = no data stored
+- Memory Eeprom = no data stored
+- Memory Eeprom = no data stored
+- Memory Ram = no data stored
+- Memory Ram = no data stored
+- sc Clearerrorhistory = no data stored
+- sc Col = no data stored
+- sc ColKickPumpTime = no data stored
+- sc ColKickTempDelta = no data stored
+- sc CollPump = no data stored
+- sc Currenterror = no data stored
+- sc D1Temp = no data stored
+- sc D2Temp = no data stored
+- sc Date = no data stored
+- sc EDFunction = no data stored
+- sc EDFunction = no data stored
+- sc EnableScProtection = no data stored
+- sc EnableScProtection = no data stored
+- sc Errorhistory = no data stored
+- sc FlowRate = no data stored
+- sc FlowRate = no data stored
+- sc FrostProtectionEnabled = no data stored
+- sc FrostProtectionLimit = no data stored
+- sc Hc1PumpKol1PP1Port = no data stored
+- sc Hc2aLegPumpP2Port = no data stored
+- sc Hc2zPort = no data stored
+- sc HydraulicScheme = no data stored
+- sc InitCircuit = no data stored
+- sc Iotest = no data stored
+- sc Ioteststop = no data stored
+- sc IsInBoostMode = no data stored
+- sc KickFunction = no data stored
+- sc KickFunction = no data stored
+- sc LpZpMaPort = no data stored
+- sc MAPreferredStorage = no data stored
+- sc MAPreferredStorage = no data stored
+- sc MaximalTemp2 = no data stored
+- sc MaximalTemp2 = no data stored
+- sc MaximalTemp = no data stored
+- sc MaximalTemp = no data stored
+- sc MultifunctionOutput = no data stored
+- sc OMultifunction = no data stored
+- sc OMultifunction = no data stored
+- sc PumpAntiLockingFlags = no data stored
+- sc QuickVetoStart = no data stored
+- sc ResetSolGain = no data stored
+- sc ResetSolGain = no data stored
+- sc RuntimeCollPump = no data stored
+- sc RuntimeCollPumpSeconds = no data stored
+- sc ScProtectionHysteresis = no data stored
+- sc ScProtectionLimit = no data stored
+- sc ScProtectionLimit = no data stored
+- sc ScProtectionTime = no data stored
+- sc SolCollPumpDcIntegrator = no data stored
+- sc SolCollPumpED = no data stored
+- sc SolGain = no data stored
+- sc SolOperationMode = no data stored
+- sc SP1 = no data stored
+- sc SP2 = no data stored
+- sc SumSolGain = no data stored
+- sc SumSolGainDayBefore = no data stored
+- sc SystemMode = no data stored
+- sc TempDifferenceOff2 = no data stored
+- sc TempDifferenceOff2 = no data stored
+- sc TempDifferenceOff = no data stored
+- sc TempDifferenceOff = no data stored
+- sc TempDifferenceOffTD12 = no data stored
+- sc TempDifferenceOffTD12 = no data stored
+- sc TempDifferenceOn2 = no data stored
+- sc TempDifferenceOn2 = no data stored
+- sc TempDifferenceOn = no data stored
+- sc TempDifferenceOn = no data stored
+- sc TempDifferenceOnTD12 = no data stored
+- sc TempDifferenceOnTD12 = no data stored
+- sc Time = no data stored
+- sc Weekday = no data stored
+- sc YieldLastYear = no data stored
+- sc YieldThisYear = no data stored
+- Scan Id = no data stored
+- scan.08  = Vaillant;HMU00;0522;5103
+- Scan.08 Id = 21;22;29;0010021619;0001;006576;N8
+- scan.15  = Vaillant;CTLV2;0514;1104
+- Scan.15 Id = 21;22;23;0020260913;0953;017572;N2
+- scan.76  = Vaillant;VWZ00;0522;5103
+- Scan.76 Id = 21;22;25;0010023504;1610;005572;N8
+- scan.ec  = Vaillant;SOL00;0514;1104
+- scan.f6  = Vaillant;NETX2;4039;5703
+- Scan.f6 Id = no data stored
+- vwz EnableTestHwcTemp = no data stored
+- vwz EnableTestOutdoorTemp = no data stored
+- vwz EnableTestThreeWayValve = no data stored
+- vwz TestHwcTemp = no data stored
+- vwz TestOutdoorTemp = no data stored
+- vwz TestThreeWayValve = no data stored
+- ''
+before_registers:
+- circuit: Broadcast
+  name: Datetime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Error
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: Broadcast
+  name: HwcStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Id
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: IdAnswer
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: IdQuery
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Load
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Outsidetemp
+  fields:
+  - value
+  values:
+  - '26.898'
+  writable: false
+  has_data: true
+- circuit: Broadcast
+  name: Queryexistence
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Signoflife
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Vdatetime
+  fields:
+  - value
+  values:
+  - 10:26:15;14.08.2026
+  writable: false
+  has_data: true
+- circuit: Broadcast
+  name: Vdatetime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: WaterPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: General
+  name: Valuerange
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Eeprom
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Eeprom
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Ram
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Ram
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Scan
+  name: Id
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Scan.08
+  name: Id
+  fields:
+  - value
+  values:
+  - 21;22;29;0010021619;0001;006576;N8
+  writable: false
+  has_data: true
+- circuit: Scan.15
+  name: Id
+  fields:
+  - value
+  values:
+  - 21;22;23;0020260913;0953;017572;N2
+  writable: false
+  has_data: true
+- circuit: Scan.76
+  name: Id
+  fields:
+  - value
+  values:
+  - 21;22;25;0010023504;1610;005572;N8
+  writable: false
+  has_data: true
+- circuit: Scan.f6
+  name: Id
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: AdaptHeatCurve
+  fields:
+  - value
+  values:
+  - 'yes'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: AdaptHeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: CcTimer_Config
+  fields:
+  - value
+  values:
+  - 00 03 0a 00 00 00 ff ff 00
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: CcTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: CcTimer_Friday0
+  fields:
+  - value
+  values:
+  - 08:30;22:00
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: CcTimer_Friday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: CcTimer_Friday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: CcTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: CcTimer_Monday0
+  fields:
+  - value
+  values:
+  - 08:30;22:00
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: CcTimer_Monday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: CcTimer_Monday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: CcTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: CcTimer_Saturday0
+  fields:
+  - value
+  values:
+  - 08:30;22:00
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: CcTimer_Saturday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: CcTimer_Saturday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: CcTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: CcTimer_Sunday0
+  fields:
+  - value
+  values:
+  - 08:30;22:00
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: CcTimer_Sunday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: CcTimer_Sunday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: CcTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: CcTimer_Thursday0
+  fields:
+  - value
+  values:
+  - 08:30;22:00
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: CcTimer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: CcTimer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: CcTimer_Timeframes
+  fields:
+  - value
+  values:
+  - 1;1;1;1;1;1;1
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: CcTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: CcTimer_Tuesday0
+  fields:
+  - value
+  values:
+  - 08:30;22:00
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: CcTimer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: CcTimer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: CcTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: CcTimer_Wednesday0
+  fields:
+  - value
+  values:
+  - 08:30;22:00
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: CcTimer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: CcTimer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Clearerrorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: ContinuousHeating
+  fields:
+  - value
+  values:
+  - '-26'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: ContinuousHeating
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - -;-;-;-;-
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: CylinderChargeHyst
+  fields:
+  - value
+  values:
+  - '5'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: CylinderChargeHyst
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: CylinderChargeOffset
+  fields:
+  - value
+  values:
+  - '8'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: CylinderChargeOffset
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Date
+  fields:
+  - value
+  values:
+  - 14.08.2026
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Date
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: DisplayedOutsideTemp
+  fields:
+  - value
+  values:
+  - '26.9492'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: FrostOverRideTime
+  fields:
+  - value
+  values:
+  - '4'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: FrostOverRideTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - '17'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc1AutoOffMode
+  fields:
+  - value
+  values:
+  - eco
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc1AutoOffMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1CircuitType
+  fields:
+  - value
+  values:
+  - mixer
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc1CoolingEnabled
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1CoolingFlowTempMin
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1DewPointMonitoring
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1DewPointOffset
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1ExcessTemp
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc1ExcessTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1FlowTemp
+  fields:
+  - value
+  values:
+  - '16.5'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc1HeatCurve
+  fields:
+  - value
+  values:
+  - '0.35'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc1HeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc1MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '45'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc1MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - '17'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc1MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - '20'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc1MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1MixerMovement
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc1PumpStatus
+  fields:
+  - value
+  values:
+  - '2'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc1PumpStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1RoomTempModulation
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - modulating
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc1RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1Status
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc1Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1SummerTempLimit
+  fields:
+  - value
+  values:
+  - '19'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc1SummerTempLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc2AutoOffMode
+  fields:
+  - value
+  values:
+  - eco
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc2AutoOffMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2CircuitType
+  fields:
+  - value
+  values:
+  - inactive
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc2ExcessTemp
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc2ExcessTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2FlowTemp
+  fields:
+  - value
+  values:
+  - (empty for 3115b52406020002010800 / 0800020800ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2HeatCurve
+  fields:
+  - value
+  values:
+  - '0.1'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc2HeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc2MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '55'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc2MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - '20'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc2MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - '15'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc2MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2MixerMovement
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc2PumpStatus
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc2PumpStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'off'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc2RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2Status
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc2Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2SummerTempLimit
+  fields:
+  - value
+  values:
+  - '21'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc2SummerTempLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc3ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc3AutoOffMode
+  fields:
+  - value
+  values:
+  - eco
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc3AutoOffMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc3CircuitType
+  fields:
+  - value
+  values:
+  - inactive
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc3ExcessTemp
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc3ExcessTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc3FlowTemp
+  fields:
+  - value
+  values:
+  - (empty for 3115b52406020002020800 / 0800020800ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc3HeatCurve
+  fields:
+  - value
+  values:
+  - '0.6'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc3HeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc3HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc3MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '55'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc3MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc3MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - '20'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc3MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc3MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - '15'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc3MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc3MixerMovement
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc3PumpStatus
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc3PumpStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc3RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'off'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc3RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc3Status
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc3Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc3SummerTempLimit
+  fields:
+  - value
+  values:
+  - '21'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc3SummerTempLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HcStorageTempBottom
+  fields:
+  - value
+  values:
+  - (empty for f115b5240602000000a000 / 080000a000ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HcStorageTempTop
+  fields:
+  - value
+  values:
+  - (empty for f115b52406020000009f00 / 0800009f00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcBankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcBankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcBankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcBankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcFlowTemp
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: HwcHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 01.01.2015
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: HwcHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 01.01.2015
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: HwcHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcLockTime
+  fields:
+  - value
+  values:
+  - '30'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: HwcLockTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcMaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '80'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: HwcMaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcOpMode
+  fields:
+  - value
+  values:
+  - day
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: HwcOpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcParallelLoading
+  fields:
+  - value
+  values:
+  - 'off'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: HwcParallelLoading
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcSFMode
+  fields:
+  - value
+  values:
+  - auto
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: HwcSFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcSfMode
+  fields:
+  - value
+  values:
+  - auto
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcStorageTemp
+  fields:
+  - value
+  values:
+  - '40.5'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: HwcStorageTempBottom
+  fields:
+  - value
+  values:
+  - (empty for f115b52406020000009e00 / 0800009e00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcStorageTempTop
+  fields:
+  - value
+  values:
+  - (empty for f115b52406020000009d00 / 0800009d00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTempDesired
+  fields:
+  - value
+  values:
+  - '35'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: HwcTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTimer_Config
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTimer_Friday0
+  fields:
+  - value
+  values:
+  - 13:30;15:00;35.0
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: HwcTimer_Friday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTimer_Friday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTimer_Monday0
+  fields:
+  - value
+  values:
+  - 13:30;15:00;35.0
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: HwcTimer_Monday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTimer_Monday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTimer_Saturday0
+  fields:
+  - value
+  values:
+  - 13:30;15:00;35.0
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: HwcTimer_Saturday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTimer_Saturday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTimer_Sunday0
+  fields:
+  - value
+  values:
+  - 13:30;15:00;35.0
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: HwcTimer_Sunday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTimer_Sunday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTimer_Thursday0
+  fields:
+  - value
+  values:
+  - 13:30;15:00;35.0
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: HwcTimer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTimer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTimer_Timeframes
+  fields:
+  - value
+  values:
+  - 1;1;1;1;1;1;1
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: HwcTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTimer_Tuesday0
+  fields:
+  - value
+  values:
+  - 13:30;15:00;35.0
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: HwcTimer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTimer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTimer_Wednesday0
+  fields:
+  - value
+  values:
+  - 13:30;15:00;35.0
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: HwcTimer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTimer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HydraulicScheme
+  fields:
+  - value
+  values:
+  - '8'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: HydraulicScheme
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Installer1
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Installer1
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Installer2
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Installer2
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: KeyCodeforConfigMenu
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: KeyCodeforConfigMenu
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: MaintenanceDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: MaintenanceDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: MaintenanceDue
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: MaxCylinderChargeTime
+  fields:
+  - value
+  values:
+  - '120'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: MaxCylinderChargeTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: MaxRoomHumidity
+  fields:
+  - value
+  values:
+  - '70'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: MaxRoomHumidity
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: MultiRelaySetting
+  fields:
+  - value
+  values:
+  - '4'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: MultiRelaySetting
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: OutsideTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: OutsideTempAvg
+  fields:
+  - value
+  values:
+  - '31.3828'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: OutsideTempAvg
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PhoneNumber1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PhoneNumber1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PhoneNumber2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PhoneNumber2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrEnergySum
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020000005c00 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrEnergySum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrEnergySumHc
+  fields:
+  - value
+  values:
+  - '4343'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: PrEnergySumHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrEnergySumHcLastMonth
+  fields:
+  - value
+  values:
+  - '8'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: PrEnergySumHcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrEnergySumHcThisMonth
+  fields:
+  - value
+  values:
+  - '3'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: PrEnergySumHcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrEnergySumHwc
+  fields:
+  - value
+  values:
+  - '4232'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: PrEnergySumHwc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrEnergySumHwcLastMonth
+  fields:
+  - value
+  values:
+  - '77'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: PrEnergySumHwcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrEnergySumHwcThisMonth
+  fields:
+  - value
+  values:
+  - '15'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: PrEnergySumHwcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrFuelSum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrFuelSum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrFuelSumHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrFuelSumHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrFuelSumHcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrFuelSumHcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrFuelSumHcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrFuelSumHcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrFuelSumHwc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrFuelSumHwc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrFuelSumHwcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrFuelSumHwcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrFuelSumHwcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrFuelSumHwcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PumpAdditionalTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PumpAdditionalTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: SolarYieldTotal
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: SolarYieldTotal
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: SystemFlowTemp
+  fields:
+  - value
+  values:
+  - (empty for f115b52406020000004b00 / 0800004b00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Time
+  fields:
+  - value
+  values:
+  - 09:50:46
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Time
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: WaterPressure
+  fields:
+  - value
+  values:
+  - '1.7'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: YieldTotal
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: YieldTotal
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z1ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1CoolingManualTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingOpMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingSetbackTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingTemp
+  fields:
+  - value
+  values:
+  - '20'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z1CoolingTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1CoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1DayTemp
+  fields:
+  - value
+  values:
+  - '20'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z1DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 01.01.2015
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z1HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 01.01.2015
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z1HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1HolidayTemp
+  fields:
+  - value
+  values:
+  - '15'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z1HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Name1
+  fields:
+  - value
+  values:
+  - Thuis
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z1Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Name2
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for f115b52406020003001800 / 050303180000)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1NightTemp
+  fields:
+  - value
+  values:
+  - '18'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z1NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1OpMode
+  fields:
+  - value
+  values:
+  - auto
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z1OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1QuickVetoDuration
+  fields:
+  - value
+  values:
+  - '3'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z1QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1QuickVetoEndDate
+  fields:
+  - value
+  values:
+  - 28.07.2026
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z1QuickVetoEndTime
+  fields:
+  - value
+  values:
+  - '11:16:00'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z1QuickVetoTemp
+  fields:
+  - value
+  values:
+  - '20'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z1QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1RoomTemp
+  fields:
+  - value
+  values:
+  - '22.975'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z1RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z1RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1SFMode
+  fields:
+  - value
+  values:
+  - auto
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z1SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Config
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Friday0
+  fields:
+  - value
+  values:
+  - 06:00;22:00;20.0
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z1Timer_Friday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Friday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Monday0
+  fields:
+  - value
+  values:
+  - 06:00;22:00;20.0
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z1Timer_Monday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Monday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Saturday0
+  fields:
+  - value
+  values:
+  - 06:00;22:00;20.0
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z1Timer_Saturday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Saturday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Sunday0
+  fields:
+  - value
+  values:
+  - 06:00;22:00;20.0
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z1Timer_Sunday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Sunday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Thursday0
+  fields:
+  - value
+  values:
+  - 06:00;22:00;20.0
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z1Timer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Timeframes
+  fields:
+  - value
+  values:
+  - 1;1;1;1;1;1;1
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z1Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Tuesday0
+  fields:
+  - value
+  values:
+  - 06:00;22:00;20.0
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z1Timer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Wednesday0
+  fields:
+  - value
+  values:
+  - 06:00;22:00;20.0
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z1Timer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2CoolingTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2CoolingTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2QuickVetoEndDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2QuickVetoEndTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2RoomTemp
+  fields:
+  - value
+  values:
+  - (empty for 3115b52406020003010f00 / 0800030f00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z2RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Config
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Friday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Friday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Friday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Monday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Monday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Monday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Saturday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Saturday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Saturday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Sunday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Sunday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Sunday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Thursday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Timeframes
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Tuesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Wednesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3QuickVetoEndDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3QuickVetoEndTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3RoomTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z3RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Config
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Friday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Friday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Friday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Monday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Monday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Monday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Saturday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Saturday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Saturday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Sunday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Sunday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Sunday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Thursday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Timeframes
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Tuesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Wednesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: z1RoomHumidity
+  fields:
+  - value
+  values:
+  - '46'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: BuildingCircuitFlow
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: BuildingCircuitPumpSpeed
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Clearerrorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: CompressorBlocktime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: CompressorHc
+  fields:
+  - value
+  values:
+  - no data stored (message not available due to condition)
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: CompressorHc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHwc
+  fields:
+  - value
+  values:
+  - no data stored (message not available due to condition)
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: CompressorHwc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHwc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CopCooling
+  fields:
+  - value
+  values:
+  - '7.8'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CopCoolingMonth
+  fields:
+  - value
+  values:
+  - '8.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CopHc
+  fields:
+  - value
+  values:
+  - '5.7'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CopHcMonth
+  fields:
+  - value
+  values:
+  - '1.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CopHwc
+  fields:
+  - value
+  values:
+  - '2.9'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CopHwcMonth
+  fields:
+  - value
+  values:
+  - '3.5'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CurrentCompressorUtil
+  fields:
+  - value
+  values:
+  - '0.00'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CurrentConsumedPower
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CurrentYieldPower
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - -;-;-;-;-
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: DateTime
+  fields:
+  - value
+  values:
+  - nosignal;-:-:-;-.-.-;-
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: EnergyIntegral
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: FlowPressure
+  fields:
+  - value
+  values:
+  - no data stored (message not available due to condition)
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: FlowTemp
+  fields:
+  - value
+  values:
+  - '42.06'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: FlowTemperature
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: HoursCool
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: PowerConsumptionHmu
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: RunDataAirInletTemp
+  fields:
+  - value
+  values:
+  - '27.5728'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataBuildingCPumpPower
+  fields:
+  - value
+  values:
+  - '72.8297'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataCompressorInletTemp
+  fields:
+  - value
+  values:
+  - '28.4709'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataCompressorOutletTemp
+  fields:
+  - value
+  values:
+  - '29.875'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataCompressorSpeed
+  fields:
+  - value
+  values:
+  - '29.9967'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataEEVOutletTemp
+  fields:
+  - value
+  values:
+  - '27.6724'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataEEVPositionAbs
+  fields:
+  - value
+  values:
+  - '179'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataFan1Speed
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataFan2Speed
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataHighPressure
+  fields:
+  - value
+  values:
+  - '15.1236'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataLowPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunDataStatuscode
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStats4PortValveHours
+  fields:
+  - value
+  values:
+  - '354'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStats4PortValveSwitches
+  fields:
+  - value
+  values:
+  - '1525'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsBuildingCPumpStarts
+  fields:
+  - value
+  values:
+  - '2109'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsBuildingPumpHours
+  fields:
+  - value
+  values:
+  - '19812'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsCompressorHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunStatsCompressorHc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHours
+  fields:
+  - value
+  values:
+  - '8171'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsCompressorHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunStatsCompressorHwc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHwc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorStarts
+  fields:
+  - value
+  values:
+  - '14019'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsFan1Hours
+  fields:
+  - value
+  values:
+  - '9257'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsFan1Starts
+  fields:
+  - value
+  values:
+  - '15862'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsFan2Hours
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsFan2Starts
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsHMUHours
+  fields:
+  - value
+  values:
+  - '34298'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsHcHours
+  fields:
+  - value
+  values:
+  - '16913'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsHwcHours
+  fields:
+  - value
+  values:
+  - '1664'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: SetMode
+  fields:
+  - value
+  values:
+  - auto;17.0;-;-;1;1;1;0;0;1
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: SetMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: StatElectricEnergySumCool
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatEnvironmentEnergySumCool
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: Status01
+  fields:
+  - value
+  values:
+  - 16.5;20.0;-;-;-;off
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: Status01.pumpstate
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.temp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.temp_1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.temp_2
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: Status01.temp_3
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: Status01.temp_4
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: Status02
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: Status16
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: StatusCirPump
+  fields:
+  - value
+  values:
+  - 'on'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: SupplyTempWeighted
+  fields:
+  - value
+  values:
+  - '20.00'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: TotalEnergyUsage
+  fields:
+  - value
+  values:
+  - '7667'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldCoolDay
+  fields:
+  - value
+  values:
+  - '14.8'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldCooling
+  fields:
+  - value
+  values:
+  - '115.7'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldCoolingMonth
+  fields:
+  - value
+  values:
+  - '90.6'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldHc
+  fields:
+  - value
+  values:
+  - '21711'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldHcDay
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldHcMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: YieldHwc
+  fields:
+  - value
+  values:
+  - '6523'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldHwcDay
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: YieldHwcMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: Clearerrorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: Col
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: ColKickPumpTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: ColKickTempDelta
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: CollPump
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: D1Temp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: D2Temp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: Date
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: EDFunction
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: EDFunction
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: EnableScProtection
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: EnableScProtection
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: FlowRate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: FlowRate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: FrostProtectionEnabled
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: FrostProtectionLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: Hc1PumpKol1PP1Port
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: Hc2aLegPumpP2Port
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: Hc2zPort
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: HydraulicScheme
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: InitCircuit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: Iotest
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: Ioteststop
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: IsInBoostMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: KickFunction
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: KickFunction
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: LpZpMaPort
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: MAPreferredStorage
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: MAPreferredStorage
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: MaximalTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: MaximalTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: MaximalTemp2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: MaximalTemp2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: MultifunctionOutput
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: OMultifunction
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: OMultifunction
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: PumpAntiLockingFlags
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: QuickVetoStart
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: ResetSolGain
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: ResetSolGain
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: RuntimeCollPump
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: RuntimeCollPumpSeconds
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: SP1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: SP2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: ScProtectionHysteresis
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: ScProtectionLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: ScProtectionLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: ScProtectionTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: SolCollPumpDcIntegrator
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: SolCollPumpED
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: SolGain
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: SolOperationMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: SumSolGain
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: SumSolGainDayBefore
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: SystemMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: TempDifferenceOff
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: TempDifferenceOff
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: TempDifferenceOff2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: TempDifferenceOff2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: TempDifferenceOffTD12
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: TempDifferenceOffTD12
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: TempDifferenceOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: TempDifferenceOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: TempDifferenceOn2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: TempDifferenceOn2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: TempDifferenceOnTD12
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: TempDifferenceOnTD12
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: Time
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: Weekday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: YieldLastYear
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: YieldThisYear
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: BypassPosition
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: ExhaustAirHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: ExhaustAirTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: MaxAirHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: MinAirHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: OutsideAirTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: SupplyAirTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: VentilationLevelDay
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: VentilationLevelNight
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldToday
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldTotal
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldYear
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vwz
+  name: EnableTestHwcTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwz
+  name: EnableTestOutdoorTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwz
+  name: EnableTestThreeWayValve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwz
+  name: TestHwcTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwz
+  name: TestOutdoorTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwz
+  name: TestThreeWayValve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+grab:
+- '[grab] grab continued'
+- 'f108070400 / 0ab5484d55303005225103 = 8: scan.08'
+- 'f108b5090127 / 094e383c3c3c3c3c3c3c = 15: Scan.08 Id'
+- 'f115070400 / 0ab543544c563205141104 = 5: scan.15'
+- 'f115b5090127 / 094e3230303030303030 = 19: Scan.15 Id'
+- 'f176070400 / 0ab556575a303005225103 = 9: scan.76'
+- 'f176b5090127 / 094e383c3c3c3c3c3c3c = 19: Scan.76 Id'
+- '31ec070400 / 0ab5534f4c303005141104 = 1: scan.ec'
+- '31f6070400 / 0ab54e4554583240395703 = 2: scan.f6'
+- '31f6b5090125 / 09323032363039363230 = 1: Scan.f6 Id'
+- '1008b51009000022ffffff070004 / 0101 = 30545: hmu SetMode'
+- '1008b512020064 / 00 = 1032: hmu StatusCirPump'
+- '10feb516080015271014080526 = 5136: Broadcast Vdatetime'
+- '10feb5160301f31a = 5163: Broadcast Outsidetemp'
+- 1008b507010a / 036e7c07 = 86
+- 1008b5110100 / 09080111326809000000 = 5080
+- '1008b5110101 / 09544a0080ffff0000ff = 3: hmu Status01'
+- 1008b5160111 / 09020106100634060a06 = 3
+- 1076b5040100 / 0a0317271014080526001b = 5077
+- 1076b5110101 / 092128001bff510000ff = 30512
+- 1076b5160111 / 09020102100234020a02 = 4
+- 10feb505025c01 = 5170
+- 10feb508020900 = 518
+- 10feb510020601 = 1042
+- '3108b5090124 / 09003231323232393030 = 1: Scan.08 Id'
+- '3115b5090124 / 09003231323232333030 = 1: Scan.15 Id'
+- '3176b5090124 / 09003231323232353030 = 1: Scan.76 Id'
+- '31f6b5090124 / 09003231323330373030 = 1: Scan.f6 Id'
+- 7108b5110107 / 0a002f0081103300000000 = 87669
+- f108b5110100 / 09090111326809000000 = 1055
+- '3108b5040100 / 0a00ffffffffffffff0080 = 1: hmu DateTime'
+- '1008b5110101 / 0921280080ffff0000ff = 36594: hmu Status01'
+- 1008b507020900 / 026b06 = 4625
+- 1008b50702092a / 02b203 = 522
+- 1008b512020464 / 00 = 116
+- 1008b5120204ff / 00 = 920
+- 1008b513020528 / 0101 = 1030
+- 7108b509022802 / 0c020005165f0100484d553031 = 1021
+- f108b503020002 / 0affffffffffffffffffff = 5057
+- f108b503020003 / 0a7200ffffffffffffffff = 2070
+- f108b503020004 / 0affffffffffffffffffff = 5075
+- f108b503020005 / 00 = 5154
+- f108b509022802 / 0c020005165f0100484d553031 = 4
+- f108b511021801 / 00 = 84
+- f108b511021802 / 00 = 85
+- f108b511021803 / 00 = 83
+- f115b503020002 / 0affffffffffffffffffff = 5073
+- f115b531020300 / 00 = 1
+- f176b503020001 / 0affffffffffffffffffff = 5091
+- f176b509022802 / 0c020005165f010056575a3031 = 4
+- f176b511021801 / 00 = 87
+- f176b511021802 / 00 = 85
+- f176b511021803 / 00 = 87
+- 'f108b503020001 / 0affffffffffffffffffff = 5072: hmu Currenterror'
+- 'f115b503020001 / 0affffffffffffffffffff = 5093: ctlv2 Currenterror'
+- '31ecb509030d3f00 / 00 = 76954: sc YieldThisYear'
+- 1076b512030f0001 / 078f0200f00111ff = 28493
+- 1076b512030f0002 / 075b0300770311ff = 1757
+- 1076b512030f0101 / 078b0200090111ff = 239
+- 7108b51a03040032 / 0e0007c0cfc07b3c00b01b20000000 = 17
+- 7108b51a03040033 / 0e000000008a000000000000000000 = 22
+- 7108b51a03040034 / 0e00cf2000c0022101001800061800 = 16
+- 7108b51a03040035 / 0e0000000000000100b00100000000 = 22
+- 7108b51a03040036 / 0e0000000000000000000000000000 = 17
+- 7108b51a03040132 / 0e0107c0cfc07b3c00b01b20000000 = 22
+- 7108b51a03040133 / 0e010000008a000000000000000000 = 18
+- 7108b51a03040134 / 0e01cf2000c0022101001800061800 = 23
+- 7108b51a03040135 / 0e0100000000000100b00100000000 = 17
+- 7108b51a03040136 / 0e0100000000000000000000000000 = 25
+- 7108b51a03040232 / 0e0207c0cfc07b3c00b01b20000000 = 17
+- 7108b51a03040233 / 0e020000008a000000000000000000 = 23
+- 7108b51a03040234 / 0e02cf2000c0022101001800061800 = 17
+- 7108b51a03040235 / 0e0200000000000100b00100000000 = 22
+- 7108b51a03040236 / 0e0200000000000000000000000000 = 17
+- 7108b51a03040332 / 0e0307c0cfc07b3c00b01b20000000 = 24
+- 7108b51a03040333 / 0e030000008a000000000000000000 = 15
+- 7108b51a03040334 / 0e03cf2000c0022101001800061800 = 23
+- 7108b51a03040335 / 0e0300000000000100b00100000000 = 18
+- 7108b51a03040336 / 0e0300000000000000000000000000 = 22
+- 7108b51a03040432 / 0e0407c0cfc07b3c00b01b20000000 = 17
+- 7108b51a03040433 / 0e040000008a000000000000000000 = 24
+- 7108b51a03040434 / 0e04cf2000c0022101001800061800 = 17
+- 7108b51a03040435 / 0e0400000000000100b00100000000 = 21
+- 7108b51a03040436 / 0e0400000000000000000000000000 = 18
+- 7108b51a03040532 / 0e0507c0cfc07b3c00b01b20000000 = 23
+- 7108b51a03040533 / 0e050000008a000000000000000000 = 14
+- 7108b51a03040534 / 0e05cf2000c0022101001800061800 = 23
+- 7108b51a03040535 / 0e0500000000000100b00100000000 = 16
+- 7108b51a03040536 / 0e0500000000000000000000000000 = 22
+- 7108b51a03040632 / 0e0607c0cfc07b3c00b01b20000000 = 18
+- 7108b51a03040633 / 0e060000008a000000000000000000 = 24
+- 7108b51a03040634 / 0e06cf2000c0022101001800061800 = 16
+- 7108b51a03040635 / 0e0600000000000100b00100000000 = 25
+- 7108b51a03040636 / 0e0600000000000000000000000000 = 15
+- 7108b51a03040732 / 0e0707c0cfc07b3c00b01b20000000 = 25
+- 7108b51a03040733 / 0e070000008a000000000000000000 = 18
+- 7108b51a03040734 / 0e07cf2000c0022101001800061800 = 22
+- 7108b51a03040735 / 0e0700000000000100b00100000000 = 16
+- 7108b51a03040736 / 0e0700000000000000000000000000 = 24
+- 7108b51a03040832 / 0e0807c0cfc07b3c00b01b20000000 = 16
+- 7108b51a03040833 / 0e080000008a000000000000000000 = 24
+- 7108b51a03040834 / 0e08cf2000c0022101001800061800 = 17
+- 7108b51a03040835 / 0e0800000000000100b00100000000 = 24
+- 7108b51a03040836 / 0e0800000000000000000000000000 = 16
+- 7108b51a03040932 / 0e0907c0cfc07b3c00b01b20000000 = 23
+- 7108b51a03040933 / 0e090000008a000000000000000000 = 16
+- 7108b51a03040934 / 0e09cf2000c0022101001800061800 = 25
+- 7108b51a03040935 / 0e0900000000000100b00100000000 = 18
+- 7108b51a03040936 / 0e0900000000000000000000000000 = 24
+- 7108b51a03040a32 / 0e0a07c0cfc07b3c00b01b20000000 = 18
+- 7108b51a03040a33 / 0e0a0000008a000000000000000000 = 23
+- 7108b51a03040a34 / 0e0acf2000c0022101001800061800 = 17
+- 7108b51a03040a35 / 0e0a00000000000100b00100000000 = 24
+- 7108b51a03040a36 / 0e0a00000000000000000000000000 = 18
+- 7108b51a03040b32 / 0e0b07c0cfc07b3c00b01b20000000 = 21
+- 7108b51a03040b33 / 0e0b0000008a000000000000000000 = 18
+- 7108b51a03040b34 / 0e0bcf2000c0022101001800061800 = 24
+- 7108b51a03040b35 / 0e0b00000000000100b00100000000 = 17
+- 7108b51a03040b36 / 0e0b00000000000000000000000000 = 24
+- 7108b51a03040c32 / 0e0c07c0cfc07b3c00b01b20000000 = 16
+- 7108b51a03040c33 / 0e0c0000008a000000000000000000 = 22
+- 7108b51a03040c34 / 0e0ccf2000c0022101001800061800 = 16
+- 7108b51a03040c35 / 0e0c00000000000100b00100000000 = 23
+- 7108b51a03040c36 / 0e0c00000000000000000000000000 = 16
+- 7108b51a03040d32 / 0e0d07c0cfc07b3c00b01b20000000 = 24
+- 7108b51a03040d33 / 0e0d0000008a000000000000000000 = 16
+- 7108b51a03040d34 / 0e0dcf2000c0022101001800061800 = 24
+- 7108b51a03040d35 / 0e0d00000000000100b00100000000 = 18
+- 7108b51a03040d36 / 0e0d00000000000000000000000000 = 23
+- 7108b51a03040e32 / 0e0e07c0cfc07b3c00b01b20000000 = 16
+- 7108b51a03040e33 / 0e0e0000008a000000000000000000 = 23
+- 7108b51a03040e34 / 0e0ecf2000c0022101001800061800 = 17
+- 7108b51a03040e35 / 0e0e00000000000100b00100000000 = 24
+- 7108b51a03040e36 / 0e0e00000000000000000000000000 = 16
+- 7108b51a03040f32 / 0e0f07c0cfc07b3c00b01b20000000 = 23
+- 7108b51a03040f33 / 0e0f0000008a000000000000000000 = 17
+- 7108b51a03040f34 / 0e0fcf2000c0022101001800061800 = 24
+- 7108b51a03040f35 / 0e0f00000000000100b00100000000 = 17
+- 7108b51a03040f36 / 0e0f00000000000000000000000000 = 23
+- 7108b51a03041032 / 0e1007c0cfc07b3c00b01b20000000 = 18
+- 7108b51a03041033 / 0e100000008a000000000000000000 = 23
+- 7108b51a03041034 / 0e10cf2000c0022101001800061800 = 17
+- 7108b51a03041035 / 0e1000000000000100b00100000000 = 24
+- 7108b51a03041036 / 0e1000000000000000000000000000 = 16
+- 7108b51a03041132 / 0e1107c0cfc07b3c00b01b20000000 = 25
+- 7108b51a03041133 / 0e110000008a000000000000000000 = 16
+- 7108b51a03041134 / 0e11cf2000c0022101001800061800 = 24
+- 7108b51a03041135 / 0e1100000000000100b00100000000 = 17
+- 7108b51a03041136 / 0e1100000000000000000000000000 = 25
+- 7108b51a03041232 / 0e1207c0cfc07b3c00b01b20000000 = 17
+- 7108b51a03041233 / 0e120000008a000000000000000000 = 24
+- 7108b51a03041234 / 0e12cf2000c0022101001800061800 = 18
+- 7108b51a03041235 / 0e1200000000000100b00100000000 = 22
+- 7108b51a03041236 / 0e1200000000000000000000000000 = 17
+- 7108b51a03041332 / 0e1307c0cfc07b3c00b01b20000000 = 23
+- 7108b51a03041333 / 0e130000008a000000000000000000 = 17
+- 7108b51a03041334 / 0e13cf2000c0022101001800061800 = 25
+- 7108b51a03041335 / 0e1300000000000100b00100000000 = 17
+- 7108b51a03041336 / 0e1300000000000000000000000000 = 24
+- 7108b51a03041432 / 0e1407c0cfc07b3c00b01b20000000 = 15
+- 7108b51a03041433 / 0e140000008a000000000000000000 = 24
+- 7108b51a03041434 / 0e14cf2000c0022101001800061800 = 14
+- 7108b51a03041435 / 0e1400000000000100b00100000000 = 21
+- 7108b51a03041436 / 0e1400000000000000000000000000 = 17
+- 7108b51a03041532 / 0e1507c0cfc07b3c00b01b20000000 = 24
+- 7108b51a03041533 / 0e150000008a000000000000000000 = 16
+- 7108b51a03041534 / 0e15cf2000c0022101001800061800 = 24
+- 7108b51a03041535 / 0e1500000000000100b00100000000 = 17
+- 7108b51a03041536 / 0e1500000000000000000000000000 = 24
+- 7108b51a03041632 / 0e1607c0cfc07b3c00b01b20000000 = 17
+- 7108b51a03041633 / 0e160000008a000000000000000000 = 24
+- 7108b51a03041634 / 0e16cf2000c0022101001800061800 = 16
+- 7108b51a03041635 / 0e1600000000000100b00100000000 = 23
+- 7108b51a03041636 / 0e1600000000000000000000000000 = 17
+- 7108b51a03041732 / 0e1707c0cfc07b3c00b01b20000000 = 24
+- 7108b51a03041733 / 0e170000008a000000000000000000 = 15
+- 7108b51a03041734 / 0e17cf2000c0022101001800061800 = 22
+- 7108b51a03041735 / 0e1700000000000100b00100000000 = 14
+- 7108b51a03041736 / 0e1700000000000000000000000000 = 24
+- 7108b51a03041832 / 0e1807c0cfc07b3c00b01b20000000 = 17
+- 7108b51a03041833 / 0e180000008a000000000000000000 = 23
+- 7108b51a03041834 / 0e18cf2000c0022101001800061800 = 17
+- 7108b51a03041835 / 0e1800000000000100b00100000000 = 23
+- 7108b51a03041836 / 0e1800000000000000000000000000 = 16
+- 7108b51a03041932 / 0e1907c0cfc07b3c00b01b20000000 = 24
+- 7108b51a03041933 / 0e190000008a000000000000000000 = 17
+- 7108b51a03041934 / 0e19cf2000c0022101001800061800 = 24
+- 7108b51a03041935 / 0e1900000000000100b00100000000 = 17
+- 7108b51a03041936 / 0e1900000000000000000000000000 = 25
+- 7108b51a03041a32 / 0e1a07c0cfc07b3c00b01b20000000 = 18
+- 7108b51a03041a33 / 0e1a0000008a000000000000000000 = 21
+- 7108b51a03041a34 / 0e1acf2000c0022101001800061800 = 17
+- 7108b51a03041a35 / 0e1a00000000000100b00100000000 = 24
+- 7108b51a03041a36 / 0e1a00000000000000000000000000 = 16
+- 7108b51a03041b32 / 0e1b07c0cfc07b3c00b01b20000000 = 24
+- 7108b51a03041b33 / 0e1b0000008a000000000000000000 = 17
+- 7108b51a03041b34 / 0e1bcf2000c0022101001800061800 = 23
+- 7108b51a03041b35 / 0e1b00000000000100b00100000000 = 17
+- 7108b51a03041b36 / 0e1b00000000000000000000000000 = 23
+- 7108b51a03041c32 / 0e1c07c0cfc07b3c00b01b20000000 = 16
+- 7108b51a03041c33 / 0e1c0000008a000000000000000000 = 24
+- '[grab stop] grab stopped'
+after_registers:
+- circuit: Broadcast
+  name: Datetime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Error
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: Broadcast
+  name: HwcStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Id
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: IdAnswer
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: IdQuery
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Load
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Outsidetemp
+  fields:
+  - value
+  values:
+  - '26.949'
+  writable: false
+  has_data: true
+- circuit: Broadcast
+  name: Queryexistence
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Signoflife
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Vdatetime
+  fields:
+  - value
+  values:
+  - 10:27:15;14.08.2026
+  writable: false
+  has_data: true
+- circuit: Broadcast
+  name: Vdatetime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: WaterPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: General
+  name: Valuerange
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Eeprom
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Eeprom
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Ram
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Ram
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Scan
+  name: Id
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Scan.08
+  name: Id
+  fields:
+  - value
+  values:
+  - 21;22;29;0010021619;0001;006576;N8
+  writable: false
+  has_data: true
+- circuit: Scan.15
+  name: Id
+  fields:
+  - value
+  values:
+  - 21;22;23;0020260913;0953;017572;N2
+  writable: false
+  has_data: true
+- circuit: Scan.76
+  name: Id
+  fields:
+  - value
+  values:
+  - 21;22;25;0010023504;1610;005572;N8
+  writable: false
+  has_data: true
+- circuit: Scan.f6
+  name: Id
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: AdaptHeatCurve
+  fields:
+  - value
+  values:
+  - 'yes'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: AdaptHeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: CcTimer_Config
+  fields:
+  - value
+  values:
+  - 00 03 0a 00 00 00 ff ff 00
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: CcTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: CcTimer_Friday0
+  fields:
+  - value
+  values:
+  - 08:30;22:00
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: CcTimer_Friday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: CcTimer_Friday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: CcTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: CcTimer_Monday0
+  fields:
+  - value
+  values:
+  - 08:30;22:00
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: CcTimer_Monday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: CcTimer_Monday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: CcTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: CcTimer_Saturday0
+  fields:
+  - value
+  values:
+  - 08:30;22:00
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: CcTimer_Saturday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: CcTimer_Saturday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: CcTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: CcTimer_Sunday0
+  fields:
+  - value
+  values:
+  - 08:30;22:00
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: CcTimer_Sunday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: CcTimer_Sunday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: CcTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: CcTimer_Thursday0
+  fields:
+  - value
+  values:
+  - 08:30;22:00
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: CcTimer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: CcTimer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: CcTimer_Timeframes
+  fields:
+  - value
+  values:
+  - 1;1;1;1;1;1;1
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: CcTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: CcTimer_Tuesday0
+  fields:
+  - value
+  values:
+  - 08:30;22:00
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: CcTimer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: CcTimer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: CcTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: CcTimer_Wednesday0
+  fields:
+  - value
+  values:
+  - 08:30;22:00
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: CcTimer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: CcTimer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Clearerrorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: ContinuousHeating
+  fields:
+  - value
+  values:
+  - '-26'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: ContinuousHeating
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - -;-;-;-;-
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: CylinderChargeHyst
+  fields:
+  - value
+  values:
+  - '5'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: CylinderChargeHyst
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: CylinderChargeOffset
+  fields:
+  - value
+  values:
+  - '8'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: CylinderChargeOffset
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Date
+  fields:
+  - value
+  values:
+  - 14.08.2026
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Date
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: DisplayedOutsideTemp
+  fields:
+  - value
+  values:
+  - '26.9492'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: FrostOverRideTime
+  fields:
+  - value
+  values:
+  - '4'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: FrostOverRideTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - '17'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc1AutoOffMode
+  fields:
+  - value
+  values:
+  - eco
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc1AutoOffMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1CircuitType
+  fields:
+  - value
+  values:
+  - mixer
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc1CoolingEnabled
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1CoolingFlowTempMin
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1DewPointMonitoring
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1DewPointOffset
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1ExcessTemp
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc1ExcessTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1FlowTemp
+  fields:
+  - value
+  values:
+  - '16.5'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc1HeatCurve
+  fields:
+  - value
+  values:
+  - '0.35'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc1HeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc1MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '45'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc1MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - '17'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc1MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - '20'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc1MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1MixerMovement
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc1PumpStatus
+  fields:
+  - value
+  values:
+  - '2'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc1PumpStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1RoomTempModulation
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - modulating
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc1RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1Status
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc1Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1SummerTempLimit
+  fields:
+  - value
+  values:
+  - '19'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc1SummerTempLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc2AutoOffMode
+  fields:
+  - value
+  values:
+  - eco
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc2AutoOffMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2CircuitType
+  fields:
+  - value
+  values:
+  - inactive
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc2ExcessTemp
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc2ExcessTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2FlowTemp
+  fields:
+  - value
+  values:
+  - (empty for 3115b52406020002010800 / 0800020800ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2HeatCurve
+  fields:
+  - value
+  values:
+  - '0.1'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc2HeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc2MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '55'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc2MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - '20'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc2MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - '15'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc2MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2MixerMovement
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc2PumpStatus
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc2PumpStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'off'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc2RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2Status
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc2Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2SummerTempLimit
+  fields:
+  - value
+  values:
+  - '21'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc2SummerTempLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc3ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc3AutoOffMode
+  fields:
+  - value
+  values:
+  - eco
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc3AutoOffMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc3CircuitType
+  fields:
+  - value
+  values:
+  - inactive
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc3ExcessTemp
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc3ExcessTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc3FlowTemp
+  fields:
+  - value
+  values:
+  - (empty for 3115b52406020002020800 / 0800020800ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc3HeatCurve
+  fields:
+  - value
+  values:
+  - '0.6'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc3HeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc3HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc3MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '55'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc3MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc3MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - '20'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc3MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc3MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - '15'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc3MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc3MixerMovement
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc3PumpStatus
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc3PumpStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc3RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'off'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc3RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc3Status
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc3Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc3SummerTempLimit
+  fields:
+  - value
+  values:
+  - '21'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc3SummerTempLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HcStorageTempBottom
+  fields:
+  - value
+  values:
+  - (empty for f115b5240602000000a000 / 080000a000ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HcStorageTempTop
+  fields:
+  - value
+  values:
+  - (empty for f115b52406020000009f00 / 0800009f00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcBankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcBankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcBankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcBankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcFlowTemp
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: HwcHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 01.01.2015
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: HwcHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 01.01.2015
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: HwcHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcLockTime
+  fields:
+  - value
+  values:
+  - '30'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: HwcLockTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcMaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '80'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: HwcMaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcOpMode
+  fields:
+  - value
+  values:
+  - day
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: HwcOpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcParallelLoading
+  fields:
+  - value
+  values:
+  - 'off'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: HwcParallelLoading
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcSFMode
+  fields:
+  - value
+  values:
+  - auto
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: HwcSFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcSfMode
+  fields:
+  - value
+  values:
+  - auto
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcStorageTemp
+  fields:
+  - value
+  values:
+  - '40.5'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: HwcStorageTempBottom
+  fields:
+  - value
+  values:
+  - (empty for f115b52406020000009e00 / 0800009e00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcStorageTempTop
+  fields:
+  - value
+  values:
+  - (empty for f115b52406020000009d00 / 0800009d00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTempDesired
+  fields:
+  - value
+  values:
+  - '35'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: HwcTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTimer_Config
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTimer_Friday0
+  fields:
+  - value
+  values:
+  - 13:30;15:00;35.0
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: HwcTimer_Friday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTimer_Friday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTimer_Monday0
+  fields:
+  - value
+  values:
+  - 13:30;15:00;35.0
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: HwcTimer_Monday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTimer_Monday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTimer_Saturday0
+  fields:
+  - value
+  values:
+  - 13:30;15:00;35.0
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: HwcTimer_Saturday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTimer_Saturday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTimer_Sunday0
+  fields:
+  - value
+  values:
+  - 13:30;15:00;35.0
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: HwcTimer_Sunday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTimer_Sunday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTimer_Thursday0
+  fields:
+  - value
+  values:
+  - 13:30;15:00;35.0
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: HwcTimer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTimer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTimer_Timeframes
+  fields:
+  - value
+  values:
+  - 1;1;1;1;1;1;1
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: HwcTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTimer_Tuesday0
+  fields:
+  - value
+  values:
+  - 13:30;15:00;35.0
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: HwcTimer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTimer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTimer_Wednesday0
+  fields:
+  - value
+  values:
+  - 13:30;15:00;35.0
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: HwcTimer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTimer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HydraulicScheme
+  fields:
+  - value
+  values:
+  - '8'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: HydraulicScheme
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Installer1
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Installer1
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Installer2
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Installer2
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: KeyCodeforConfigMenu
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: KeyCodeforConfigMenu
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: MaintenanceDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: MaintenanceDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: MaintenanceDue
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: MaxCylinderChargeTime
+  fields:
+  - value
+  values:
+  - '120'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: MaxCylinderChargeTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: MaxRoomHumidity
+  fields:
+  - value
+  values:
+  - '70'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: MaxRoomHumidity
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: MultiRelaySetting
+  fields:
+  - value
+  values:
+  - '4'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: MultiRelaySetting
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: OutsideTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: OutsideTempAvg
+  fields:
+  - value
+  values:
+  - '31.3828'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: OutsideTempAvg
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PhoneNumber1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PhoneNumber1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PhoneNumber2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PhoneNumber2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrEnergySum
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020000005c00 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrEnergySum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrEnergySumHc
+  fields:
+  - value
+  values:
+  - '4343'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: PrEnergySumHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrEnergySumHcLastMonth
+  fields:
+  - value
+  values:
+  - '8'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: PrEnergySumHcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrEnergySumHcThisMonth
+  fields:
+  - value
+  values:
+  - '3'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: PrEnergySumHcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrEnergySumHwc
+  fields:
+  - value
+  values:
+  - '4232'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: PrEnergySumHwc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrEnergySumHwcLastMonth
+  fields:
+  - value
+  values:
+  - '77'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: PrEnergySumHwcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrEnergySumHwcThisMonth
+  fields:
+  - value
+  values:
+  - '15'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: PrEnergySumHwcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrFuelSum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrFuelSum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrFuelSumHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrFuelSumHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrFuelSumHcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrFuelSumHcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrFuelSumHcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrFuelSumHcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrFuelSumHwc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrFuelSumHwc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrFuelSumHwcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrFuelSumHwcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrFuelSumHwcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrFuelSumHwcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PumpAdditionalTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PumpAdditionalTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: SolarYieldTotal
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: SolarYieldTotal
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: SystemFlowTemp
+  fields:
+  - value
+  values:
+  - (empty for f115b52406020000004b00 / 0800004b00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Time
+  fields:
+  - value
+  values:
+  - 09:50:46
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Time
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: WaterPressure
+  fields:
+  - value
+  values:
+  - '1.7'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: YieldTotal
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: YieldTotal
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z1ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1CoolingManualTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingOpMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingSetbackTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingTemp
+  fields:
+  - value
+  values:
+  - '20'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z1CoolingTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1CoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1DayTemp
+  fields:
+  - value
+  values:
+  - '20'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z1DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 01.01.2015
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z1HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 01.01.2015
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z1HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1HolidayTemp
+  fields:
+  - value
+  values:
+  - '15'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z1HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Name1
+  fields:
+  - value
+  values:
+  - Thuis
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z1Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Name2
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for f115b52406020003001800 / 050303180000)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1NightTemp
+  fields:
+  - value
+  values:
+  - '18'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z1NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1OpMode
+  fields:
+  - value
+  values:
+  - auto
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z1OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1QuickVetoDuration
+  fields:
+  - value
+  values:
+  - '3'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z1QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1QuickVetoEndDate
+  fields:
+  - value
+  values:
+  - 28.07.2026
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z1QuickVetoEndTime
+  fields:
+  - value
+  values:
+  - '11:16:00'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z1QuickVetoTemp
+  fields:
+  - value
+  values:
+  - '20'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z1QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1RoomTemp
+  fields:
+  - value
+  values:
+  - '22.975'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z1RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z1RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1SFMode
+  fields:
+  - value
+  values:
+  - auto
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z1SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Config
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Friday0
+  fields:
+  - value
+  values:
+  - 06:00;22:00;20.0
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z1Timer_Friday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Friday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Monday0
+  fields:
+  - value
+  values:
+  - 06:00;22:00;20.0
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z1Timer_Monday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Monday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Saturday0
+  fields:
+  - value
+  values:
+  - 06:00;22:00;20.0
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z1Timer_Saturday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Saturday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Sunday0
+  fields:
+  - value
+  values:
+  - 06:00;22:00;20.0
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z1Timer_Sunday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Sunday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Thursday0
+  fields:
+  - value
+  values:
+  - 06:00;22:00;20.0
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z1Timer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Timeframes
+  fields:
+  - value
+  values:
+  - 1;1;1;1;1;1;1
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z1Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Tuesday0
+  fields:
+  - value
+  values:
+  - 06:00;22:00;20.0
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z1Timer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Wednesday0
+  fields:
+  - value
+  values:
+  - 06:00;22:00;20.0
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z1Timer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2CoolingTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2CoolingTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2QuickVetoEndDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2QuickVetoEndTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2RoomTemp
+  fields:
+  - value
+  values:
+  - (empty for 3115b52406020003010f00 / 0800030f00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z2RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Config
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Friday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Friday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Friday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Monday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Monday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Monday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Saturday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Saturday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Saturday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Sunday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Sunday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Sunday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Thursday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Timeframes
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Tuesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Wednesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3QuickVetoEndDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3QuickVetoEndTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3RoomTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z3RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Config
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Friday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Friday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Friday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Monday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Monday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Monday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Saturday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Saturday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Saturday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Sunday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Sunday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Sunday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Thursday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Timeframes
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Tuesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Wednesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: z1RoomHumidity
+  fields:
+  - value
+  values:
+  - '46'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: BuildingCircuitFlow
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: BuildingCircuitPumpSpeed
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Clearerrorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: CompressorBlocktime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: CompressorHc
+  fields:
+  - value
+  values:
+  - no data stored (message not available due to condition)
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: CompressorHc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHwc
+  fields:
+  - value
+  values:
+  - no data stored (message not available due to condition)
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: CompressorHwc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHwc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CopCooling
+  fields:
+  - value
+  values:
+  - '7.8'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CopCoolingMonth
+  fields:
+  - value
+  values:
+  - '8.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CopHc
+  fields:
+  - value
+  values:
+  - '5.7'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CopHcMonth
+  fields:
+  - value
+  values:
+  - '1.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CopHwc
+  fields:
+  - value
+  values:
+  - '2.9'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CopHwcMonth
+  fields:
+  - value
+  values:
+  - '3.5'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CurrentCompressorUtil
+  fields:
+  - value
+  values:
+  - '0.00'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CurrentConsumedPower
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CurrentYieldPower
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - -;-;-;-;-
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: DateTime
+  fields:
+  - value
+  values:
+  - nosignal;-:-:-;-.-.-;-
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: EnergyIntegral
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: FlowPressure
+  fields:
+  - value
+  values:
+  - no data stored (message not available due to condition)
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: FlowTemp
+  fields:
+  - value
+  values:
+  - '42.06'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: FlowTemperature
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: HoursCool
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: PowerConsumptionHmu
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: RunDataAirInletTemp
+  fields:
+  - value
+  values:
+  - '27.5728'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataBuildingCPumpPower
+  fields:
+  - value
+  values:
+  - '72.8297'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataCompressorInletTemp
+  fields:
+  - value
+  values:
+  - '28.4709'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataCompressorOutletTemp
+  fields:
+  - value
+  values:
+  - '29.875'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataCompressorSpeed
+  fields:
+  - value
+  values:
+  - '29.9967'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataEEVOutletTemp
+  fields:
+  - value
+  values:
+  - '27.6724'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataEEVPositionAbs
+  fields:
+  - value
+  values:
+  - '179'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataFan1Speed
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataFan2Speed
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataHighPressure
+  fields:
+  - value
+  values:
+  - '15.1236'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataLowPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunDataStatuscode
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStats4PortValveHours
+  fields:
+  - value
+  values:
+  - '354'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStats4PortValveSwitches
+  fields:
+  - value
+  values:
+  - '1525'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsBuildingCPumpStarts
+  fields:
+  - value
+  values:
+  - '2109'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsBuildingPumpHours
+  fields:
+  - value
+  values:
+  - '19812'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsCompressorHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunStatsCompressorHc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHours
+  fields:
+  - value
+  values:
+  - '8171'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsCompressorHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunStatsCompressorHwc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHwc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorStarts
+  fields:
+  - value
+  values:
+  - '14019'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsFan1Hours
+  fields:
+  - value
+  values:
+  - '9257'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsFan1Starts
+  fields:
+  - value
+  values:
+  - '15862'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsFan2Hours
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsFan2Starts
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsHMUHours
+  fields:
+  - value
+  values:
+  - '34298'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsHcHours
+  fields:
+  - value
+  values:
+  - '16913'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsHwcHours
+  fields:
+  - value
+  values:
+  - '1664'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: SetMode
+  fields:
+  - value
+  values:
+  - auto;17.0;-;-;1;1;1;0;0;1
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: SetMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: StatElectricEnergySumCool
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatEnvironmentEnergySumCool
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: Status01
+  fields:
+  - value
+  values:
+  - 16.0;20.0;-;-;-;off
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: Status01.pumpstate
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.temp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.temp_1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.temp_2
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: Status01.temp_3
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: Status01.temp_4
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: Status02
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: Status16
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: StatusCirPump
+  fields:
+  - value
+  values:
+  - 'on'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: SupplyTempWeighted
+  fields:
+  - value
+  values:
+  - '20.00'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: TotalEnergyUsage
+  fields:
+  - value
+  values:
+  - '7667'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldCoolDay
+  fields:
+  - value
+  values:
+  - '14.8'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldCooling
+  fields:
+  - value
+  values:
+  - '115.7'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldCoolingMonth
+  fields:
+  - value
+  values:
+  - '90.6'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldHc
+  fields:
+  - value
+  values:
+  - '21711'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldHcDay
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldHcMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: YieldHwc
+  fields:
+  - value
+  values:
+  - '6523'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldHwcDay
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: YieldHwcMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: Clearerrorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: Col
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: ColKickPumpTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: ColKickTempDelta
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: CollPump
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: D1Temp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: D2Temp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: Date
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: EDFunction
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: EDFunction
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: EnableScProtection
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: EnableScProtection
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: FlowRate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: FlowRate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: FrostProtectionEnabled
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: FrostProtectionLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: Hc1PumpKol1PP1Port
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: Hc2aLegPumpP2Port
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: Hc2zPort
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: HydraulicScheme
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: InitCircuit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: Iotest
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: Ioteststop
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: IsInBoostMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: KickFunction
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: KickFunction
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: LpZpMaPort
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: MAPreferredStorage
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: MAPreferredStorage
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: MaximalTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: MaximalTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: MaximalTemp2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: MaximalTemp2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: MultifunctionOutput
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: OMultifunction
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: OMultifunction
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: PumpAntiLockingFlags
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: QuickVetoStart
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: ResetSolGain
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: ResetSolGain
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: RuntimeCollPump
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: RuntimeCollPumpSeconds
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: SP1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: SP2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: ScProtectionHysteresis
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: ScProtectionLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: ScProtectionLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: ScProtectionTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: SolCollPumpDcIntegrator
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: SolCollPumpED
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: SolGain
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: SolOperationMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: SumSolGain
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: SumSolGainDayBefore
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: SystemMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: TempDifferenceOff
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: TempDifferenceOff
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: TempDifferenceOff2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: TempDifferenceOff2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: TempDifferenceOffTD12
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: TempDifferenceOffTD12
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: TempDifferenceOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: TempDifferenceOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: TempDifferenceOn2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: TempDifferenceOn2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: TempDifferenceOnTD12
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: TempDifferenceOnTD12
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: Time
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: Weekday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: YieldLastYear
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: YieldThisYear
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: BypassPosition
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: ExhaustAirHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: ExhaustAirTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: MaxAirHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: MinAirHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: OutsideAirTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: SupplyAirTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: VentilationLevelDay
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: VentilationLevelNight
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldToday
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldTotal
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldYear
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vwz
+  name: EnableTestHwcTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwz
+  name: EnableTestOutdoorTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwz
+  name: EnableTestThreeWayValve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwz
+  name: TestHwcTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwz
+  name: TestOutdoorTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwz
+  name: TestThreeWayValve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+raw_find_lines_after:
+- Broadcast Datetime = no data stored
+- Broadcast Error = no data stored
+- Broadcast HwcStatus = no data stored
+- Broadcast Id = no data stored
+- Broadcast IdAnswer = no data stored
+- Broadcast IdQuery = no data stored
+- Broadcast Load = no data stored
+- Broadcast Outsidetemp = 26.949
+- Broadcast Queryexistence = no data stored
+- Broadcast Signoflife = no data stored
+- Broadcast Vdatetime = 10:27:15;14.08.2026
+- Broadcast Vdatetime = no data stored
+- ctlv2 AdaptHeatCurve = yes
+- ctlv2 AdaptHeatCurve = no data stored
+- ctlv2 CcTimer_Config = 00 03 0a 00 00 00 ff ff 00
+- ctlv2 CcTimer_Friday0 = 08:30;22:00
+- ctlv2 CcTimer_Friday1 = no data stored
+- ctlv2 CcTimer_Friday2 = no data stored
+- ctlv2 CcTimer_Friday = no data stored
+- ctlv2 CcTimer_Monday0 = 08:30;22:00
+- ctlv2 CcTimer_Monday1 = no data stored
+- ctlv2 CcTimer_Monday2 = no data stored
+- ctlv2 CcTimer_Monday = no data stored
+- ctlv2 CcTimer_Saturday0 = 08:30;22:00
+- ctlv2 CcTimer_Saturday1 = no data stored
+- ctlv2 CcTimer_Saturday2 = no data stored
+- ctlv2 CcTimer_Saturday = no data stored
+- ctlv2 CcTimer_Sunday0 = 08:30;22:00
+- ctlv2 CcTimer_Sunday1 = no data stored
+- ctlv2 CcTimer_Sunday2 = no data stored
+- ctlv2 CcTimer_Sunday = no data stored
+- ctlv2 CcTimer_Thursday0 = 08:30;22:00
+- ctlv2 CcTimer_Thursday1 = no data stored
+- ctlv2 CcTimer_Thursday2 = no data stored
+- ctlv2 CcTimer_Thursday = no data stored
+- ctlv2 CcTimer_Timeframes = 1;1;1;1;1;1;1
+- ctlv2 CcTimer_Tuesday0 = 08:30;22:00
+- ctlv2 CcTimer_Tuesday1 = no data stored
+- ctlv2 CcTimer_Tuesday2 = no data stored
+- ctlv2 CcTimer_Tuesday = no data stored
+- ctlv2 CcTimer_Wednesday0 = 08:30;22:00
+- ctlv2 CcTimer_Wednesday1 = no data stored
+- ctlv2 CcTimer_Wednesday2 = no data stored
+- ctlv2 CcTimer_Wednesday = no data stored
+- ctlv2 Clearerrorhistory = no data stored
+- ctlv2 ContinuousHeating = -26
+- ctlv2 ContinuousHeating = no data stored
+- ctlv2 Currenterror = -;-;-;-;-
+- ctlv2 CylinderChargeHyst = 5
+- ctlv2 CylinderChargeHyst = no data stored
+- ctlv2 CylinderChargeOffset = 8
+- ctlv2 CylinderChargeOffset = no data stored
+- ctlv2 Date = 14.08.2026
+- ctlv2 Date = no data stored
+- ctlv2 DisplayedOutsideTemp = 26.9492
+- ctlv2 Errorhistory = no data stored
+- ctlv2 FrostOverRideTime = 4
+- ctlv2 FrostOverRideTime = no data stored
+- ctlv2 Hc1ActualFlowTempDesired = 17
+- ctlv2 Hc1AutoOffMode = eco
+- ctlv2 Hc1AutoOffMode = no data stored
+- ctlv2 Hc1CircuitType = mixer
+- ctlv2 Hc1ExcessTemp = 0.0
+- ctlv2 Hc1ExcessTemp = no data stored
+- ctlv2 Hc1FlowTemp = 16.5
+- ctlv2 Hc1HeatCurve = 0.35
+- ctlv2 Hc1HeatCurve = no data stored
+- ctlv2 Hc1HeatCurveAdaption = 0.0
+- ctlv2 Hc1MaxFlowTempDesired = 45
+- ctlv2 Hc1MaxFlowTempDesired = no data stored
+- ctlv2 Hc1MinCoolingTempDesired = 17
+- ctlv2 Hc1MinCoolingTempDesired = no data stored
+- ctlv2 Hc1MinFlowTempDesired = 20
+- ctlv2 Hc1MinFlowTempDesired = no data stored
+- ctlv2 Hc1MixerMovement = 0.0
+- ctlv2 Hc1PumpStatus = 2
+- ctlv2 Hc1PumpStatus = no data stored
+- ctlv2 Hc1RoomTempSwitchOn = modulating
+- ctlv2 Hc1RoomTempSwitchOn = no data stored
+- ctlv2 Hc1Status = 0
+- ctlv2 Hc1Status = no data stored
+- ctlv2 Hc1SummerTempLimit = 19
+- ctlv2 Hc1SummerTempLimit = no data stored
+- ctlv2 Hc2ActualFlowTempDesired = 0.0
+- ctlv2 Hc2AutoOffMode = eco
+- ctlv2 Hc2AutoOffMode = no data stored
+- ctlv2 Hc2CircuitType = inactive
+- ctlv2 Hc2ExcessTemp = 0.0
+- ctlv2 Hc2ExcessTemp = no data stored
+- ctlv2 Hc2FlowTemp =  (empty for 3115b52406020002010800 / 0800020800ffffff7f)
+- ctlv2 Hc2HeatCurve = 0.1
+- ctlv2 Hc2HeatCurve = no data stored
+- ctlv2 Hc2HeatCurveAdaption = 0.0
+- ctlv2 Hc2MaxFlowTempDesired = 55
+- ctlv2 Hc2MaxFlowTempDesired = no data stored
+- ctlv2 Hc2MinCoolingTempDesired = 20
+- ctlv2 Hc2MinCoolingTempDesired = no data stored
+- ctlv2 Hc2MinFlowTempDesired = 15
+- ctlv2 Hc2MinFlowTempDesired = no data stored
+- ctlv2 Hc2MixerMovement = 0.0
+- ctlv2 Hc2PumpStatus = 0
+- ctlv2 Hc2PumpStatus = no data stored
+- ctlv2 Hc2RoomTempSwitchOn = off
+- ctlv2 Hc2RoomTempSwitchOn = no data stored
+- ctlv2 Hc2Status = 0
+- ctlv2 Hc2Status = no data stored
+- ctlv2 Hc2SummerTempLimit = 21
+- ctlv2 Hc2SummerTempLimit = no data stored
+- ctlv2 Hc3ActualFlowTempDesired = 0.0
+- ctlv2 Hc3AutoOffMode = eco
+- ctlv2 Hc3AutoOffMode = no data stored
+- ctlv2 Hc3CircuitType = inactive
+- ctlv2 Hc3ExcessTemp = 0.0
+- ctlv2 Hc3ExcessTemp = no data stored
+- ctlv2 Hc3FlowTemp =  (empty for 3115b52406020002020800 / 0800020800ffffff7f)
+- ctlv2 Hc3HeatCurve = 0.6
+- ctlv2 Hc3HeatCurve = no data stored
+- ctlv2 Hc3HeatCurveAdaption = 0.0
+- ctlv2 Hc3MaxFlowTempDesired = 55
+- ctlv2 Hc3MaxFlowTempDesired = no data stored
+- ctlv2 Hc3MinCoolingTempDesired = 20
+- ctlv2 Hc3MinCoolingTempDesired = no data stored
+- ctlv2 Hc3MinFlowTempDesired = 15
+- ctlv2 Hc3MinFlowTempDesired = no data stored
+- ctlv2 Hc3MixerMovement = 0.0
+- ctlv2 Hc3PumpStatus = 0
+- ctlv2 Hc3PumpStatus = no data stored
+- ctlv2 Hc3RoomTempSwitchOn = off
+- ctlv2 Hc3RoomTempSwitchOn = no data stored
+- ctlv2 Hc3Status = 0
+- ctlv2 Hc3Status = no data stored
+- ctlv2 Hc3SummerTempLimit = 21
+- ctlv2 Hc3SummerTempLimit = no data stored
+- ctlv2 HcStorageTempBottom =  (empty for f115b5240602000000a000 / 080000a000ffffff7f)
+- ctlv2 HcStorageTempTop =  (empty for f115b52406020000009f00 / 0800009f00ffffff7f)
+- ctlv2 HwcBankHolidayEndPeriod = no data stored
+- ctlv2 HwcBankHolidayEndPeriod = no data stored
+- ctlv2 HwcBankHolidayStartPeriod = no data stored
+- ctlv2 HwcBankHolidayStartPeriod = no data stored
+- ctlv2 HwcFlowTemp = 0.0
+- ctlv2 HwcHolidayEndPeriod = 01.01.2015
+- ctlv2 HwcHolidayEndPeriod = no data stored
+- ctlv2 HwcHolidayStartPeriod = 01.01.2015
+- ctlv2 HwcHolidayStartPeriod = no data stored
+- ctlv2 HwcLockTime = 30
+- ctlv2 HwcLockTime = no data stored
+- ctlv2 HwcMaxFlowTempDesired = 80
+- ctlv2 HwcMaxFlowTempDesired = no data stored
+- ctlv2 HwcOpMode = day
+- ctlv2 HwcOpMode = no data stored
+- ctlv2 HwcParallelLoading = off
+- ctlv2 HwcParallelLoading = no data stored
+- ctlv2 HwcSFMode = auto
+- ctlv2 HwcSFMode = no data stored
+- ctlv2 HwcStorageTemp = 40.5
+- ctlv2 HwcStorageTempBottom =  (empty for f115b52406020000009e00 / 0800009e00ffffff7f)
+- ctlv2 HwcStorageTempTop =  (empty for f115b52406020000009d00 / 0800009d00ffffff7f)
+- ctlv2 HwcTempDesired = 35
+- ctlv2 HwcTempDesired = no data stored
+- ctlv2 HwcTimer_Config = no data stored
+- ctlv2 HwcTimer_Friday0 = 13:30;15:00;35.0
+- ctlv2 HwcTimer_Friday1 = no data stored
+- ctlv2 HwcTimer_Friday2 = no data stored
+- ctlv2 HwcTimer_Friday = no data stored
+- ctlv2 HwcTimer_Monday0 = 13:30;15:00;35.0
+- ctlv2 HwcTimer_Monday1 = no data stored
+- ctlv2 HwcTimer_Monday2 = no data stored
+- ctlv2 HwcTimer_Monday = no data stored
+- ctlv2 HwcTimer_Saturday0 = 13:30;15:00;35.0
+- ctlv2 HwcTimer_Saturday1 = no data stored
+- ctlv2 HwcTimer_Saturday2 = no data stored
+- ctlv2 HwcTimer_Saturday = no data stored
+- ctlv2 HwcTimer_Sunday0 = 13:30;15:00;35.0
+- ctlv2 HwcTimer_Sunday1 = no data stored
+- ctlv2 HwcTimer_Sunday2 = no data stored
+- ctlv2 HwcTimer_Sunday = no data stored
+- ctlv2 HwcTimer_Thursday0 = 13:30;15:00;35.0
+- ctlv2 HwcTimer_Thursday1 = no data stored
+- ctlv2 HwcTimer_Thursday2 = no data stored
+- ctlv2 HwcTimer_Thursday = no data stored
+- ctlv2 HwcTimer_Timeframes = 1;1;1;1;1;1;1
+- ctlv2 HwcTimer_Tuesday0 = 13:30;15:00;35.0
+- ctlv2 HwcTimer_Tuesday1 = no data stored
+- ctlv2 HwcTimer_Tuesday2 = no data stored
+- ctlv2 HwcTimer_Tuesday = no data stored
+- ctlv2 HwcTimer_Wednesday0 = 13:30;15:00;35.0
+- ctlv2 HwcTimer_Wednesday1 = no data stored
+- ctlv2 HwcTimer_Wednesday2 = no data stored
+- ctlv2 HwcTimer_Wednesday = no data stored
+- ctlv2 HydraulicScheme = 8
+- ctlv2 HydraulicScheme = no data stored
+- ctlv2 Installer1 = no data stored
+- ctlv2 Installer1 = no data stored
+- ctlv2 Installer2 = no data stored
+- ctlv2 Installer2 = no data stored
+- ctlv2 KeyCodeforConfigMenu = no data stored
+- ctlv2 KeyCodeforConfigMenu = no data stored
+- ctlv2 MaintenanceDate = no data stored
+- ctlv2 MaintenanceDate = no data stored
+- ctlv2 MaintenanceDue = no data stored
+- ctlv2 MaxCylinderChargeTime = 120
+- ctlv2 MaxCylinderChargeTime = no data stored
+- ctlv2 MaxRoomHumidity = 70
+- ctlv2 MaxRoomHumidity = no data stored
+- ctlv2 MultiRelaySetting = 4
+- ctlv2 MultiRelaySetting = no data stored
+- ctlv2 OutsideTempAvg = 31.3828
+- ctlv2 OutsideTempAvg = no data stored
+- ctlv2 PhoneNumber1 = no data stored
+- ctlv2 PhoneNumber1 = no data stored
+- ctlv2 PhoneNumber2 = no data stored
+- ctlv2 PhoneNumber2 = no data stored
+- 'ctlv2 PrEnergySum =  (ERR: invalid position for 3115b52406020000005c00 / 00)'
+- ctlv2 PrEnergySum = no data stored
+- ctlv2 PrEnergySumHc = 4343
+- ctlv2 PrEnergySumHc = no data stored
+- ctlv2 PrEnergySumHcLastMonth = 8
+- ctlv2 PrEnergySumHcLastMonth = no data stored
+- ctlv2 PrEnergySumHcThisMonth = 3
+- ctlv2 PrEnergySumHcThisMonth = no data stored
+- ctlv2 PrEnergySumHwc = 4232
+- ctlv2 PrEnergySumHwc = no data stored
+- ctlv2 PrEnergySumHwcLastMonth = 77
+- ctlv2 PrEnergySumHwcLastMonth = no data stored
+- ctlv2 PrEnergySumHwcThisMonth = 15
+- ctlv2 PrEnergySumHwcThisMonth = no data stored
+- ctlv2 PrFuelSum = no data stored
+- ctlv2 PrFuelSum = no data stored
+- ctlv2 PrFuelSumHc = no data stored
+- ctlv2 PrFuelSumHc = no data stored
+- ctlv2 PrFuelSumHcLastMonth = no data stored
+- ctlv2 PrFuelSumHcLastMonth = no data stored
+- ctlv2 PrFuelSumHcThisMonth = no data stored
+- ctlv2 PrFuelSumHcThisMonth = no data stored
+- ctlv2 PrFuelSumHwc = no data stored
+- ctlv2 PrFuelSumHwc = no data stored
+- ctlv2 PrFuelSumHwcLastMonth = no data stored
+- ctlv2 PrFuelSumHwcLastMonth = no data stored
+- ctlv2 PrFuelSumHwcThisMonth = no data stored
+- ctlv2 PrFuelSumHwcThisMonth = no data stored
+- ctlv2 PumpAdditionalTime = no data stored
+- ctlv2 PumpAdditionalTime = no data stored
+- ctlv2 SolarYieldTotal = no data stored
+- ctlv2 SolarYieldTotal = no data stored
+- ctlv2 SystemFlowTemp =  (empty for f115b52406020000004b00 / 0800004b00ffffff7f)
+- ctlv2 Time = 09:50:46
+- ctlv2 Time = no data stored
+- ctlv2 WaterPressure = 1.7
+- ctlv2 YieldTotal = no data stored
+- ctlv2 YieldTotal = no data stored
+- ctlv2 Z1ActualRoomTempDesired = 0.0
+- ctlv2 Z1ActualRoomTempDesired = no data stored
+- ctlv2 Z1BankHolidayEndPeriod = no data stored
+- ctlv2 Z1BankHolidayEndPeriod = no data stored
+- ctlv2 Z1BankHolidayStartPeriod = no data stored
+- ctlv2 Z1BankHolidayStartPeriod = no data stored
+- ctlv2 Z1CoolingTemp = 20
+- ctlv2 Z1CoolingTemp = no data stored
+- ctlv2 Z1DayTemp = 20
+- ctlv2 Z1DayTemp = no data stored
+- ctlv2 Z1HolidayEndPeriod = 01.01.2015
+- ctlv2 Z1HolidayEndPeriod = no data stored
+- ctlv2 Z1HolidayStartPeriod = 01.01.2015
+- ctlv2 Z1HolidayStartPeriod = no data stored
+- ctlv2 Z1HolidayTemp = 15
+- ctlv2 Z1HolidayTemp = no data stored
+- ctlv2 Z1Name1 = Thuis
+- ctlv2 Z1Name1 = no data stored
+- 'ctlv2 Z1Name2 =  (ERR: invalid position for f115b52406020003001800 / 050303180000)'
+- ctlv2 Z1Name2 = no data stored
+- ctlv2 Z1NightTemp = 18
+- ctlv2 Z1NightTemp = no data stored
+- ctlv2 Z1OpMode = auto
+- ctlv2 Z1OpMode = no data stored
+- ctlv2 Z1QuickVetoDuration = 3
+- ctlv2 Z1QuickVetoDuration = no data stored
+- ctlv2 Z1QuickVetoEndDate = 28.07.2026
+- ctlv2 Z1QuickVetoEndTime = 11:16:00
+- ctlv2 Z1QuickVetoTemp = 20
+- ctlv2 Z1QuickVetoTemp = no data stored
+- ctlv2 z1RoomHumidity = 46
+- ctlv2 Z1RoomTemp = 22.975
+- ctlv2 Z1RoomZoneMapping = VRC700
+- ctlv2 Z1RoomZoneMapping = no data stored
+- ctlv2 Z1SFMode = auto
+- ctlv2 Z1SFMode = no data stored
+- ctlv2 Z1Shortname = no data stored
+- ctlv2 Z1Shortname = no data stored
+- ctlv2 Z1Timer_Config = no data stored
+- ctlv2 Z1Timer_Friday0 = 06:00;22:00;20.0
+- ctlv2 Z1Timer_Friday1 = no data stored
+- ctlv2 Z1Timer_Friday2 = no data stored
+- ctlv2 Z1Timer_Friday = no data stored
+- ctlv2 Z1Timer_Monday0 = 06:00;22:00;20.0
+- ctlv2 Z1Timer_Monday1 = no data stored
+- ctlv2 Z1Timer_Monday2 = no data stored
+- ctlv2 Z1Timer_Monday = no data stored
+- ctlv2 Z1Timer_Saturday0 = 06:00;22:00;20.0
+- ctlv2 Z1Timer_Saturday1 = no data stored
+- ctlv2 Z1Timer_Saturday2 = no data stored
+- ctlv2 Z1Timer_Saturday = no data stored
+- ctlv2 Z1Timer_Sunday0 = 06:00;22:00;20.0
+- ctlv2 Z1Timer_Sunday1 = no data stored
+- ctlv2 Z1Timer_Sunday2 = no data stored
+- ctlv2 Z1Timer_Sunday = no data stored
+- ctlv2 Z1Timer_Thursday0 = 06:00;22:00;20.0
+- ctlv2 Z1Timer_Thursday1 = no data stored
+- ctlv2 Z1Timer_Thursday2 = no data stored
+- ctlv2 Z1Timer_Thursday = no data stored
+- ctlv2 Z1Timer_Timeframes = 1;1;1;1;1;1;1
+- ctlv2 Z1Timer_Tuesday0 = 06:00;22:00;20.0
+- ctlv2 Z1Timer_Tuesday1 = no data stored
+- ctlv2 Z1Timer_Tuesday2 = no data stored
+- ctlv2 Z1Timer_Tuesday = no data stored
+- ctlv2 Z1Timer_Wednesday0 = 06:00;22:00;20.0
+- ctlv2 Z1Timer_Wednesday1 = no data stored
+- ctlv2 Z1Timer_Wednesday2 = no data stored
+- ctlv2 Z1Timer_Wednesday = no data stored
+- ctlv2 Z1ValveStatus = no data stored
+- ctlv2 Z1ValveStatus = no data stored
+- ctlv2 Z2ActualRoomTempDesired = no data stored
+- ctlv2 Z2ActualRoomTempDesired = no data stored
+- ctlv2 Z2BankHolidayEndPeriod = no data stored
+- ctlv2 Z2BankHolidayEndPeriod = no data stored
+- ctlv2 Z2BankHolidayStartPeriod = no data stored
+- ctlv2 Z2BankHolidayStartPeriod = no data stored
+- ctlv2 Z2CoolingTemp = no data stored
+- ctlv2 Z2CoolingTemp = no data stored
+- ctlv2 Z2DayTemp = no data stored
+- ctlv2 Z2DayTemp = no data stored
+- ctlv2 Z2HolidayEndPeriod = no data stored
+- ctlv2 Z2HolidayEndPeriod = no data stored
+- ctlv2 Z2HolidayStartPeriod = no data stored
+- ctlv2 Z2HolidayStartPeriod = no data stored
+- ctlv2 Z2HolidayTemp = no data stored
+- ctlv2 Z2HolidayTemp = no data stored
+- ctlv2 Z2Name1 = no data stored
+- ctlv2 Z2Name1 = no data stored
+- ctlv2 Z2Name2 = no data stored
+- ctlv2 Z2Name2 = no data stored
+- ctlv2 Z2NightTemp = no data stored
+- ctlv2 Z2NightTemp = no data stored
+- ctlv2 Z2OpMode = no data stored
+- ctlv2 Z2OpMode = no data stored
+- ctlv2 Z2QuickVetoDuration = no data stored
+- ctlv2 Z2QuickVetoDuration = no data stored
+- ctlv2 Z2QuickVetoEndDate = no data stored
+- ctlv2 Z2QuickVetoEndTime = no data stored
+- ctlv2 Z2QuickVetoTemp = no data stored
+- ctlv2 Z2QuickVetoTemp = no data stored
+- ctlv2 Z2RoomTemp =  (empty for 3115b52406020003010f00 / 0800030f00ffffff7f)
+- ctlv2 Z2RoomZoneMapping = none
+- ctlv2 Z2RoomZoneMapping = no data stored
+- ctlv2 Z2SFMode = no data stored
+- ctlv2 Z2SFMode = no data stored
+- ctlv2 Z2Shortname = no data stored
+- ctlv2 Z2Shortname = no data stored
+- ctlv2 Z2Timer_Config = no data stored
+- ctlv2 Z2Timer_Friday0 = no data stored
+- ctlv2 Z2Timer_Friday1 = no data stored
+- ctlv2 Z2Timer_Friday2 = no data stored
+- ctlv2 Z2Timer_Friday = no data stored
+- ctlv2 Z2Timer_Monday0 = no data stored
+- ctlv2 Z2Timer_Monday1 = no data stored
+- ctlv2 Z2Timer_Monday2 = no data stored
+- ctlv2 Z2Timer_Monday = no data stored
+- ctlv2 Z2Timer_Saturday0 = no data stored
+- ctlv2 Z2Timer_Saturday1 = no data stored
+- ctlv2 Z2Timer_Saturday2 = no data stored
+- ctlv2 Z2Timer_Saturday = no data stored
+- ctlv2 Z2Timer_Sunday0 = no data stored
+- ctlv2 Z2Timer_Sunday1 = no data stored
+- ctlv2 Z2Timer_Sunday2 = no data stored
+- ctlv2 Z2Timer_Sunday = no data stored
+- ctlv2 Z2Timer_Thursday0 = no data stored
+- ctlv2 Z2Timer_Thursday1 = no data stored
+- ctlv2 Z2Timer_Thursday2 = no data stored
+- ctlv2 Z2Timer_Thursday = no data stored
+- ctlv2 Z2Timer_Timeframes = no data stored
+- ctlv2 Z2Timer_Tuesday0 = no data stored
+- ctlv2 Z2Timer_Tuesday1 = no data stored
+- ctlv2 Z2Timer_Tuesday2 = no data stored
+- ctlv2 Z2Timer_Tuesday = no data stored
+- ctlv2 Z2Timer_Wednesday0 = no data stored
+- ctlv2 Z2Timer_Wednesday1 = no data stored
+- ctlv2 Z2Timer_Wednesday2 = no data stored
+- ctlv2 Z2Timer_Wednesday = no data stored
+- ctlv2 Z2ValveStatus = no data stored
+- ctlv2 Z2ValveStatus = no data stored
+- ctlv2 Z3ActualRoomTempDesired = no data stored
+- ctlv2 Z3ActualRoomTempDesired = no data stored
+- ctlv2 Z3BankHolidayEndPeriod = no data stored
+- ctlv2 Z3BankHolidayEndPeriod = no data stored
+- ctlv2 Z3BankHolidayStartPeriod = no data stored
+- ctlv2 Z3BankHolidayStartPeriod = no data stored
+- ctlv2 Z3DayTemp = no data stored
+- ctlv2 Z3DayTemp = no data stored
+- ctlv2 Z3HolidayEndPeriod = no data stored
+- ctlv2 Z3HolidayEndPeriod = no data stored
+- ctlv2 Z3HolidayStartPeriod = no data stored
+- ctlv2 Z3HolidayStartPeriod = no data stored
+- ctlv2 Z3HolidayTemp = no data stored
+- ctlv2 Z3HolidayTemp = no data stored
+- ctlv2 Z3Name1 = no data stored
+- ctlv2 Z3Name1 = no data stored
+- ctlv2 Z3Name2 = no data stored
+- ctlv2 Z3Name2 = no data stored
+- ctlv2 Z3NightTemp = no data stored
+- ctlv2 Z3NightTemp = no data stored
+- ctlv2 Z3OpMode = no data stored
+- ctlv2 Z3OpMode = no data stored
+- ctlv2 Z3QuickVetoDuration = no data stored
+- ctlv2 Z3QuickVetoDuration = no data stored
+- ctlv2 Z3QuickVetoEndDate = no data stored
+- ctlv2 Z3QuickVetoEndTime = no data stored
+- ctlv2 Z3QuickVetoTemp = no data stored
+- ctlv2 Z3QuickVetoTemp = no data stored
+- ctlv2 Z3RoomTemp = no data stored
+- ctlv2 Z3RoomZoneMapping = none
+- ctlv2 Z3RoomZoneMapping = no data stored
+- ctlv2 Z3SFMode = no data stored
+- ctlv2 Z3SFMode = no data stored
+- ctlv2 Z3Shortname = no data stored
+- ctlv2 Z3Shortname = no data stored
+- ctlv2 Z3Timer_Config = no data stored
+- ctlv2 Z3Timer_Friday0 = no data stored
+- ctlv2 Z3Timer_Friday1 = no data stored
+- ctlv2 Z3Timer_Friday2 = no data stored
+- ctlv2 Z3Timer_Friday = no data stored
+- ctlv2 Z3Timer_Monday0 = no data stored
+- ctlv2 Z3Timer_Monday1 = no data stored
+- ctlv2 Z3Timer_Monday2 = no data stored
+- ctlv2 Z3Timer_Monday = no data stored
+- ctlv2 Z3Timer_Saturday0 = no data stored
+- ctlv2 Z3Timer_Saturday1 = no data stored
+- ctlv2 Z3Timer_Saturday2 = no data stored
+- ctlv2 Z3Timer_Saturday = no data stored
+- ctlv2 Z3Timer_Sunday0 = no data stored
+- ctlv2 Z3Timer_Sunday1 = no data stored
+- ctlv2 Z3Timer_Sunday2 = no data stored
+- ctlv2 Z3Timer_Sunday = no data stored
+- ctlv2 Z3Timer_Thursday0 = no data stored
+- ctlv2 Z3Timer_Thursday1 = no data stored
+- ctlv2 Z3Timer_Thursday2 = no data stored
+- ctlv2 Z3Timer_Thursday = no data stored
+- ctlv2 Z3Timer_Timeframes = no data stored
+- ctlv2 Z3Timer_Tuesday0 = no data stored
+- ctlv2 Z3Timer_Tuesday1 = no data stored
+- ctlv2 Z3Timer_Tuesday2 = no data stored
+- ctlv2 Z3Timer_Tuesday = no data stored
+- ctlv2 Z3Timer_Wednesday0 = no data stored
+- ctlv2 Z3Timer_Wednesday1 = no data stored
+- ctlv2 Z3Timer_Wednesday2 = no data stored
+- ctlv2 Z3Timer_Wednesday = no data stored
+- ctlv2 Z3ValveStatus = no data stored
+- ctlv2 Z3ValveStatus = no data stored
+- General Valuerange = no data stored
+- hmu BuildingCircuitFlow = 0
+- hmu Clearerrorhistory = no data stored
+- hmu CompressorBlocktime = no data stored
+- hmu CompressorHc = no data stored (message not available due to condition)
+- hmu CompressorHwc = no data stored (message not available due to condition)
+- hmu CopCooling = 7.8
+- hmu CopCoolingMonth = 8.0
+- hmu CopHc = 5.7
+- hmu CopHcMonth = 1.0
+- hmu CopHwc = 2.9
+- hmu CopHwcMonth = 3.5
+- hmu CurrentCompressorUtil = 0.00
+- hmu CurrentConsumedPower = 0.0
+- hmu Currenterror = -;-;-;-;-
+- hmu CurrentYieldPower = 0.0
+- hmu DateTime = nosignal;-:-:-;-.-.-;-
+- hmu EnergyIntegral = no data stored
+- hmu Errorhistory = no data stored
+- hmu FlowPressure = no data stored (message not available due to condition)
+- hmu FlowTemp = 42.06
+- hmu PowerConsumptionHmu = no data stored
+- hmu RunDataAirInletTemp = 27.5728
+- hmu RunDataBuildingCPumpPower = 72.8297
+- hmu RunDataCompressorInletTemp = 28.4709
+- hmu RunDataCompressorOutletTemp = 29.875
+- hmu RunDataCompressorSpeed = 29.9967
+- hmu RunDataEEVOutletTemp = 27.6724
+- hmu RunDataEEVPositionAbs = 179
+- hmu RunDataFan1Speed = 0.0
+- hmu RunDataFan2Speed = 0.0
+- hmu RunDataHighPressure = 15.1236
+- hmu RunDataStatuscode = cool_compressor_active
+- hmu RunStats4PortValveHours = 354
+- hmu RunStats4PortValveSwitches = 1525
+- hmu RunStatsBuildingCPumpStarts = 2109
+- hmu RunStatsBuildingPumpHours = 19812
+- hmu RunStatsCompressorHours = 8171
+- hmu RunStatsCompressorStarts = 14019
+- hmu RunStatsFan1Hours = 9257
+- hmu RunStatsFan1Starts = 15862
+- hmu RunStatsFan2Hours = 0
+- hmu RunStatsFan2Starts = 0
+- hmu RunStatsHcHours = 16913
+- hmu RunStatsHMUHours = 34298
+- hmu RunStatsHwcHours = 1664
+- hmu SetMode = auto;17.0;-;-;1;1;1;0;0;1
+- hmu SetMode = no data stored
+- hmu Status01 = 16.0;20.0;-;-;-;off
+- hmu Status02 = no data stored
+- hmu Status16 = no data stored
+- hmu Status = no data stored
+- hmu StatusCirPump = on
+- hmu SupplyTempWeighted = 20.00
+- hmu TotalEnergyUsage = 7667
+- hmu YieldCoolDay = 14.8
+- hmu YieldCooling = 115.7
+- hmu YieldCoolingMonth = 90.6
+- hmu YieldHc = 21711
+- hmu YieldHcDay = 0.0
+- hmu YieldHcMonth = no data stored
+- hmu YieldHwc = 6523
+- hmu YieldHwcDay = no data stored
+- hmu YieldHwcMonth = no data stored
+- Memory Eeprom = no data stored
+- Memory Eeprom = no data stored
+- Memory Ram = no data stored
+- Memory Ram = no data stored
+- sc Clearerrorhistory = no data stored
+- sc Col = no data stored
+- sc ColKickPumpTime = no data stored
+- sc ColKickTempDelta = no data stored
+- sc CollPump = no data stored
+- sc Currenterror = no data stored
+- sc D1Temp = no data stored
+- sc D2Temp = no data stored
+- sc Date = no data stored
+- sc EDFunction = no data stored
+- sc EDFunction = no data stored
+- sc EnableScProtection = no data stored
+- sc EnableScProtection = no data stored
+- sc Errorhistory = no data stored
+- sc FlowRate = no data stored
+- sc FlowRate = no data stored
+- sc FrostProtectionEnabled = no data stored
+- sc FrostProtectionLimit = no data stored
+- sc Hc1PumpKol1PP1Port = no data stored
+- sc Hc2aLegPumpP2Port = no data stored
+- sc Hc2zPort = no data stored
+- sc HydraulicScheme = no data stored
+- sc InitCircuit = no data stored
+- sc Iotest = no data stored
+- sc Ioteststop = no data stored
+- sc IsInBoostMode = no data stored
+- sc KickFunction = no data stored
+- sc KickFunction = no data stored
+- sc LpZpMaPort = no data stored
+- sc MAPreferredStorage = no data stored
+- sc MAPreferredStorage = no data stored
+- sc MaximalTemp2 = no data stored
+- sc MaximalTemp2 = no data stored
+- sc MaximalTemp = no data stored
+- sc MaximalTemp = no data stored
+- sc MultifunctionOutput = no data stored
+- sc OMultifunction = no data stored
+- sc OMultifunction = no data stored
+- sc PumpAntiLockingFlags = no data stored
+- sc QuickVetoStart = no data stored
+- sc ResetSolGain = no data stored
+- sc ResetSolGain = no data stored
+- sc RuntimeCollPump = no data stored
+- sc RuntimeCollPumpSeconds = no data stored
+- sc ScProtectionHysteresis = no data stored
+- sc ScProtectionLimit = no data stored
+- sc ScProtectionLimit = no data stored
+- sc ScProtectionTime = no data stored
+- sc SolCollPumpDcIntegrator = no data stored
+- sc SolCollPumpED = no data stored
+- sc SolGain = no data stored
+- sc SolOperationMode = no data stored
+- sc SP1 = no data stored
+- sc SP2 = no data stored
+- sc SumSolGain = no data stored
+- sc SumSolGainDayBefore = no data stored
+- sc SystemMode = no data stored
+- sc TempDifferenceOff2 = no data stored
+- sc TempDifferenceOff2 = no data stored
+- sc TempDifferenceOff = no data stored
+- sc TempDifferenceOff = no data stored
+- sc TempDifferenceOffTD12 = no data stored
+- sc TempDifferenceOffTD12 = no data stored
+- sc TempDifferenceOn2 = no data stored
+- sc TempDifferenceOn2 = no data stored
+- sc TempDifferenceOn = no data stored
+- sc TempDifferenceOn = no data stored
+- sc TempDifferenceOnTD12 = no data stored
+- sc TempDifferenceOnTD12 = no data stored
+- sc Time = no data stored
+- sc Weekday = no data stored
+- sc YieldLastYear = no data stored
+- sc YieldThisYear = no data stored
+- Scan Id = no data stored
+- scan.08  = Vaillant;HMU00;0522;5103
+- Scan.08 Id = 21;22;29;0010021619;0001;006576;N8
+- scan.15  = Vaillant;CTLV2;0514;1104
+- Scan.15 Id = 21;22;23;0020260913;0953;017572;N2
+- scan.76  = Vaillant;VWZ00;0522;5103
+- Scan.76 Id = 21;22;25;0010023504;1610;005572;N8
+- scan.ec  = Vaillant;SOL00;0514;1104
+- scan.f6  = Vaillant;NETX2;4039;5703
+- Scan.f6 Id = no data stored
+- vwz EnableTestHwcTemp = no data stored
+- vwz EnableTestOutdoorTemp = no data stored
+- vwz EnableTestThreeWayValve = no data stored
+- vwz TestHwcTemp = no data stored
+- vwz TestOutdoorTemp = no data stored
+- vwz TestThreeWayValve = no data stored
+- ''

--- a/tests/fixtures/community/arotherm_plus_hwc_run_discovery.yaml
+++ b/tests/fixtures/community/arotherm_plus_hwc_run_discovery.yaml
@@ -1,0 +1,12595 @@
+# Discovery dump for vaillant_ebus
+# Review this file for sensitive information before sharing
+metadata:
+  timestamp: '2026-08-14T08:42:22.017749'
+  ebusd_version: null
+  register_count: 696
+  grab_duration: 10
+  dump_version: 3
+raw_find_lines:
+- Broadcast Datetime = no data stored
+- Broadcast Error = no data stored
+- Broadcast HwcStatus = no data stored
+- Broadcast Id = no data stored
+- Broadcast IdAnswer = no data stored
+- Broadcast IdQuery = no data stored
+- Broadcast Load = no data stored
+- Broadcast Outsidetemp = 24.062
+- Broadcast Queryexistence =  (empty for 31fe07fe00 / )
+- Broadcast Signoflife = no data stored
+- Broadcast Vdatetime = 08:41:24;14.08.2026
+- Broadcast Vdatetime = no data stored
+- ctlv2 z1RoomHumidity = 49
+- ctlv3 AdaptHeatCurve = yes
+- ctlv3 AdaptHeatCurve = no data stored
+- ctlv3 CcTimer_Config = no data stored
+- ctlv3 CcTimer_Friday0 = no data stored
+- ctlv3 CcTimer_Friday1 = no data stored
+- ctlv3 CcTimer_Friday2 = no data stored
+- ctlv3 CcTimer_Friday = no data stored
+- ctlv3 CcTimer_Monday0 = no data stored
+- ctlv3 CcTimer_Monday1 = no data stored
+- ctlv3 CcTimer_Monday2 = no data stored
+- ctlv3 CcTimer_Monday = no data stored
+- ctlv3 CcTimer_Saturday0 = no data stored
+- ctlv3 CcTimer_Saturday1 = no data stored
+- ctlv3 CcTimer_Saturday2 = no data stored
+- ctlv3 CcTimer_Saturday = no data stored
+- ctlv3 CcTimer_Sunday0 = no data stored
+- ctlv3 CcTimer_Sunday1 = no data stored
+- ctlv3 CcTimer_Sunday2 = no data stored
+- ctlv3 CcTimer_Sunday = no data stored
+- ctlv3 CcTimer_Thursday0 = no data stored
+- ctlv3 CcTimer_Thursday1 = no data stored
+- ctlv3 CcTimer_Thursday2 = no data stored
+- ctlv3 CcTimer_Thursday = no data stored
+- ctlv3 CcTimer_Timeframes = 0;0;0;0;0;0;0
+- ctlv3 CcTimer_Tuesday0 = no data stored
+- ctlv3 CcTimer_Tuesday1 = no data stored
+- ctlv3 CcTimer_Tuesday2 = no data stored
+- ctlv3 CcTimer_Tuesday = no data stored
+- ctlv3 CcTimer_Wednesday0 = no data stored
+- ctlv3 CcTimer_Wednesday1 = no data stored
+- ctlv3 CcTimer_Wednesday2 = no data stored
+- ctlv3 CcTimer_Wednesday = no data stored
+- ctlv3 Clearerrorhistory = no data stored
+- ctlv3 ContinuousHeating = -26
+- ctlv3 ContinuousHeating = no data stored
+- ctlv3 Currenterror = -;-;-;-;-
+- ctlv3 CylinderChargeHyst = 7
+- ctlv3 CylinderChargeHyst = no data stored
+- ctlv3 CylinderChargeOffset = 5
+- ctlv3 CylinderChargeOffset = no data stored
+- ctlv3 Date = 14.08.2026
+- ctlv3 Date = no data stored
+- ctlv3 DisplayedOutsideTemp = 23.875
+- ctlv3 Errorhistory = no data stored
+- ctlv3 FrostOverRideTime = no data stored
+- ctlv3 FrostOverRideTime = no data stored
+- ctlv3 Hc1ActualFlowTempDesired = 21
+- ctlv3 Hc1AutoOffMode = night
+- ctlv3 Hc1AutoOffMode = no data stored
+- ctlv3 Hc1CircuitType = mixer
+- ctlv3 Hc1ExcessTemp = 0.0
+- ctlv3 Hc1ExcessTemp = no data stored
+- ctlv3 Hc1FlowTemp = 19.0625
+- ctlv3 Hc1HeatCurve = 0.4
+- ctlv3 Hc1HeatCurve = no data stored
+- ctlv3 Hc1HeatCurveAdaption = 0.0
+- ctlv3 Hc1MaxFlowTempDesired = 50
+- ctlv3 Hc1MaxFlowTempDesired = no data stored
+- ctlv3 Hc1MinCoolingTempDesired = 21
+- ctlv3 Hc1MinCoolingTempDesired = no data stored
+- ctlv3 Hc1MinFlowTempDesired = 25
+- ctlv3 Hc1MinFlowTempDesired = no data stored
+- ctlv3 Hc1MixerMovement = -15
+- ctlv3 Hc1PumpStatus = 2
+- ctlv3 Hc1PumpStatus = no data stored
+- ctlv3 Hc1RoomTempSwitchOn = modulating
+- ctlv3 Hc1RoomTempSwitchOn = no data stored
+- ctlv3 Hc1Status = no data stored
+- ctlv3 Hc1Status = no data stored
+- ctlv3 Hc1SummerTempLimit = 16
+- ctlv3 Hc1SummerTempLimit = no data stored
+- ctlv3 Hc2ActualFlowTempDesired = 0.0
+- ctlv3 Hc2AutoOffMode = night
+- ctlv3 Hc2AutoOffMode = no data stored
+- ctlv3 Hc2CircuitType = mixer
+- ctlv3 Hc2ExcessTemp = 0.0
+- ctlv3 Hc2ExcessTemp = no data stored
+- ctlv3 Hc2FlowTemp = 23.125
+- ctlv3 Hc2HeatCurve = 0.3
+- ctlv3 Hc2HeatCurve = no data stored
+- ctlv3 Hc2HeatCurveAdaption = 0.0
+- ctlv3 Hc2MaxFlowTempDesired = 50
+- ctlv3 Hc2MaxFlowTempDesired = no data stored
+- ctlv3 Hc2MinCoolingTempDesired = no data stored
+- ctlv3 Hc2MinCoolingTempDesired = no data stored
+- ctlv3 Hc2MinFlowTempDesired = 15
+- ctlv3 Hc2MinFlowTempDesired = no data stored
+- ctlv3 Hc2MixerMovement = -100
+- ctlv3 Hc2PumpStatus = 0
+- ctlv3 Hc2PumpStatus = no data stored
+- ctlv3 Hc2RoomTempSwitchOn = modulating
+- ctlv3 Hc2RoomTempSwitchOn = no data stored
+- ctlv3 Hc2Status = no data stored
+- ctlv3 Hc2Status = no data stored
+- ctlv3 Hc2SummerTempLimit = 16
+- ctlv3 Hc2SummerTempLimit = no data stored
+- ctlv3 Hc3ActualFlowTempDesired = no data stored
+- ctlv3 Hc3AutoOffMode = no data stored
+- ctlv3 Hc3AutoOffMode = no data stored
+- ctlv3 Hc3CircuitType = inactive
+- ctlv3 Hc3ExcessTemp = no data stored
+- ctlv3 Hc3ExcessTemp = no data stored
+- ctlv3 Hc3FlowTemp = no data stored
+- ctlv3 Hc3HeatCurve = no data stored
+- ctlv3 Hc3HeatCurve = no data stored
+- ctlv3 Hc3HeatCurveAdaption = no data stored
+- ctlv3 Hc3MaxFlowTempDesired = no data stored
+- ctlv3 Hc3MaxFlowTempDesired = no data stored
+- ctlv3 Hc3MinCoolingTempDesired = no data stored
+- ctlv3 Hc3MinCoolingTempDesired = no data stored
+- ctlv3 Hc3MinFlowTempDesired = no data stored
+- ctlv3 Hc3MinFlowTempDesired = no data stored
+- ctlv3 Hc3MixerMovement = no data stored
+- ctlv3 Hc3PumpStatus = no data stored
+- ctlv3 Hc3PumpStatus = no data stored
+- ctlv3 Hc3RoomTempSwitchOn = no data stored
+- ctlv3 Hc3RoomTempSwitchOn = no data stored
+- ctlv3 Hc3Status = no data stored
+- ctlv3 Hc3Status = no data stored
+- ctlv3 Hc3SummerTempLimit = no data stored
+- ctlv3 Hc3SummerTempLimit = no data stored
+- ctlv3 HcStorageTempBottom =  (empty for f115b5240602000000a000 / 080000a000ffffff7f)
+- ctlv3 HcStorageTempTop =  (empty for f115b52406020000009f00 / 0800009f00ffffff7f)
+- ctlv3 HwcBankHolidayEndPeriod = no data stored
+- ctlv3 HwcBankHolidayEndPeriod = no data stored
+- ctlv3 HwcBankHolidayStartPeriod = no data stored
+- ctlv3 HwcBankHolidayStartPeriod = no data stored
+- ctlv3 HwcFlowTemp = no data stored
+- ctlv3 HwcHolidayEndPeriod = 01.01.2019
+- ctlv3 HwcHolidayEndPeriod = no data stored
+- ctlv3 HwcHolidayStartPeriod = 01.01.2019
+- ctlv3 HwcHolidayStartPeriod = no data stored
+- ctlv3 HwcLockTime = 30
+- ctlv3 HwcLockTime = no data stored
+- ctlv3 HwcMaxFlowTempDesired = 80
+- ctlv3 HwcMaxFlowTempDesired = no data stored
+- ctlv3 HwcOpMode = auto
+- ctlv3 HwcOpMode = no data stored
+- ctlv3 HwcParallelLoading = off
+- ctlv3 HwcParallelLoading = no data stored
+- ctlv3 HwcSFMode = no data stored
+- ctlv3 HwcSFMode = no data stored
+- ctlv3 HwcStorageTemp = 49.5
+- ctlv3 HwcStorageTempBottom =  (empty for f115b52406020000009e00 / 0800009e00ffffff7f)
+- ctlv3 HwcStorageTempTop =  (empty for f115b52406020000009d00 / 0800009d00ffffff7f)
+- ctlv3 HwcTempDesired = 52
+- ctlv3 HwcTempDesired = no data stored
+- ctlv3 HwcTimer_Config = no data stored
+- ctlv3 HwcTimer_Friday0 = 01:00;03:00;52.0
+- ctlv3 HwcTimer_Friday1 = no data stored
+- ctlv3 HwcTimer_Friday2 = no data stored
+- ctlv3 HwcTimer_Friday = no data stored
+- ctlv3 HwcTimer_Monday0 = 01:00;03:00;52.0
+- ctlv3 HwcTimer_Monday1 = no data stored
+- ctlv3 HwcTimer_Monday2 = no data stored
+- ctlv3 HwcTimer_Monday = no data stored
+- ctlv3 HwcTimer_Saturday0 = 01:00;03:00;52.0
+- ctlv3 HwcTimer_Saturday1 = no data stored
+- ctlv3 HwcTimer_Saturday2 = no data stored
+- ctlv3 HwcTimer_Saturday = no data stored
+- ctlv3 HwcTimer_Sunday0 = 01:00;03:00;52.0
+- ctlv3 HwcTimer_Sunday1 = no data stored
+- ctlv3 HwcTimer_Sunday2 = no data stored
+- ctlv3 HwcTimer_Sunday = no data stored
+- ctlv3 HwcTimer_Thursday0 = 01:00;03:00;52.0
+- ctlv3 HwcTimer_Thursday1 = no data stored
+- ctlv3 HwcTimer_Thursday2 = no data stored
+- ctlv3 HwcTimer_Thursday = no data stored
+- ctlv3 HwcTimer_Timeframes = 1;1;1;1;1;1;1
+- ctlv3 HwcTimer_Tuesday0 = 01:00;03:00;52.0
+- ctlv3 HwcTimer_Tuesday1 = no data stored
+- ctlv3 HwcTimer_Tuesday2 = no data stored
+- ctlv3 HwcTimer_Tuesday = no data stored
+- ctlv3 HwcTimer_Wednesday0 = 01:00;03:00;52.0
+- ctlv3 HwcTimer_Wednesday1 = no data stored
+- ctlv3 HwcTimer_Wednesday2 = no data stored
+- ctlv3 HwcTimer_Wednesday = no data stored
+- ctlv3 HydraulicScheme = 8
+- ctlv3 HydraulicScheme = no data stored
+- ctlv3 Installer1 = no data stored
+- ctlv3 Installer1 = no data stored
+- ctlv3 Installer2 = no data stored
+- ctlv3 Installer2 = no data stored
+- ctlv3 KeyCodeforConfigMenu = no data stored
+- ctlv3 KeyCodeforConfigMenu = no data stored
+- ctlv3 MaintenanceDate = no data stored
+- ctlv3 MaintenanceDate = no data stored
+- ctlv3 MaintenanceDue = no
+- ctlv3 MaxCylinderChargeTime = 120
+- ctlv3 MaxCylinderChargeTime = no data stored
+- ctlv3 MaxRoomHumidity = no data stored
+- ctlv3 MaxRoomHumidity = no data stored
+- ctlv3 MultiRelaySetting = 4
+- ctlv3 MultiRelaySetting = no data stored
+- ctlv3 OutsideTempAvg = 24.8125
+- ctlv3 OutsideTempAvg = no data stored
+- ctlv3 PhoneNumber1 = no data stored
+- ctlv3 PhoneNumber1 = no data stored
+- ctlv3 PhoneNumber2 = no data stored
+- ctlv3 PhoneNumber2 = no data stored
+- ctlv3 PrEnergySum = no data stored
+- ctlv3 PrEnergySum = no data stored
+- ctlv3 PrEnergySumHc = no data stored
+- ctlv3 PrEnergySumHc = no data stored
+- ctlv3 PrEnergySumHcLastMonth = no data stored
+- ctlv3 PrEnergySumHcLastMonth = no data stored
+- ctlv3 PrEnergySumHcThisMonth = no data stored
+- ctlv3 PrEnergySumHcThisMonth = no data stored
+- ctlv3 PrEnergySumHwc = no data stored
+- ctlv3 PrEnergySumHwc = no data stored
+- ctlv3 PrEnergySumHwcLastMonth = no data stored
+- ctlv3 PrEnergySumHwcLastMonth = no data stored
+- ctlv3 PrEnergySumHwcThisMonth = no data stored
+- ctlv3 PrEnergySumHwcThisMonth = no data stored
+- ctlv3 PrFuelSum = no data stored
+- ctlv3 PrFuelSum = no data stored
+- ctlv3 PrFuelSumHc = no data stored
+- ctlv3 PrFuelSumHc = no data stored
+- ctlv3 PrFuelSumHcLastMonth = no data stored
+- ctlv3 PrFuelSumHcLastMonth = no data stored
+- ctlv3 PrFuelSumHcThisMonth = no data stored
+- ctlv3 PrFuelSumHcThisMonth = no data stored
+- ctlv3 PrFuelSumHwc = no data stored
+- ctlv3 PrFuelSumHwc = no data stored
+- ctlv3 PrFuelSumHwcLastMonth = no data stored
+- ctlv3 PrFuelSumHwcLastMonth = no data stored
+- ctlv3 PrFuelSumHwcThisMonth = no data stored
+- ctlv3 PrFuelSumHwcThisMonth = no data stored
+- ctlv3 PumpAdditionalTime = no data stored
+- ctlv3 PumpAdditionalTime = no data stored
+- ctlv3 SolarYieldTotal = no data stored
+- ctlv3 SolarYieldTotal = no data stored
+- ctlv3 SystemFlowTemp =  (empty for f115b52406020000004b00 / 0800004b00ffffff7f)
+- ctlv3 Time = 07:42:04
+- ctlv3 Time = no data stored
+- ctlv3 WaterPressure = 1.8
+- ctlv3 YieldTotal = no data stored
+- ctlv3 YieldTotal = no data stored
+- ctlv3 Z1ActualRoomTempDesired = 0.0
+- ctlv3 Z1ActualRoomTempDesired = no data stored
+- ctlv3 Z1BankHolidayEndPeriod = no data stored
+- ctlv3 Z1BankHolidayEndPeriod = no data stored
+- ctlv3 Z1BankHolidayStartPeriod = no data stored
+- ctlv3 Z1BankHolidayStartPeriod = no data stored
+- ctlv3 Z1CoolingTemp = 24
+- ctlv3 Z1CoolingTemp = no data stored
+- ctlv3 Z1DayTemp = 21
+- ctlv3 Z1DayTemp = no data stored
+- ctlv3 Z1HolidayEndPeriod = 01.01.2019
+- ctlv3 Z1HolidayEndPeriod = no data stored
+- ctlv3 Z1HolidayStartPeriod = 01.01.2019
+- ctlv3 Z1HolidayStartPeriod = no data stored
+- ctlv3 Z1HolidayTemp = 20
+- ctlv3 Z1HolidayTemp = no data stored
+- ctlv3 Z1Name1 = Downs
+- ctlv3 Z1Name1 = no data stored
+- ctlv3 Z1Name2 = tairs
+- ctlv3 Z1Name2 = no data stored
+- ctlv3 Z1NightTemp = 20
+- ctlv3 Z1NightTemp = no data stored
+- ctlv3 Z1OpMode = day
+- ctlv3 Z1OpMode = no data stored
+- ctlv3 Z1QuickVetoDuration = no data stored
+- ctlv3 Z1QuickVetoDuration = no data stored
+- ctlv3 Z1QuickVetoEndDate = no data stored
+- ctlv3 Z1QuickVetoEndTime = no data stored
+- ctlv3 Z1QuickVetoTemp = no data stored
+- ctlv3 Z1QuickVetoTemp = no data stored
+- ctlv3 Z1RoomTemp = 24.7875
+- ctlv3 Z1RoomZoneMapping = VRC700
+- ctlv3 Z1RoomZoneMapping = no data stored
+- ctlv3 Z1SFMode = no data stored
+- ctlv3 Z1SFMode = no data stored
+- ctlv3 Z1Shortname = no data stored
+- ctlv3 Z1Shortname = no data stored
+- ctlv3 Z1Timer_Config = no data stored
+- ctlv3 Z1Timer_Friday0 = 00:00;24:00;21.0
+- ctlv3 Z1Timer_Friday1 = no data stored
+- ctlv3 Z1Timer_Friday2 = no data stored
+- ctlv3 Z1Timer_Friday = no data stored
+- ctlv3 Z1Timer_Monday0 = 00:00;24:00;21.0
+- ctlv3 Z1Timer_Monday1 = no data stored
+- ctlv3 Z1Timer_Monday2 = no data stored
+- ctlv3 Z1Timer_Monday = no data stored
+- ctlv3 Z1Timer_Saturday0 = 00:00;24:00;21.0
+- ctlv3 Z1Timer_Saturday1 = no data stored
+- ctlv3 Z1Timer_Saturday2 = no data stored
+- ctlv3 Z1Timer_Saturday = no data stored
+- ctlv3 Z1Timer_Sunday0 = 00:00;24:00;21.0
+- ctlv3 Z1Timer_Sunday1 = no data stored
+- ctlv3 Z1Timer_Sunday2 = no data stored
+- ctlv3 Z1Timer_Sunday = no data stored
+- ctlv3 Z1Timer_Thursday0 = 00:00;24:00;21.0
+- ctlv3 Z1Timer_Thursday1 = no data stored
+- ctlv3 Z1Timer_Thursday2 = no data stored
+- ctlv3 Z1Timer_Thursday = no data stored
+- ctlv3 Z1Timer_Timeframes = 1;1;1;1;1;1;1
+- ctlv3 Z1Timer_Tuesday0 = 00:00;24:00;21.0
+- ctlv3 Z1Timer_Tuesday1 = no data stored
+- ctlv3 Z1Timer_Tuesday2 = no data stored
+- ctlv3 Z1Timer_Tuesday = no data stored
+- ctlv3 Z1Timer_Wednesday0 = 00:00;24:00;21.0
+- ctlv3 Z1Timer_Wednesday1 = no data stored
+- ctlv3 Z1Timer_Wednesday2 = no data stored
+- ctlv3 Z1Timer_Wednesday = no data stored
+- ctlv3 Z1ValveStatus = no data stored
+- ctlv3 Z1ValveStatus = no data stored
+- ctlv3 Z2ActualRoomTempDesired = 0.0
+- ctlv3 Z2ActualRoomTempDesired = no data stored
+- ctlv3 Z2BankHolidayEndPeriod = no data stored
+- ctlv3 Z2BankHolidayEndPeriod = no data stored
+- ctlv3 Z2BankHolidayStartPeriod = no data stored
+- ctlv3 Z2BankHolidayStartPeriod = no data stored
+- ctlv3 Z2CoolingTemp = no data stored
+- ctlv3 Z2CoolingTemp = no data stored
+- ctlv3 Z2DayTemp = 20.5
+- ctlv3 Z2DayTemp = no data stored
+- ctlv3 Z2HolidayEndPeriod = 01.01.2019
+- ctlv3 Z2HolidayEndPeriod = no data stored
+- ctlv3 Z2HolidayStartPeriod = 01.01.2019
+- ctlv3 Z2HolidayStartPeriod = no data stored
+- ctlv3 Z2HolidayTemp = 20
+- ctlv3 Z2HolidayTemp = no data stored
+- ctlv3 Z2Name1 = Upsta
+- ctlv3 Z2Name1 = no data stored
+- 'ctlv3 Z2Name2 =  (ERR: invalid position for f115b52406020003011800 / 080303180069727300)'
+- ctlv3 Z2Name2 = no data stored
+- ctlv3 Z2NightTemp = 21
+- ctlv3 Z2NightTemp = no data stored
+- ctlv3 Z2OpMode = auto
+- ctlv3 Z2OpMode = no data stored
+- ctlv3 Z2QuickVetoDuration = no data stored
+- ctlv3 Z2QuickVetoDuration = no data stored
+- ctlv3 Z2QuickVetoEndDate = no data stored
+- ctlv3 Z2QuickVetoEndTime = 00:00:00
+- ctlv3 Z2QuickVetoTemp = no data stored
+- ctlv3 Z2QuickVetoTemp = no data stored
+- ctlv3 Z2RoomTemp = 26.4125
+- ctlv3 Z2RoomZoneMapping = VR91_1
+- ctlv3 Z2RoomZoneMapping = no data stored
+- ctlv3 Z2SFMode = no data stored
+- ctlv3 Z2SFMode = no data stored
+- ctlv3 Z2Shortname = no data stored
+- ctlv3 Z2Shortname = no data stored
+- ctlv3 Z2Timer_Config = no data stored
+- ctlv3 Z2Timer_Friday0 = 03:00;24:00;20.0
+- ctlv3 Z2Timer_Friday1 = no data stored
+- ctlv3 Z2Timer_Friday2 = no data stored
+- ctlv3 Z2Timer_Friday = no data stored
+- ctlv3 Z2Timer_Monday0 = 03:00;24:00;20.0
+- ctlv3 Z2Timer_Monday1 = no data stored
+- ctlv3 Z2Timer_Monday2 = no data stored
+- ctlv3 Z2Timer_Monday = no data stored
+- ctlv3 Z2Timer_Saturday0 = 03:00;24:00;20.0
+- ctlv3 Z2Timer_Saturday1 = no data stored
+- ctlv3 Z2Timer_Saturday2 = no data stored
+- ctlv3 Z2Timer_Saturday = no data stored
+- ctlv3 Z2Timer_Sunday0 = 03:00;24:00;20.0
+- ctlv3 Z2Timer_Sunday1 = no data stored
+- ctlv3 Z2Timer_Sunday2 = no data stored
+- ctlv3 Z2Timer_Sunday = no data stored
+- ctlv3 Z2Timer_Thursday0 = 03:00;24:00;20.0
+- ctlv3 Z2Timer_Thursday1 = no data stored
+- ctlv3 Z2Timer_Thursday2 = no data stored
+- ctlv3 Z2Timer_Thursday = no data stored
+- ctlv3 Z2Timer_Timeframes = 1;1;1;1;1;1;1
+- ctlv3 Z2Timer_Tuesday0 = 03:00;24:00;20.0
+- ctlv3 Z2Timer_Tuesday1 = no data stored
+- ctlv3 Z2Timer_Tuesday2 = no data stored
+- ctlv3 Z2Timer_Tuesday = no data stored
+- ctlv3 Z2Timer_Wednesday0 = 03:00;24:00;20.0
+- ctlv3 Z2Timer_Wednesday1 = no data stored
+- ctlv3 Z2Timer_Wednesday2 = no data stored
+- ctlv3 Z2Timer_Wednesday = no data stored
+- ctlv3 Z2ValveStatus = no data stored
+- ctlv3 Z2ValveStatus = no data stored
+- ctlv3 Z3ActualRoomTempDesired = no data stored
+- ctlv3 Z3ActualRoomTempDesired = no data stored
+- ctlv3 Z3BankHolidayEndPeriod = no data stored
+- ctlv3 Z3BankHolidayEndPeriod = no data stored
+- ctlv3 Z3BankHolidayStartPeriod = no data stored
+- ctlv3 Z3BankHolidayStartPeriod = no data stored
+- ctlv3 Z3DayTemp = no data stored
+- ctlv3 Z3DayTemp = no data stored
+- ctlv3 Z3HolidayEndPeriod = no data stored
+- ctlv3 Z3HolidayEndPeriod = no data stored
+- ctlv3 Z3HolidayStartPeriod = no data stored
+- ctlv3 Z3HolidayStartPeriod = no data stored
+- ctlv3 Z3HolidayTemp = no data stored
+- ctlv3 Z3HolidayTemp = no data stored
+- ctlv3 Z3Name1 = no data stored
+- ctlv3 Z3Name1 = no data stored
+- ctlv3 Z3Name2 = no data stored
+- ctlv3 Z3Name2 = no data stored
+- ctlv3 Z3NightTemp = no data stored
+- ctlv3 Z3NightTemp = no data stored
+- ctlv3 Z3OpMode = no data stored
+- ctlv3 Z3OpMode = no data stored
+- ctlv3 Z3QuickVetoDuration = no data stored
+- ctlv3 Z3QuickVetoDuration = no data stored
+- ctlv3 Z3QuickVetoEndDate = no data stored
+- ctlv3 Z3QuickVetoEndTime = no data stored
+- ctlv3 Z3QuickVetoTemp = no data stored
+- ctlv3 Z3QuickVetoTemp = no data stored
+- ctlv3 Z3RoomTemp = no data stored
+- ctlv3 Z3RoomZoneMapping = none
+- ctlv3 Z3RoomZoneMapping = no data stored
+- ctlv3 Z3SFMode = no data stored
+- ctlv3 Z3SFMode = no data stored
+- ctlv3 Z3Shortname = no data stored
+- ctlv3 Z3Shortname = no data stored
+- ctlv3 Z3Timer_Config = no data stored
+- ctlv3 Z3Timer_Friday0 = no data stored
+- ctlv3 Z3Timer_Friday1 = no data stored
+- ctlv3 Z3Timer_Friday2 = no data stored
+- ctlv3 Z3Timer_Friday = no data stored
+- ctlv3 Z3Timer_Monday0 = no data stored
+- ctlv3 Z3Timer_Monday1 = no data stored
+- ctlv3 Z3Timer_Monday2 = no data stored
+- ctlv3 Z3Timer_Monday = no data stored
+- ctlv3 Z3Timer_Saturday0 = no data stored
+- ctlv3 Z3Timer_Saturday1 = no data stored
+- ctlv3 Z3Timer_Saturday2 = no data stored
+- ctlv3 Z3Timer_Saturday = no data stored
+- ctlv3 Z3Timer_Sunday0 = no data stored
+- ctlv3 Z3Timer_Sunday1 = no data stored
+- ctlv3 Z3Timer_Sunday2 = no data stored
+- ctlv3 Z3Timer_Sunday = no data stored
+- ctlv3 Z3Timer_Thursday0 = no data stored
+- ctlv3 Z3Timer_Thursday1 = no data stored
+- ctlv3 Z3Timer_Thursday2 = no data stored
+- ctlv3 Z3Timer_Thursday = no data stored
+- ctlv3 Z3Timer_Timeframes = no data stored
+- ctlv3 Z3Timer_Tuesday0 = no data stored
+- ctlv3 Z3Timer_Tuesday1 = no data stored
+- ctlv3 Z3Timer_Tuesday2 = no data stored
+- ctlv3 Z3Timer_Tuesday = no data stored
+- ctlv3 Z3Timer_Wednesday0 = no data stored
+- ctlv3 Z3Timer_Wednesday1 = no data stored
+- ctlv3 Z3Timer_Wednesday2 = no data stored
+- ctlv3 Z3Timer_Wednesday = no data stored
+- ctlv3 Z3ValveStatus = no data stored
+- ctlv3 Z3ValveStatus = no data stored
+- General Valuerange = no data stored
+- hmu BuildingCircuitFlow = 769
+- hmu Clearerrorhistory = no data stored
+- hmu CompressorBlocktime = no data stored
+- hmu CompressorHc = 187179;4337
+- hmu CompressorHwc = 52345;737
+- hmu CopCooling = 6.8
+- hmu CopCoolingMonth = 6.6
+- hmu CopHc = 3.4
+- hmu CopHcMonth = 1.1
+- hmu CopHwc = 2.7
+- hmu CopHwcMonth = 3.5
+- hmu CurrentCompressorUtil = 0.00
+- hmu CurrentConsumedPower = 0.4
+- hmu Currenterror = -;-;-;-;-
+- hmu CurrentYieldPower = 2.5
+- hmu DateTime = nosignal;-:-:-;-.-.-;-
+- hmu EnergyIntegral = no data stored
+- hmu Errorhistory = no data stored
+- hmu FlowPressure = no data stored
+- hmu FlowTemp = 22.62
+- hmu PowerConsumptionHmu = 0.028224209
+- hmu RunDataAirInletTemp = 24.4843
+- hmu RunDataBuildingCPumpPower = 62.5333
+- hmu RunDataCompressorInletTemp = 21.3901
+- hmu RunDataCompressorOutletTemp = 39.6602
+- hmu RunDataCompressorSpeed = 0.0
+- hmu RunDataEEVOutletTemp = 23.9375
+- hmu RunDataEEVPositionAbs = 250
+- hmu RunDataFan1Speed = 506.881
+- hmu RunDataFan2Speed = 0.0
+- hmu RunDataHighPressure = 6.91209
+- hmu RunDataStatuscode = cool_compressor_shutdown
+- hmu RunStats4PortValveHours = 320
+- hmu RunStats4PortValveSwitches = 1305
+- hmu RunStatsBuildingCPumpStarts = 2140
+- hmu RunStatsBuildingPumpHours = 11315
+- hmu RunStatsCompressorHours = 4287
+- hmu RunStatsCompressorStarts = 6150
+- hmu RunStatsFan1Hours = 4725
+- hmu RunStatsFan1Starts = 8489
+- hmu RunStatsFan2Hours = 0
+- hmu RunStatsFan2Starts = 0
+- hmu RunStatsHcHours = 8204
+- hmu RunStatsHMUHours = 17725
+- hmu RunStatsHwcHours = 914
+- hmu SetMode = auto;21.0;-;-;1;1;1;0;0;1
+- hmu SetMode = no data stored
+- hmu Status01 = 20.0;20.0;-;-;-;off
+- hmu Status02 = no data stored
+- hmu Status16 = no data stored
+- hmu Status = no data stored
+- hmu StatusCirPump = off
+- hmu SupplyTempWeighted = 22.00
+- hmu TotalEnergyUsage = 3517
+- hmu YieldCoolDay = 0.0
+- hmu YieldCooling = 0.0
+- hmu YieldCoolingMonth = 0.0
+- hmu YieldHc = 6225
+- hmu YieldHcDay = 0.1
+- hmu YieldHcMonth = no data stored
+- hmu YieldHwc = 1857
+- hmu YieldHwcDay = no data stored
+- hmu YieldHwcMonth = no data stored
+- Memory Eeprom = no data stored
+- Memory Eeprom = no data stored
+- Memory Ram = no data stored
+- Memory Ram = no data stored
+- Scan Id = no data stored
+- scan.08  = Vaillant;HMU00;0902;5103
+- Scan.08 Id = 21;24;18;0010047380;1300;105808;N4
+- scan.15  = Vaillant;CTLV3;0709;3704
+- Scan.15 Id = 21;23;44;0020260921;0953;015178;N9
+- scan.26  = Vaillant;VR_71;0201;0503
+- Scan.26 Id = 21;23;16;0020184847;0082;016128;N6
+- scan.35  = Vaillant;VR_92;0122;9403
+- Scan.35 Id = 21;21;06;0020260925;0953;006869;N7
+- scan.76  = Vaillant;VWZIO;0202;0103
+- Scan.76 Id = 21;24;17;0010031644;0082;009808;N6
+- scan.f6  = Vaillant;NETX3;0129;0404
+- Scan.f6 Id = 21;23;22;0020292012;0933;097000;N1
+- vr_71 Clearerrorhistory = no data stored
+- vr_71 Currenterror = no data stored
+- vr_71 Errorhistory = no data stored
+- vr_71 Mc1Operation = 2;21.0;on;-10
+- vr_71 Mc2Operation = off;0.0;on;-100
+- vr_71 Mc3Operation = no data stored
+- vr_71 SensorData1 = -;19.62;23.12;-;-;-;-;41 01
+- vr_71 SensorData2 = -;-;-;-;0.00;8.00;80 54 05
+- vr_71 SetActorState = -;-;off;on;off;off;-;-;-;-;off;off;00 00
+- vwzio EnableTestHwcTemp = no data stored
+- vwzio EnableTestOutdoorTemp = no data stored
+- vwzio EnableTestThreeWayValve = no data stored
+- vwzio TestHwcTemp = no data stored
+- vwzio TestOutdoorTemp = no data stored
+- vwzio TestThreeWayValve = no data stored
+- ''
+before_registers:
+- circuit: Broadcast
+  name: Datetime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Error
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: Broadcast
+  name: HwcStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Id
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: IdAnswer
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: IdQuery
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Load
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Outsidetemp
+  fields:
+  - value
+  values:
+  - '24.062'
+  writable: false
+  has_data: true
+- circuit: Broadcast
+  name: Queryexistence
+  fields:
+  - value
+  values:
+  - (empty for 31fe07fe00 / )
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Signoflife
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Vdatetime
+  fields:
+  - value
+  values:
+  - 08:41:24;14.08.2026
+  writable: false
+  has_data: true
+- circuit: Broadcast
+  name: Vdatetime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: WaterPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: General
+  name: Valuerange
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Eeprom
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Eeprom
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Ram
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Ram
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Scan
+  name: Id
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Scan.08
+  name: Id
+  fields:
+  - value
+  values:
+  - 21;24;18;0010047380;1300;105808;N4
+  writable: false
+  has_data: true
+- circuit: Scan.15
+  name: Id
+  fields:
+  - value
+  values:
+  - 21;23;44;0020260921;0953;015178;N9
+  writable: false
+  has_data: true
+- circuit: Scan.26
+  name: Id
+  fields:
+  - value
+  values:
+  - 21;23;16;0020184847;0082;016128;N6
+  writable: false
+  has_data: true
+- circuit: Scan.35
+  name: Id
+  fields:
+  - value
+  values:
+  - 21;21;06;0020260925;0953;006869;N7
+  writable: false
+  has_data: true
+- circuit: Scan.76
+  name: Id
+  fields:
+  - value
+  values:
+  - 21;24;17;0010031644;0082;009808;N6
+  writable: false
+  has_data: true
+- circuit: Scan.f6
+  name: Id
+  fields:
+  - value
+  values:
+  - 21;23;22;0020292012;0933;097000;N1
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: AdaptHeatCurve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: CcTimer_Config
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: CcTimer_Timeframes
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: ContinuousHeating
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: CylinderChargeHyst
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: CylinderChargeOffset
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Date
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: DisplayedOutsideTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: FrostOverRideTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1AutoOffMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1CircuitType
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1CoolingEnabled
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1CoolingFlowTempMin
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1DewPointMonitoring
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1DewPointOffset
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1ExcessTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1HeatCurve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MixerMovement
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1PumpStatus
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1RoomTempModulation
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1Status
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1SummerTempLimit
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2AutoOffMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2CircuitType
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2ExcessTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2HeatCurve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MixerMovement
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2PumpStatus
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2Status
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2SummerTempLimit
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3AutoOffMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3CircuitType
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3ExcessTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3HeatCurve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MixerMovement
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3PumpStatus
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3Status
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3SummerTempLimit
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HcStorageTempBottom
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: ctlv2
+  name: HcStorageTempTop
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: ctlv2
+  name: HwcFlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcLockTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcMaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcOpMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcParallelLoading
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcSFMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcSfMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcStorageTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcStorageTempBottom
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcStorageTempTop
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HydraulicScheme
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: MaxCylinderChargeTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: MaxRoomHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: MultiRelaySetting
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: OutsideTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: OutsideTempAvg
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySum
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHcLastMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHcThisMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHwcLastMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHwcThisMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: SystemFlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: WaterPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingManualTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingOpMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingSetbackTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1DayTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1HolidayTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1NightTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1OpMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoDuration
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoEndDate
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoEndTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1RoomTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1SFMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z2RoomTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: z1RoomHumidity
+  fields:
+  - value
+  values:
+  - '49'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: AdaptHeatCurve
+  fields:
+  - value
+  values:
+  - 'yes'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: AdaptHeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Config
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Friday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Friday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Friday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Monday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Monday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Monday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Saturday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Saturday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Saturday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Sunday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Sunday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Sunday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Thursday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Timeframes
+  fields:
+  - value
+  values:
+  - 0;0;0;0;0;0;0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CcTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Tuesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Wednesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Clearerrorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: ContinuousHeating
+  fields:
+  - value
+  values:
+  - '-26'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: ContinuousHeating
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - -;-;-;-;-
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CylinderChargeHyst
+  fields:
+  - value
+  values:
+  - '7'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CylinderChargeHyst
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CylinderChargeOffset
+  fields:
+  - value
+  values:
+  - '5'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CylinderChargeOffset
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Date
+  fields:
+  - value
+  values:
+  - 14.08.2026
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Date
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: DisplayedOutsideTemp
+  fields:
+  - value
+  values:
+  - '23.875'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: FrostOverRideTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: FrostOverRideTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - '21'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1AutoOffMode
+  fields:
+  - value
+  values:
+  - night
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1AutoOffMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1CircuitType
+  fields:
+  - value
+  values:
+  - mixer
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1ExcessTemp
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1ExcessTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1FlowTemp
+  fields:
+  - value
+  values:
+  - '19.0625'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1HeatCurve
+  fields:
+  - value
+  values:
+  - '0.4'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1HeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '50'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - '21'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - '25'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1MixerMovement
+  fields:
+  - value
+  values:
+  - '-15'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1PumpStatus
+  fields:
+  - value
+  values:
+  - '2'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1PumpStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - modulating
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1SummerTempLimit
+  fields:
+  - value
+  values:
+  - '16'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1SummerTempLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2AutoOffMode
+  fields:
+  - value
+  values:
+  - night
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2AutoOffMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2CircuitType
+  fields:
+  - value
+  values:
+  - mixer
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2ExcessTemp
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2ExcessTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2FlowTemp
+  fields:
+  - value
+  values:
+  - '23.125'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2HeatCurve
+  fields:
+  - value
+  values:
+  - '0.3'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2HeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '50'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - '15'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2MixerMovement
+  fields:
+  - value
+  values:
+  - '-100'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2PumpStatus
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2PumpStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - modulating
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2SummerTempLimit
+  fields:
+  - value
+  values:
+  - '16'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2SummerTempLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3AutoOffMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3AutoOffMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3CircuitType
+  fields:
+  - value
+  values:
+  - inactive
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3ExcessTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3ExcessTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3FlowTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3HeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3HeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3MixerMovement
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3PumpStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3PumpStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3SummerTempLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3SummerTempLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HcStorageTempBottom
+  fields:
+  - value
+  values:
+  - (empty for f115b5240602000000a000 / 080000a000ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HcStorageTempTop
+  fields:
+  - value
+  values:
+  - (empty for f115b52406020000009f00 / 0800009f00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcBankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcBankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcBankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcBankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcFlowTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcLockTime
+  fields:
+  - value
+  values:
+  - '30'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcLockTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcMaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '80'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcMaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcOpMode
+  fields:
+  - value
+  values:
+  - auto
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcOpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcParallelLoading
+  fields:
+  - value
+  values:
+  - 'off'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcParallelLoading
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcSFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcSFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcStorageTemp
+  fields:
+  - value
+  values:
+  - '49.5'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcStorageTempBottom
+  fields:
+  - value
+  values:
+  - (empty for f115b52406020000009e00 / 0800009e00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcStorageTempTop
+  fields:
+  - value
+  values:
+  - (empty for f115b52406020000009d00 / 0800009d00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTempDesired
+  fields:
+  - value
+  values:
+  - '52'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Config
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Friday0
+  fields:
+  - value
+  values:
+  - 01:00;03:00;52.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcTimer_Friday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Friday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Monday0
+  fields:
+  - value
+  values:
+  - 01:00;03:00;52.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcTimer_Monday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Monday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Saturday0
+  fields:
+  - value
+  values:
+  - 01:00;03:00;52.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcTimer_Saturday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Saturday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Sunday0
+  fields:
+  - value
+  values:
+  - 01:00;03:00;52.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcTimer_Sunday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Sunday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Thursday0
+  fields:
+  - value
+  values:
+  - 01:00;03:00;52.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcTimer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Timeframes
+  fields:
+  - value
+  values:
+  - 1;1;1;1;1;1;1
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Tuesday0
+  fields:
+  - value
+  values:
+  - 01:00;03:00;52.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcTimer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Wednesday0
+  fields:
+  - value
+  values:
+  - 01:00;03:00;52.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcTimer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HydraulicScheme
+  fields:
+  - value
+  values:
+  - '8'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HydraulicScheme
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Installer1
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Installer1
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Installer2
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Installer2
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: KeyCodeforConfigMenu
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: KeyCodeforConfigMenu
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: MaintenanceDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: MaintenanceDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: MaintenanceDue
+  fields:
+  - value
+  values:
+  - 'no'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: MaxCylinderChargeTime
+  fields:
+  - value
+  values:
+  - '120'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: MaxCylinderChargeTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: MaxRoomHumidity
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: MaxRoomHumidity
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: MultiRelaySetting
+  fields:
+  - value
+  values:
+  - '4'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: MultiRelaySetting
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: OutsideTempAvg
+  fields:
+  - value
+  values:
+  - '24.8125'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: OutsideTempAvg
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PhoneNumber1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PhoneNumber1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PhoneNumber2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PhoneNumber2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHwc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHwc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHwcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHwcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHwcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHwcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHwc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHwc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHwcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHwcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHwcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHwcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PumpAdditionalTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PumpAdditionalTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: SolarYieldTotal
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: SolarYieldTotal
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: SystemFlowTemp
+  fields:
+  - value
+  values:
+  - (empty for f115b52406020000004b00 / 0800004b00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Time
+  fields:
+  - value
+  values:
+  - 07:42:04
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Time
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: WaterPressure
+  fields:
+  - value
+  values:
+  - '1.8'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: YieldTotal
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: YieldTotal
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1CoolingTemp
+  fields:
+  - value
+  values:
+  - '24'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1CoolingTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1DayTemp
+  fields:
+  - value
+  values:
+  - '21'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1HolidayTemp
+  fields:
+  - value
+  values:
+  - '20'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Name1
+  fields:
+  - value
+  values:
+  - Downs
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Name2
+  fields:
+  - value
+  values:
+  - tairs
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1NightTemp
+  fields:
+  - value
+  values:
+  - '20'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1OpMode
+  fields:
+  - value
+  values:
+  - day
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1QuickVetoEndDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1QuickVetoEndTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1RoomTemp
+  fields:
+  - value
+  values:
+  - '24.7875'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Config
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Friday0
+  fields:
+  - value
+  values:
+  - 00:00;24:00;21.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Friday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Friday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Monday0
+  fields:
+  - value
+  values:
+  - 00:00;24:00;21.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Monday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Monday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Saturday0
+  fields:
+  - value
+  values:
+  - 00:00;24:00;21.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Saturday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Saturday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Sunday0
+  fields:
+  - value
+  values:
+  - 00:00;24:00;21.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Sunday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Sunday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Thursday0
+  fields:
+  - value
+  values:
+  - 00:00;24:00;21.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Timeframes
+  fields:
+  - value
+  values:
+  - 1;1;1;1;1;1;1
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Tuesday0
+  fields:
+  - value
+  values:
+  - 00:00;24:00;21.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Wednesday0
+  fields:
+  - value
+  values:
+  - 00:00;24:00;21.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z2ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2CoolingTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2CoolingTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2DayTemp
+  fields:
+  - value
+  values:
+  - '20.5'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z2DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z2HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z2HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2HolidayTemp
+  fields:
+  - value
+  values:
+  - '20'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z2HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Name1
+  fields:
+  - value
+  values:
+  - Upsta
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z2Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Name2
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for f115b52406020003011800 / 080303180069727300)'
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2NightTemp
+  fields:
+  - value
+  values:
+  - '21'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z2NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2OpMode
+  fields:
+  - value
+  values:
+  - auto
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z2OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2QuickVetoEndDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2QuickVetoEndTime
+  fields:
+  - value
+  values:
+  - 00:00:00
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z2QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2RoomTemp
+  fields:
+  - value
+  values:
+  - '26.4125'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z2RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z2RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Config
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Friday0
+  fields:
+  - value
+  values:
+  - 03:00;24:00;20.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z2Timer_Friday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Friday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Monday0
+  fields:
+  - value
+  values:
+  - 03:00;24:00;20.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z2Timer_Monday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Monday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Saturday0
+  fields:
+  - value
+  values:
+  - 03:00;24:00;20.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z2Timer_Saturday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Saturday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Sunday0
+  fields:
+  - value
+  values:
+  - 03:00;24:00;20.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z2Timer_Sunday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Sunday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Thursday0
+  fields:
+  - value
+  values:
+  - 03:00;24:00;20.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z2Timer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Timeframes
+  fields:
+  - value
+  values:
+  - 1;1;1;1;1;1;1
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z2Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Tuesday0
+  fields:
+  - value
+  values:
+  - 03:00;24:00;20.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z2Timer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Wednesday0
+  fields:
+  - value
+  values:
+  - 03:00;24:00;20.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z2Timer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3QuickVetoEndDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3QuickVetoEndTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3RoomTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z3RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Config
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Friday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Friday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Friday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Monday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Monday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Monday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Saturday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Saturday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Saturday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Sunday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Sunday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Sunday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Thursday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Timeframes
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Tuesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Wednesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: BuildingCircuitFlow
+  fields:
+  - value
+  values:
+  - '769'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: BuildingCircuitPumpSpeed
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Clearerrorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: CompressorBlocktime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: CompressorHc
+  fields:
+  - value
+  values:
+  - 187179;4337
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CompressorHc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHwc
+  fields:
+  - value
+  values:
+  - 52345;737
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CompressorHwc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHwc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CopCooling
+  fields:
+  - value
+  values:
+  - '6.8'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CopCoolingMonth
+  fields:
+  - value
+  values:
+  - '6.6'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CopHc
+  fields:
+  - value
+  values:
+  - '3.4'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CopHcMonth
+  fields:
+  - value
+  values:
+  - '1.1'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CopHwc
+  fields:
+  - value
+  values:
+  - '2.7'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CopHwcMonth
+  fields:
+  - value
+  values:
+  - '3.5'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CurrentCompressorUtil
+  fields:
+  - value
+  values:
+  - '0.00'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CurrentConsumedPower
+  fields:
+  - value
+  values:
+  - '0.4'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CurrentYieldPower
+  fields:
+  - value
+  values:
+  - '2.5'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - -;-;-;-;-
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: DateTime
+  fields:
+  - value
+  values:
+  - nosignal;-:-:-;-.-.-;-
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: EnergyIntegral
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: FlowPressure
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: FlowTemp
+  fields:
+  - value
+  values:
+  - '22.62'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: FlowTemperature
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: HoursCool
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: PowerConsumptionHmu
+  fields:
+  - value
+  values:
+  - '0.028224209'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataAirInletTemp
+  fields:
+  - value
+  values:
+  - '24.4843'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataBuildingCPumpPower
+  fields:
+  - value
+  values:
+  - '62.5333'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataCompressorInletTemp
+  fields:
+  - value
+  values:
+  - '21.3901'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataCompressorOutletTemp
+  fields:
+  - value
+  values:
+  - '39.6602'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataCompressorSpeed
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataEEVOutletTemp
+  fields:
+  - value
+  values:
+  - '23.9375'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataEEVPositionAbs
+  fields:
+  - value
+  values:
+  - '250'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataFan1Speed
+  fields:
+  - value
+  values:
+  - '506.881'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataFan2Speed
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataHighPressure
+  fields:
+  - value
+  values:
+  - '6.91209'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataLowPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunDataStatuscode
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStats4PortValveHours
+  fields:
+  - value
+  values:
+  - '320'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStats4PortValveSwitches
+  fields:
+  - value
+  values:
+  - '1305'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsBuildingCPumpStarts
+  fields:
+  - value
+  values:
+  - '2140'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsBuildingPumpHours
+  fields:
+  - value
+  values:
+  - '11315'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsCompressorHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunStatsCompressorHc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHours
+  fields:
+  - value
+  values:
+  - '4287'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsCompressorHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunStatsCompressorHwc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHwc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorStarts
+  fields:
+  - value
+  values:
+  - '6150'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsFan1Hours
+  fields:
+  - value
+  values:
+  - '4725'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsFan1Starts
+  fields:
+  - value
+  values:
+  - '8489'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsFan2Hours
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsFan2Starts
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsHMUHours
+  fields:
+  - value
+  values:
+  - '17725'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsHcHours
+  fields:
+  - value
+  values:
+  - '8204'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsHwcHours
+  fields:
+  - value
+  values:
+  - '914'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: SetMode
+  fields:
+  - value
+  values:
+  - auto;21.0;-;-;1;1;1;0;0;1
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: SetMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: StatElectricEnergySumCool
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatEnvironmentEnergySumCool
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: Status01
+  fields:
+  - value
+  values:
+  - 20.0;20.0;-;-;-;off
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: Status01.pumpstate
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.temp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.temp_1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.temp_2
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: Status01.temp_3
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: Status01.temp_4
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: Status02
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: Status16
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: StatusCirPump
+  fields:
+  - value
+  values:
+  - 'off'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: SupplyTempWeighted
+  fields:
+  - value
+  values:
+  - '22.00'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: TotalEnergyUsage
+  fields:
+  - value
+  values:
+  - '3517'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldCoolDay
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldCooling
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldCoolingMonth
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldHc
+  fields:
+  - value
+  values:
+  - '6225'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldHcDay
+  fields:
+  - value
+  values:
+  - '0.1'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldHcMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: YieldHwc
+  fields:
+  - value
+  values:
+  - '1857'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldHwcDay
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: YieldHwcMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: BypassPosition
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: ExhaustAirHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: ExhaustAirTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: MaxAirHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: MinAirHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: OutsideAirTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: SupplyAirTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: VentilationLevelDay
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: VentilationLevelNight
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldToday
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldTotal
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldYear
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Clearerrorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vr_71
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vr_71
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vr_71
+  name: Mc1Operation
+  fields:
+  - value
+  values:
+  - 2;21.0;on;-10
+  writable: false
+  has_data: true
+- circuit: vr_71
+  name: Mc2Operation
+  fields:
+  - value
+  values:
+  - off;0.0;on;-100
+  writable: false
+  has_data: true
+- circuit: vr_71
+  name: Mc3Operation
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vr_71
+  name: SensorData1
+  fields:
+  - value
+  values:
+  - -;19.62;23.12;-;-;-;-;41 01
+  writable: false
+  has_data: true
+- circuit: vr_71
+  name: SensorData2
+  fields:
+  - value
+  values:
+  - -;-;-;-;0.00;8.00;80 54 05
+  writable: false
+  has_data: true
+- circuit: vr_71
+  name: SetActorState
+  fields:
+  - value
+  values:
+  - -;-;off;on;off;off;-;-;-;-;off;off;00 00
+  writable: false
+  has_data: true
+- circuit: vwz
+  name: TestHwcTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: vwz
+  name: TestOutdoorTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: vwz
+  name: TestThreeWayValve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: vwzio
+  name: EnableTestHwcTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: EnableTestOutdoorTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: EnableTestThreeWayValve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: TestHwcTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: TestOutdoorTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: TestThreeWayValve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+grab:
+- '[grab] grab started'
+- '1008b5100900002affffff070004 / 0101 = 2: hmu SetMode'
+- 1076b5110101 / 09ffff2018ff630000ff = 1
+- 7108b5110107 / 0a00160081103600000000 = 4
+- '1008b5110101 / 0928280080ffff0000ff = 1: hmu Status01'
+- '1026b5230106 / 1000803b01720100800080008000804101 = 2: vr_71 SensorData1'
+- '1026b5230107 / 0f008000800080008000008000805405 = 2: vr_71 SensorData2'
+- '1026b5230f05ffff00140000ffffffff00000000 / 0101 = 2: vr_71 SetActorState'
+- '1026b523040200022a / 0201f6 = 2: vr_71 Mc1Operation'
+- '1026b5230402010000 / 02019c = 2: vr_71 Mc2Operation'
+- 1076b512030f0101 / 071c03000080ff03 = 2
+- 1076b51009000000ffffff050000 / 0101 = 2
+- f115b52406020001000f00 / 0601010f000000 = 1
+- f115b52406020003001b00 / 0601031b000000 = 1
+- f115b52406020003011b00 / 0601031b000000 = 1
+- 0376b51206130012040200 / 0200ff = 2
+- '3115b52406020003002800 / 080303280000004442 = 2: ctlv2 z1RoomHumidity'
+- '[grab stop] grab stopped'
+after_registers:
+- circuit: Broadcast
+  name: Datetime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Error
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: Broadcast
+  name: HwcStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Id
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: IdAnswer
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: IdQuery
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Load
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Outsidetemp
+  fields:
+  - value
+  values:
+  - '24.062'
+  writable: false
+  has_data: true
+- circuit: Broadcast
+  name: Queryexistence
+  fields:
+  - value
+  values:
+  - (empty for 31fe07fe00 / )
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Signoflife
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Vdatetime
+  fields:
+  - value
+  values:
+  - 08:41:24;14.08.2026
+  writable: false
+  has_data: true
+- circuit: Broadcast
+  name: Vdatetime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: WaterPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: General
+  name: Valuerange
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Eeprom
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Eeprom
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Ram
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Ram
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Scan
+  name: Id
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Scan.08
+  name: Id
+  fields:
+  - value
+  values:
+  - 21;24;18;0010047380;1300;105808;N4
+  writable: false
+  has_data: true
+- circuit: Scan.15
+  name: Id
+  fields:
+  - value
+  values:
+  - 21;23;44;0020260921;0953;015178;N9
+  writable: false
+  has_data: true
+- circuit: Scan.26
+  name: Id
+  fields:
+  - value
+  values:
+  - 21;23;16;0020184847;0082;016128;N6
+  writable: false
+  has_data: true
+- circuit: Scan.35
+  name: Id
+  fields:
+  - value
+  values:
+  - 21;21;06;0020260925;0953;006869;N7
+  writable: false
+  has_data: true
+- circuit: Scan.76
+  name: Id
+  fields:
+  - value
+  values:
+  - 21;24;17;0010031644;0082;009808;N6
+  writable: false
+  has_data: true
+- circuit: Scan.f6
+  name: Id
+  fields:
+  - value
+  values:
+  - 21;23;22;0020292012;0933;097000;N1
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: AdaptHeatCurve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: CcTimer_Config
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: CcTimer_Timeframes
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: ContinuousHeating
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: CylinderChargeHyst
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: CylinderChargeOffset
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Date
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: DisplayedOutsideTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: FrostOverRideTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1AutoOffMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1CircuitType
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1CoolingEnabled
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1CoolingFlowTempMin
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1DewPointMonitoring
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1DewPointOffset
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1ExcessTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1HeatCurve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MixerMovement
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1PumpStatus
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1RoomTempModulation
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1Status
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1SummerTempLimit
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2AutoOffMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2CircuitType
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2ExcessTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2HeatCurve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MixerMovement
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2PumpStatus
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2Status
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2SummerTempLimit
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3AutoOffMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3CircuitType
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3ExcessTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3HeatCurve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MixerMovement
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3PumpStatus
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3Status
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3SummerTempLimit
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HcStorageTempBottom
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: ctlv2
+  name: HcStorageTempTop
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: ctlv2
+  name: HwcFlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcLockTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcMaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcOpMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcParallelLoading
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcSFMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcSfMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcStorageTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcStorageTempBottom
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcStorageTempTop
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HydraulicScheme
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: MaxCylinderChargeTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: MaxRoomHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: MultiRelaySetting
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: OutsideTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: OutsideTempAvg
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySum
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHcLastMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHcThisMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHwcLastMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHwcThisMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: SystemFlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: WaterPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingManualTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingOpMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingSetbackTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1DayTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1HolidayTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1NightTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1OpMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoDuration
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoEndDate
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoEndTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1RoomTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1SFMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z2RoomTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: z1RoomHumidity
+  fields:
+  - value
+  values:
+  - '49'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: AdaptHeatCurve
+  fields:
+  - value
+  values:
+  - 'yes'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: AdaptHeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Config
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Friday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Friday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Friday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Monday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Monday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Monday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Saturday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Saturday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Saturday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Sunday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Sunday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Sunday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Thursday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Timeframes
+  fields:
+  - value
+  values:
+  - 0;0;0;0;0;0;0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CcTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Tuesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Wednesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Clearerrorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: ContinuousHeating
+  fields:
+  - value
+  values:
+  - '-26'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: ContinuousHeating
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - -;-;-;-;-
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CylinderChargeHyst
+  fields:
+  - value
+  values:
+  - '7'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CylinderChargeHyst
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CylinderChargeOffset
+  fields:
+  - value
+  values:
+  - '5'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CylinderChargeOffset
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Date
+  fields:
+  - value
+  values:
+  - 14.08.2026
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Date
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: DisplayedOutsideTemp
+  fields:
+  - value
+  values:
+  - '23.875'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: FrostOverRideTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: FrostOverRideTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - '21'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1AutoOffMode
+  fields:
+  - value
+  values:
+  - night
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1AutoOffMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1CircuitType
+  fields:
+  - value
+  values:
+  - mixer
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1ExcessTemp
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1ExcessTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1FlowTemp
+  fields:
+  - value
+  values:
+  - '19.0625'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1HeatCurve
+  fields:
+  - value
+  values:
+  - '0.4'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1HeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '50'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - '21'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - '25'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1MixerMovement
+  fields:
+  - value
+  values:
+  - '-15'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1PumpStatus
+  fields:
+  - value
+  values:
+  - '2'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1PumpStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - modulating
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1SummerTempLimit
+  fields:
+  - value
+  values:
+  - '16'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1SummerTempLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2AutoOffMode
+  fields:
+  - value
+  values:
+  - night
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2AutoOffMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2CircuitType
+  fields:
+  - value
+  values:
+  - mixer
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2ExcessTemp
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2ExcessTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2FlowTemp
+  fields:
+  - value
+  values:
+  - '23.125'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2HeatCurve
+  fields:
+  - value
+  values:
+  - '0.3'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2HeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '50'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - '15'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2MixerMovement
+  fields:
+  - value
+  values:
+  - '-100'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2PumpStatus
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2PumpStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - modulating
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2SummerTempLimit
+  fields:
+  - value
+  values:
+  - '16'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2SummerTempLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3AutoOffMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3AutoOffMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3CircuitType
+  fields:
+  - value
+  values:
+  - inactive
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3ExcessTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3ExcessTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3FlowTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3HeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3HeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3MixerMovement
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3PumpStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3PumpStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3SummerTempLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3SummerTempLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HcStorageTempBottom
+  fields:
+  - value
+  values:
+  - (empty for f115b5240602000000a000 / 080000a000ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HcStorageTempTop
+  fields:
+  - value
+  values:
+  - (empty for f115b52406020000009f00 / 0800009f00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcBankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcBankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcBankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcBankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcFlowTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcLockTime
+  fields:
+  - value
+  values:
+  - '30'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcLockTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcMaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '80'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcMaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcOpMode
+  fields:
+  - value
+  values:
+  - auto
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcOpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcParallelLoading
+  fields:
+  - value
+  values:
+  - 'off'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcParallelLoading
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcSFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcSFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcStorageTemp
+  fields:
+  - value
+  values:
+  - '49.5'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcStorageTempBottom
+  fields:
+  - value
+  values:
+  - (empty for f115b52406020000009e00 / 0800009e00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcStorageTempTop
+  fields:
+  - value
+  values:
+  - (empty for f115b52406020000009d00 / 0800009d00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTempDesired
+  fields:
+  - value
+  values:
+  - '52'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Config
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Friday0
+  fields:
+  - value
+  values:
+  - 01:00;03:00;52.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcTimer_Friday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Friday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Monday0
+  fields:
+  - value
+  values:
+  - 01:00;03:00;52.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcTimer_Monday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Monday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Saturday0
+  fields:
+  - value
+  values:
+  - 01:00;03:00;52.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcTimer_Saturday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Saturday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Sunday0
+  fields:
+  - value
+  values:
+  - 01:00;03:00;52.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcTimer_Sunday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Sunday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Thursday0
+  fields:
+  - value
+  values:
+  - 01:00;03:00;52.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcTimer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Timeframes
+  fields:
+  - value
+  values:
+  - 1;1;1;1;1;1;1
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Tuesday0
+  fields:
+  - value
+  values:
+  - 01:00;03:00;52.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcTimer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Wednesday0
+  fields:
+  - value
+  values:
+  - 01:00;03:00;52.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcTimer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HydraulicScheme
+  fields:
+  - value
+  values:
+  - '8'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HydraulicScheme
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Installer1
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Installer1
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Installer2
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Installer2
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: KeyCodeforConfigMenu
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: KeyCodeforConfigMenu
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: MaintenanceDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: MaintenanceDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: MaintenanceDue
+  fields:
+  - value
+  values:
+  - 'no'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: MaxCylinderChargeTime
+  fields:
+  - value
+  values:
+  - '120'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: MaxCylinderChargeTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: MaxRoomHumidity
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: MaxRoomHumidity
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: MultiRelaySetting
+  fields:
+  - value
+  values:
+  - '4'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: MultiRelaySetting
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: OutsideTempAvg
+  fields:
+  - value
+  values:
+  - '24.8125'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: OutsideTempAvg
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PhoneNumber1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PhoneNumber1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PhoneNumber2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PhoneNumber2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHwc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHwc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHwcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHwcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHwcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHwcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHwc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHwc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHwcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHwcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHwcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHwcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PumpAdditionalTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PumpAdditionalTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: SolarYieldTotal
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: SolarYieldTotal
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: SystemFlowTemp
+  fields:
+  - value
+  values:
+  - (empty for f115b52406020000004b00 / 0800004b00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Time
+  fields:
+  - value
+  values:
+  - 07:42:04
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Time
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: WaterPressure
+  fields:
+  - value
+  values:
+  - '1.8'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: YieldTotal
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: YieldTotal
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1CoolingTemp
+  fields:
+  - value
+  values:
+  - '24'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1CoolingTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1DayTemp
+  fields:
+  - value
+  values:
+  - '21'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1HolidayTemp
+  fields:
+  - value
+  values:
+  - '20'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Name1
+  fields:
+  - value
+  values:
+  - Downs
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Name2
+  fields:
+  - value
+  values:
+  - tairs
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1NightTemp
+  fields:
+  - value
+  values:
+  - '20'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1OpMode
+  fields:
+  - value
+  values:
+  - day
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1QuickVetoEndDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1QuickVetoEndTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1RoomTemp
+  fields:
+  - value
+  values:
+  - '24.7875'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Config
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Friday0
+  fields:
+  - value
+  values:
+  - 00:00;24:00;21.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Friday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Friday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Monday0
+  fields:
+  - value
+  values:
+  - 00:00;24:00;21.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Monday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Monday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Saturday0
+  fields:
+  - value
+  values:
+  - 00:00;24:00;21.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Saturday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Saturday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Sunday0
+  fields:
+  - value
+  values:
+  - 00:00;24:00;21.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Sunday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Sunday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Thursday0
+  fields:
+  - value
+  values:
+  - 00:00;24:00;21.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Timeframes
+  fields:
+  - value
+  values:
+  - 1;1;1;1;1;1;1
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Tuesday0
+  fields:
+  - value
+  values:
+  - 00:00;24:00;21.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Wednesday0
+  fields:
+  - value
+  values:
+  - 00:00;24:00;21.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z2ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2CoolingTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2CoolingTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2DayTemp
+  fields:
+  - value
+  values:
+  - '20.5'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z2DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z2HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z2HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2HolidayTemp
+  fields:
+  - value
+  values:
+  - '20'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z2HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Name1
+  fields:
+  - value
+  values:
+  - Upsta
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z2Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Name2
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for f115b52406020003011800 / 080303180069727300)'
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2NightTemp
+  fields:
+  - value
+  values:
+  - '21'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z2NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2OpMode
+  fields:
+  - value
+  values:
+  - auto
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z2OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2QuickVetoEndDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2QuickVetoEndTime
+  fields:
+  - value
+  values:
+  - 00:00:00
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z2QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2RoomTemp
+  fields:
+  - value
+  values:
+  - '26.4125'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z2RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z2RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Config
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Friday0
+  fields:
+  - value
+  values:
+  - 03:00;24:00;20.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z2Timer_Friday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Friday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Monday0
+  fields:
+  - value
+  values:
+  - 03:00;24:00;20.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z2Timer_Monday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Monday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Saturday0
+  fields:
+  - value
+  values:
+  - 03:00;24:00;20.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z2Timer_Saturday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Saturday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Sunday0
+  fields:
+  - value
+  values:
+  - 03:00;24:00;20.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z2Timer_Sunday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Sunday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Thursday0
+  fields:
+  - value
+  values:
+  - 03:00;24:00;20.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z2Timer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Timeframes
+  fields:
+  - value
+  values:
+  - 1;1;1;1;1;1;1
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z2Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Tuesday0
+  fields:
+  - value
+  values:
+  - 03:00;24:00;20.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z2Timer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Wednesday0
+  fields:
+  - value
+  values:
+  - 03:00;24:00;20.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z2Timer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3QuickVetoEndDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3QuickVetoEndTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3RoomTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z3RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Config
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Friday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Friday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Friday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Monday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Monday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Monday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Saturday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Saturday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Saturday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Sunday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Sunday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Sunday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Thursday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Timeframes
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Tuesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Wednesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: BuildingCircuitFlow
+  fields:
+  - value
+  values:
+  - '769'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: BuildingCircuitPumpSpeed
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Clearerrorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: CompressorBlocktime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: CompressorHc
+  fields:
+  - value
+  values:
+  - 187179;4337
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CompressorHc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHwc
+  fields:
+  - value
+  values:
+  - 52345;737
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CompressorHwc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHwc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CopCooling
+  fields:
+  - value
+  values:
+  - '6.8'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CopCoolingMonth
+  fields:
+  - value
+  values:
+  - '6.6'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CopHc
+  fields:
+  - value
+  values:
+  - '3.4'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CopHcMonth
+  fields:
+  - value
+  values:
+  - '1.1'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CopHwc
+  fields:
+  - value
+  values:
+  - '2.7'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CopHwcMonth
+  fields:
+  - value
+  values:
+  - '3.5'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CurrentCompressorUtil
+  fields:
+  - value
+  values:
+  - '0.00'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CurrentConsumedPower
+  fields:
+  - value
+  values:
+  - '0.4'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CurrentYieldPower
+  fields:
+  - value
+  values:
+  - '2.5'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - -;-;-;-;-
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: DateTime
+  fields:
+  - value
+  values:
+  - nosignal;-:-:-;-.-.-;-
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: EnergyIntegral
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: FlowPressure
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: FlowTemp
+  fields:
+  - value
+  values:
+  - '22.62'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: FlowTemperature
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: HoursCool
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: PowerConsumptionHmu
+  fields:
+  - value
+  values:
+  - '0.028224209'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataAirInletTemp
+  fields:
+  - value
+  values:
+  - '24.4843'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataBuildingCPumpPower
+  fields:
+  - value
+  values:
+  - '62.5333'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataCompressorInletTemp
+  fields:
+  - value
+  values:
+  - '21.3901'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataCompressorOutletTemp
+  fields:
+  - value
+  values:
+  - '39.6602'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataCompressorSpeed
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataEEVOutletTemp
+  fields:
+  - value
+  values:
+  - '23.9375'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataEEVPositionAbs
+  fields:
+  - value
+  values:
+  - '250'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataFan1Speed
+  fields:
+  - value
+  values:
+  - '506.881'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataFan2Speed
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataHighPressure
+  fields:
+  - value
+  values:
+  - '6.91209'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataLowPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunDataStatuscode
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStats4PortValveHours
+  fields:
+  - value
+  values:
+  - '320'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStats4PortValveSwitches
+  fields:
+  - value
+  values:
+  - '1305'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsBuildingCPumpStarts
+  fields:
+  - value
+  values:
+  - '2140'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsBuildingPumpHours
+  fields:
+  - value
+  values:
+  - '11315'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsCompressorHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunStatsCompressorHc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHours
+  fields:
+  - value
+  values:
+  - '4287'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsCompressorHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunStatsCompressorHwc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHwc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorStarts
+  fields:
+  - value
+  values:
+  - '6150'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsFan1Hours
+  fields:
+  - value
+  values:
+  - '4725'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsFan1Starts
+  fields:
+  - value
+  values:
+  - '8489'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsFan2Hours
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsFan2Starts
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsHMUHours
+  fields:
+  - value
+  values:
+  - '17725'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsHcHours
+  fields:
+  - value
+  values:
+  - '8204'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsHwcHours
+  fields:
+  - value
+  values:
+  - '914'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: SetMode
+  fields:
+  - value
+  values:
+  - auto;21.0;-;-;1;1;1;0;0;1
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: SetMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: StatElectricEnergySumCool
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatEnvironmentEnergySumCool
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: Status01
+  fields:
+  - value
+  values:
+  - 20.0;20.0;-;-;-;off
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: Status01.pumpstate
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.temp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.temp_1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.temp_2
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: Status01.temp_3
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: Status01.temp_4
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: Status02
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: Status16
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: StatusCirPump
+  fields:
+  - value
+  values:
+  - 'off'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: SupplyTempWeighted
+  fields:
+  - value
+  values:
+  - '22.00'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: TotalEnergyUsage
+  fields:
+  - value
+  values:
+  - '3517'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldCoolDay
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldCooling
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldCoolingMonth
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldHc
+  fields:
+  - value
+  values:
+  - '6225'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldHcDay
+  fields:
+  - value
+  values:
+  - '0.1'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldHcMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: YieldHwc
+  fields:
+  - value
+  values:
+  - '1857'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldHwcDay
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: YieldHwcMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: BypassPosition
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: ExhaustAirHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: ExhaustAirTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: MaxAirHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: MinAirHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: OutsideAirTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: SupplyAirTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: VentilationLevelDay
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: VentilationLevelNight
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldToday
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldTotal
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldYear
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Clearerrorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vr_71
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vr_71
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vr_71
+  name: Mc1Operation
+  fields:
+  - value
+  values:
+  - 2;21.0;on;-10
+  writable: false
+  has_data: true
+- circuit: vr_71
+  name: Mc2Operation
+  fields:
+  - value
+  values:
+  - off;0.0;on;-100
+  writable: false
+  has_data: true
+- circuit: vr_71
+  name: Mc3Operation
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vr_71
+  name: SensorData1
+  fields:
+  - value
+  values:
+  - -;19.69;23.12;-;-;-;-;41 01
+  writable: false
+  has_data: true
+- circuit: vr_71
+  name: SensorData2
+  fields:
+  - value
+  values:
+  - -;-;-;-;0.00;8.00;80 54 05
+  writable: false
+  has_data: true
+- circuit: vr_71
+  name: SetActorState
+  fields:
+  - value
+  values:
+  - -;-;off;on;off;off;-;-;-;-;off;off;00 00
+  writable: false
+  has_data: true
+- circuit: vwz
+  name: TestHwcTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: vwz
+  name: TestOutdoorTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: vwz
+  name: TestThreeWayValve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: vwzio
+  name: EnableTestHwcTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: EnableTestOutdoorTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: EnableTestThreeWayValve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: TestHwcTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: TestOutdoorTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: TestThreeWayValve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+raw_find_lines_after:
+- Broadcast Datetime = no data stored
+- Broadcast Error = no data stored
+- Broadcast HwcStatus = no data stored
+- Broadcast Id = no data stored
+- Broadcast IdAnswer = no data stored
+- Broadcast IdQuery = no data stored
+- Broadcast Load = no data stored
+- Broadcast Outsidetemp = 24.062
+- Broadcast Queryexistence =  (empty for 31fe07fe00 / )
+- Broadcast Signoflife = no data stored
+- Broadcast Vdatetime = 08:41:24;14.08.2026
+- Broadcast Vdatetime = no data stored
+- ctlv2 z1RoomHumidity = 49
+- ctlv3 AdaptHeatCurve = yes
+- ctlv3 AdaptHeatCurve = no data stored
+- ctlv3 CcTimer_Config = no data stored
+- ctlv3 CcTimer_Friday0 = no data stored
+- ctlv3 CcTimer_Friday1 = no data stored
+- ctlv3 CcTimer_Friday2 = no data stored
+- ctlv3 CcTimer_Friday = no data stored
+- ctlv3 CcTimer_Monday0 = no data stored
+- ctlv3 CcTimer_Monday1 = no data stored
+- ctlv3 CcTimer_Monday2 = no data stored
+- ctlv3 CcTimer_Monday = no data stored
+- ctlv3 CcTimer_Saturday0 = no data stored
+- ctlv3 CcTimer_Saturday1 = no data stored
+- ctlv3 CcTimer_Saturday2 = no data stored
+- ctlv3 CcTimer_Saturday = no data stored
+- ctlv3 CcTimer_Sunday0 = no data stored
+- ctlv3 CcTimer_Sunday1 = no data stored
+- ctlv3 CcTimer_Sunday2 = no data stored
+- ctlv3 CcTimer_Sunday = no data stored
+- ctlv3 CcTimer_Thursday0 = no data stored
+- ctlv3 CcTimer_Thursday1 = no data stored
+- ctlv3 CcTimer_Thursday2 = no data stored
+- ctlv3 CcTimer_Thursday = no data stored
+- ctlv3 CcTimer_Timeframes = 0;0;0;0;0;0;0
+- ctlv3 CcTimer_Tuesday0 = no data stored
+- ctlv3 CcTimer_Tuesday1 = no data stored
+- ctlv3 CcTimer_Tuesday2 = no data stored
+- ctlv3 CcTimer_Tuesday = no data stored
+- ctlv3 CcTimer_Wednesday0 = no data stored
+- ctlv3 CcTimer_Wednesday1 = no data stored
+- ctlv3 CcTimer_Wednesday2 = no data stored
+- ctlv3 CcTimer_Wednesday = no data stored
+- ctlv3 Clearerrorhistory = no data stored
+- ctlv3 ContinuousHeating = -26
+- ctlv3 ContinuousHeating = no data stored
+- ctlv3 Currenterror = -;-;-;-;-
+- ctlv3 CylinderChargeHyst = 7
+- ctlv3 CylinderChargeHyst = no data stored
+- ctlv3 CylinderChargeOffset = 5
+- ctlv3 CylinderChargeOffset = no data stored
+- ctlv3 Date = 14.08.2026
+- ctlv3 Date = no data stored
+- ctlv3 DisplayedOutsideTemp = 23.875
+- ctlv3 Errorhistory = no data stored
+- ctlv3 FrostOverRideTime = no data stored
+- ctlv3 FrostOverRideTime = no data stored
+- ctlv3 Hc1ActualFlowTempDesired = 21
+- ctlv3 Hc1AutoOffMode = night
+- ctlv3 Hc1AutoOffMode = no data stored
+- ctlv3 Hc1CircuitType = mixer
+- ctlv3 Hc1ExcessTemp = 0.0
+- ctlv3 Hc1ExcessTemp = no data stored
+- ctlv3 Hc1FlowTemp = 19.0625
+- ctlv3 Hc1HeatCurve = 0.4
+- ctlv3 Hc1HeatCurve = no data stored
+- ctlv3 Hc1HeatCurveAdaption = 0.0
+- ctlv3 Hc1MaxFlowTempDesired = 50
+- ctlv3 Hc1MaxFlowTempDesired = no data stored
+- ctlv3 Hc1MinCoolingTempDesired = 21
+- ctlv3 Hc1MinCoolingTempDesired = no data stored
+- ctlv3 Hc1MinFlowTempDesired = 25
+- ctlv3 Hc1MinFlowTempDesired = no data stored
+- ctlv3 Hc1MixerMovement = -15
+- ctlv3 Hc1PumpStatus = 2
+- ctlv3 Hc1PumpStatus = no data stored
+- ctlv3 Hc1RoomTempSwitchOn = modulating
+- ctlv3 Hc1RoomTempSwitchOn = no data stored
+- ctlv3 Hc1Status = no data stored
+- ctlv3 Hc1Status = no data stored
+- ctlv3 Hc1SummerTempLimit = 16
+- ctlv3 Hc1SummerTempLimit = no data stored
+- ctlv3 Hc2ActualFlowTempDesired = 0.0
+- ctlv3 Hc2AutoOffMode = night
+- ctlv3 Hc2AutoOffMode = no data stored
+- ctlv3 Hc2CircuitType = mixer
+- ctlv3 Hc2ExcessTemp = 0.0
+- ctlv3 Hc2ExcessTemp = no data stored
+- ctlv3 Hc2FlowTemp = 23.125
+- ctlv3 Hc2HeatCurve = 0.3
+- ctlv3 Hc2HeatCurve = no data stored
+- ctlv3 Hc2HeatCurveAdaption = 0.0
+- ctlv3 Hc2MaxFlowTempDesired = 50
+- ctlv3 Hc2MaxFlowTempDesired = no data stored
+- ctlv3 Hc2MinCoolingTempDesired = no data stored
+- ctlv3 Hc2MinCoolingTempDesired = no data stored
+- ctlv3 Hc2MinFlowTempDesired = 15
+- ctlv3 Hc2MinFlowTempDesired = no data stored
+- ctlv3 Hc2MixerMovement = -100
+- ctlv3 Hc2PumpStatus = 0
+- ctlv3 Hc2PumpStatus = no data stored
+- ctlv3 Hc2RoomTempSwitchOn = modulating
+- ctlv3 Hc2RoomTempSwitchOn = no data stored
+- ctlv3 Hc2Status = no data stored
+- ctlv3 Hc2Status = no data stored
+- ctlv3 Hc2SummerTempLimit = 16
+- ctlv3 Hc2SummerTempLimit = no data stored
+- ctlv3 Hc3ActualFlowTempDesired = no data stored
+- ctlv3 Hc3AutoOffMode = no data stored
+- ctlv3 Hc3AutoOffMode = no data stored
+- ctlv3 Hc3CircuitType = inactive
+- ctlv3 Hc3ExcessTemp = no data stored
+- ctlv3 Hc3ExcessTemp = no data stored
+- ctlv3 Hc3FlowTemp = no data stored
+- ctlv3 Hc3HeatCurve = no data stored
+- ctlv3 Hc3HeatCurve = no data stored
+- ctlv3 Hc3HeatCurveAdaption = no data stored
+- ctlv3 Hc3MaxFlowTempDesired = no data stored
+- ctlv3 Hc3MaxFlowTempDesired = no data stored
+- ctlv3 Hc3MinCoolingTempDesired = no data stored
+- ctlv3 Hc3MinCoolingTempDesired = no data stored
+- ctlv3 Hc3MinFlowTempDesired = no data stored
+- ctlv3 Hc3MinFlowTempDesired = no data stored
+- ctlv3 Hc3MixerMovement = no data stored
+- ctlv3 Hc3PumpStatus = no data stored
+- ctlv3 Hc3PumpStatus = no data stored
+- ctlv3 Hc3RoomTempSwitchOn = no data stored
+- ctlv3 Hc3RoomTempSwitchOn = no data stored
+- ctlv3 Hc3Status = no data stored
+- ctlv3 Hc3Status = no data stored
+- ctlv3 Hc3SummerTempLimit = no data stored
+- ctlv3 Hc3SummerTempLimit = no data stored
+- ctlv3 HcStorageTempBottom =  (empty for f115b5240602000000a000 / 080000a000ffffff7f)
+- ctlv3 HcStorageTempTop =  (empty for f115b52406020000009f00 / 0800009f00ffffff7f)
+- ctlv3 HwcBankHolidayEndPeriod = no data stored
+- ctlv3 HwcBankHolidayEndPeriod = no data stored
+- ctlv3 HwcBankHolidayStartPeriod = no data stored
+- ctlv3 HwcBankHolidayStartPeriod = no data stored
+- ctlv3 HwcFlowTemp = no data stored
+- ctlv3 HwcHolidayEndPeriod = 01.01.2019
+- ctlv3 HwcHolidayEndPeriod = no data stored
+- ctlv3 HwcHolidayStartPeriod = 01.01.2019
+- ctlv3 HwcHolidayStartPeriod = no data stored
+- ctlv3 HwcLockTime = 30
+- ctlv3 HwcLockTime = no data stored
+- ctlv3 HwcMaxFlowTempDesired = 80
+- ctlv3 HwcMaxFlowTempDesired = no data stored
+- ctlv3 HwcOpMode = auto
+- ctlv3 HwcOpMode = no data stored
+- ctlv3 HwcParallelLoading = off
+- ctlv3 HwcParallelLoading = no data stored
+- ctlv3 HwcSFMode = no data stored
+- ctlv3 HwcSFMode = no data stored
+- ctlv3 HwcStorageTemp = 49.5
+- ctlv3 HwcStorageTempBottom =  (empty for f115b52406020000009e00 / 0800009e00ffffff7f)
+- ctlv3 HwcStorageTempTop =  (empty for f115b52406020000009d00 / 0800009d00ffffff7f)
+- ctlv3 HwcTempDesired = 52
+- ctlv3 HwcTempDesired = no data stored
+- ctlv3 HwcTimer_Config = no data stored
+- ctlv3 HwcTimer_Friday0 = 01:00;03:00;52.0
+- ctlv3 HwcTimer_Friday1 = no data stored
+- ctlv3 HwcTimer_Friday2 = no data stored
+- ctlv3 HwcTimer_Friday = no data stored
+- ctlv3 HwcTimer_Monday0 = 01:00;03:00;52.0
+- ctlv3 HwcTimer_Monday1 = no data stored
+- ctlv3 HwcTimer_Monday2 = no data stored
+- ctlv3 HwcTimer_Monday = no data stored
+- ctlv3 HwcTimer_Saturday0 = 01:00;03:00;52.0
+- ctlv3 HwcTimer_Saturday1 = no data stored
+- ctlv3 HwcTimer_Saturday2 = no data stored
+- ctlv3 HwcTimer_Saturday = no data stored
+- ctlv3 HwcTimer_Sunday0 = 01:00;03:00;52.0
+- ctlv3 HwcTimer_Sunday1 = no data stored
+- ctlv3 HwcTimer_Sunday2 = no data stored
+- ctlv3 HwcTimer_Sunday = no data stored
+- ctlv3 HwcTimer_Thursday0 = 01:00;03:00;52.0
+- ctlv3 HwcTimer_Thursday1 = no data stored
+- ctlv3 HwcTimer_Thursday2 = no data stored
+- ctlv3 HwcTimer_Thursday = no data stored
+- ctlv3 HwcTimer_Timeframes = 1;1;1;1;1;1;1
+- ctlv3 HwcTimer_Tuesday0 = 01:00;03:00;52.0
+- ctlv3 HwcTimer_Tuesday1 = no data stored
+- ctlv3 HwcTimer_Tuesday2 = no data stored
+- ctlv3 HwcTimer_Tuesday = no data stored
+- ctlv3 HwcTimer_Wednesday0 = 01:00;03:00;52.0
+- ctlv3 HwcTimer_Wednesday1 = no data stored
+- ctlv3 HwcTimer_Wednesday2 = no data stored
+- ctlv3 HwcTimer_Wednesday = no data stored
+- ctlv3 HydraulicScheme = 8
+- ctlv3 HydraulicScheme = no data stored
+- ctlv3 Installer1 = no data stored
+- ctlv3 Installer1 = no data stored
+- ctlv3 Installer2 = no data stored
+- ctlv3 Installer2 = no data stored
+- ctlv3 KeyCodeforConfigMenu = no data stored
+- ctlv3 KeyCodeforConfigMenu = no data stored
+- ctlv3 MaintenanceDate = no data stored
+- ctlv3 MaintenanceDate = no data stored
+- ctlv3 MaintenanceDue = no
+- ctlv3 MaxCylinderChargeTime = 120
+- ctlv3 MaxCylinderChargeTime = no data stored
+- ctlv3 MaxRoomHumidity = no data stored
+- ctlv3 MaxRoomHumidity = no data stored
+- ctlv3 MultiRelaySetting = 4
+- ctlv3 MultiRelaySetting = no data stored
+- ctlv3 OutsideTempAvg = 24.8125
+- ctlv3 OutsideTempAvg = no data stored
+- ctlv3 PhoneNumber1 = no data stored
+- ctlv3 PhoneNumber1 = no data stored
+- ctlv3 PhoneNumber2 = no data stored
+- ctlv3 PhoneNumber2 = no data stored
+- ctlv3 PrEnergySum = no data stored
+- ctlv3 PrEnergySum = no data stored
+- ctlv3 PrEnergySumHc = no data stored
+- ctlv3 PrEnergySumHc = no data stored
+- ctlv3 PrEnergySumHcLastMonth = no data stored
+- ctlv3 PrEnergySumHcLastMonth = no data stored
+- ctlv3 PrEnergySumHcThisMonth = no data stored
+- ctlv3 PrEnergySumHcThisMonth = no data stored
+- ctlv3 PrEnergySumHwc = no data stored
+- ctlv3 PrEnergySumHwc = no data stored
+- ctlv3 PrEnergySumHwcLastMonth = no data stored
+- ctlv3 PrEnergySumHwcLastMonth = no data stored
+- ctlv3 PrEnergySumHwcThisMonth = no data stored
+- ctlv3 PrEnergySumHwcThisMonth = no data stored
+- ctlv3 PrFuelSum = no data stored
+- ctlv3 PrFuelSum = no data stored
+- ctlv3 PrFuelSumHc = no data stored
+- ctlv3 PrFuelSumHc = no data stored
+- ctlv3 PrFuelSumHcLastMonth = no data stored
+- ctlv3 PrFuelSumHcLastMonth = no data stored
+- ctlv3 PrFuelSumHcThisMonth = no data stored
+- ctlv3 PrFuelSumHcThisMonth = no data stored
+- ctlv3 PrFuelSumHwc = no data stored
+- ctlv3 PrFuelSumHwc = no data stored
+- ctlv3 PrFuelSumHwcLastMonth = no data stored
+- ctlv3 PrFuelSumHwcLastMonth = no data stored
+- ctlv3 PrFuelSumHwcThisMonth = no data stored
+- ctlv3 PrFuelSumHwcThisMonth = no data stored
+- ctlv3 PumpAdditionalTime = no data stored
+- ctlv3 PumpAdditionalTime = no data stored
+- ctlv3 SolarYieldTotal = no data stored
+- ctlv3 SolarYieldTotal = no data stored
+- ctlv3 SystemFlowTemp =  (empty for f115b52406020000004b00 / 0800004b00ffffff7f)
+- ctlv3 Time = 07:42:04
+- ctlv3 Time = no data stored
+- ctlv3 WaterPressure = 1.8
+- ctlv3 YieldTotal = no data stored
+- ctlv3 YieldTotal = no data stored
+- ctlv3 Z1ActualRoomTempDesired = 0.0
+- ctlv3 Z1ActualRoomTempDesired = no data stored
+- ctlv3 Z1BankHolidayEndPeriod = no data stored
+- ctlv3 Z1BankHolidayEndPeriod = no data stored
+- ctlv3 Z1BankHolidayStartPeriod = no data stored
+- ctlv3 Z1BankHolidayStartPeriod = no data stored
+- ctlv3 Z1CoolingTemp = 24
+- ctlv3 Z1CoolingTemp = no data stored
+- ctlv3 Z1DayTemp = 21
+- ctlv3 Z1DayTemp = no data stored
+- ctlv3 Z1HolidayEndPeriod = 01.01.2019
+- ctlv3 Z1HolidayEndPeriod = no data stored
+- ctlv3 Z1HolidayStartPeriod = 01.01.2019
+- ctlv3 Z1HolidayStartPeriod = no data stored
+- ctlv3 Z1HolidayTemp = 20
+- ctlv3 Z1HolidayTemp = no data stored
+- ctlv3 Z1Name1 = Downs
+- ctlv3 Z1Name1 = no data stored
+- ctlv3 Z1Name2 = tairs
+- ctlv3 Z1Name2 = no data stored
+- ctlv3 Z1NightTemp = 20
+- ctlv3 Z1NightTemp = no data stored
+- ctlv3 Z1OpMode = day
+- ctlv3 Z1OpMode = no data stored
+- ctlv3 Z1QuickVetoDuration = no data stored
+- ctlv3 Z1QuickVetoDuration = no data stored
+- ctlv3 Z1QuickVetoEndDate = no data stored
+- ctlv3 Z1QuickVetoEndTime = no data stored
+- ctlv3 Z1QuickVetoTemp = no data stored
+- ctlv3 Z1QuickVetoTemp = no data stored
+- ctlv3 Z1RoomTemp = 24.7875
+- ctlv3 Z1RoomZoneMapping = VRC700
+- ctlv3 Z1RoomZoneMapping = no data stored
+- ctlv3 Z1SFMode = no data stored
+- ctlv3 Z1SFMode = no data stored
+- ctlv3 Z1Shortname = no data stored
+- ctlv3 Z1Shortname = no data stored
+- ctlv3 Z1Timer_Config = no data stored
+- ctlv3 Z1Timer_Friday0 = 00:00;24:00;21.0
+- ctlv3 Z1Timer_Friday1 = no data stored
+- ctlv3 Z1Timer_Friday2 = no data stored
+- ctlv3 Z1Timer_Friday = no data stored
+- ctlv3 Z1Timer_Monday0 = 00:00;24:00;21.0
+- ctlv3 Z1Timer_Monday1 = no data stored
+- ctlv3 Z1Timer_Monday2 = no data stored
+- ctlv3 Z1Timer_Monday = no data stored
+- ctlv3 Z1Timer_Saturday0 = 00:00;24:00;21.0
+- ctlv3 Z1Timer_Saturday1 = no data stored
+- ctlv3 Z1Timer_Saturday2 = no data stored
+- ctlv3 Z1Timer_Saturday = no data stored
+- ctlv3 Z1Timer_Sunday0 = 00:00;24:00;21.0
+- ctlv3 Z1Timer_Sunday1 = no data stored
+- ctlv3 Z1Timer_Sunday2 = no data stored
+- ctlv3 Z1Timer_Sunday = no data stored
+- ctlv3 Z1Timer_Thursday0 = 00:00;24:00;21.0
+- ctlv3 Z1Timer_Thursday1 = no data stored
+- ctlv3 Z1Timer_Thursday2 = no data stored
+- ctlv3 Z1Timer_Thursday = no data stored
+- ctlv3 Z1Timer_Timeframes = 1;1;1;1;1;1;1
+- ctlv3 Z1Timer_Tuesday0 = 00:00;24:00;21.0
+- ctlv3 Z1Timer_Tuesday1 = no data stored
+- ctlv3 Z1Timer_Tuesday2 = no data stored
+- ctlv3 Z1Timer_Tuesday = no data stored
+- ctlv3 Z1Timer_Wednesday0 = 00:00;24:00;21.0
+- ctlv3 Z1Timer_Wednesday1 = no data stored
+- ctlv3 Z1Timer_Wednesday2 = no data stored
+- ctlv3 Z1Timer_Wednesday = no data stored
+- ctlv3 Z1ValveStatus = no data stored
+- ctlv3 Z1ValveStatus = no data stored
+- ctlv3 Z2ActualRoomTempDesired = 0.0
+- ctlv3 Z2ActualRoomTempDesired = no data stored
+- ctlv3 Z2BankHolidayEndPeriod = no data stored
+- ctlv3 Z2BankHolidayEndPeriod = no data stored
+- ctlv3 Z2BankHolidayStartPeriod = no data stored
+- ctlv3 Z2BankHolidayStartPeriod = no data stored
+- ctlv3 Z2CoolingTemp = no data stored
+- ctlv3 Z2CoolingTemp = no data stored
+- ctlv3 Z2DayTemp = 20.5
+- ctlv3 Z2DayTemp = no data stored
+- ctlv3 Z2HolidayEndPeriod = 01.01.2019
+- ctlv3 Z2HolidayEndPeriod = no data stored
+- ctlv3 Z2HolidayStartPeriod = 01.01.2019
+- ctlv3 Z2HolidayStartPeriod = no data stored
+- ctlv3 Z2HolidayTemp = 20
+- ctlv3 Z2HolidayTemp = no data stored
+- ctlv3 Z2Name1 = Upsta
+- ctlv3 Z2Name1 = no data stored
+- 'ctlv3 Z2Name2 =  (ERR: invalid position for f115b52406020003011800 / 080303180069727300)'
+- ctlv3 Z2Name2 = no data stored
+- ctlv3 Z2NightTemp = 21
+- ctlv3 Z2NightTemp = no data stored
+- ctlv3 Z2OpMode = auto
+- ctlv3 Z2OpMode = no data stored
+- ctlv3 Z2QuickVetoDuration = no data stored
+- ctlv3 Z2QuickVetoDuration = no data stored
+- ctlv3 Z2QuickVetoEndDate = no data stored
+- ctlv3 Z2QuickVetoEndTime = 00:00:00
+- ctlv3 Z2QuickVetoTemp = no data stored
+- ctlv3 Z2QuickVetoTemp = no data stored
+- ctlv3 Z2RoomTemp = 26.4125
+- ctlv3 Z2RoomZoneMapping = VR91_1
+- ctlv3 Z2RoomZoneMapping = no data stored
+- ctlv3 Z2SFMode = no data stored
+- ctlv3 Z2SFMode = no data stored
+- ctlv3 Z2Shortname = no data stored
+- ctlv3 Z2Shortname = no data stored
+- ctlv3 Z2Timer_Config = no data stored
+- ctlv3 Z2Timer_Friday0 = 03:00;24:00;20.0
+- ctlv3 Z2Timer_Friday1 = no data stored
+- ctlv3 Z2Timer_Friday2 = no data stored
+- ctlv3 Z2Timer_Friday = no data stored
+- ctlv3 Z2Timer_Monday0 = 03:00;24:00;20.0
+- ctlv3 Z2Timer_Monday1 = no data stored
+- ctlv3 Z2Timer_Monday2 = no data stored
+- ctlv3 Z2Timer_Monday = no data stored
+- ctlv3 Z2Timer_Saturday0 = 03:00;24:00;20.0
+- ctlv3 Z2Timer_Saturday1 = no data stored
+- ctlv3 Z2Timer_Saturday2 = no data stored
+- ctlv3 Z2Timer_Saturday = no data stored
+- ctlv3 Z2Timer_Sunday0 = 03:00;24:00;20.0
+- ctlv3 Z2Timer_Sunday1 = no data stored
+- ctlv3 Z2Timer_Sunday2 = no data stored
+- ctlv3 Z2Timer_Sunday = no data stored
+- ctlv3 Z2Timer_Thursday0 = 03:00;24:00;20.0
+- ctlv3 Z2Timer_Thursday1 = no data stored
+- ctlv3 Z2Timer_Thursday2 = no data stored
+- ctlv3 Z2Timer_Thursday = no data stored
+- ctlv3 Z2Timer_Timeframes = 1;1;1;1;1;1;1
+- ctlv3 Z2Timer_Tuesday0 = 03:00;24:00;20.0
+- ctlv3 Z2Timer_Tuesday1 = no data stored
+- ctlv3 Z2Timer_Tuesday2 = no data stored
+- ctlv3 Z2Timer_Tuesday = no data stored
+- ctlv3 Z2Timer_Wednesday0 = 03:00;24:00;20.0
+- ctlv3 Z2Timer_Wednesday1 = no data stored
+- ctlv3 Z2Timer_Wednesday2 = no data stored
+- ctlv3 Z2Timer_Wednesday = no data stored
+- ctlv3 Z2ValveStatus = no data stored
+- ctlv3 Z2ValveStatus = no data stored
+- ctlv3 Z3ActualRoomTempDesired = no data stored
+- ctlv3 Z3ActualRoomTempDesired = no data stored
+- ctlv3 Z3BankHolidayEndPeriod = no data stored
+- ctlv3 Z3BankHolidayEndPeriod = no data stored
+- ctlv3 Z3BankHolidayStartPeriod = no data stored
+- ctlv3 Z3BankHolidayStartPeriod = no data stored
+- ctlv3 Z3DayTemp = no data stored
+- ctlv3 Z3DayTemp = no data stored
+- ctlv3 Z3HolidayEndPeriod = no data stored
+- ctlv3 Z3HolidayEndPeriod = no data stored
+- ctlv3 Z3HolidayStartPeriod = no data stored
+- ctlv3 Z3HolidayStartPeriod = no data stored
+- ctlv3 Z3HolidayTemp = no data stored
+- ctlv3 Z3HolidayTemp = no data stored
+- ctlv3 Z3Name1 = no data stored
+- ctlv3 Z3Name1 = no data stored
+- ctlv3 Z3Name2 = no data stored
+- ctlv3 Z3Name2 = no data stored
+- ctlv3 Z3NightTemp = no data stored
+- ctlv3 Z3NightTemp = no data stored
+- ctlv3 Z3OpMode = no data stored
+- ctlv3 Z3OpMode = no data stored
+- ctlv3 Z3QuickVetoDuration = no data stored
+- ctlv3 Z3QuickVetoDuration = no data stored
+- ctlv3 Z3QuickVetoEndDate = no data stored
+- ctlv3 Z3QuickVetoEndTime = no data stored
+- ctlv3 Z3QuickVetoTemp = no data stored
+- ctlv3 Z3QuickVetoTemp = no data stored
+- ctlv3 Z3RoomTemp = no data stored
+- ctlv3 Z3RoomZoneMapping = none
+- ctlv3 Z3RoomZoneMapping = no data stored
+- ctlv3 Z3SFMode = no data stored
+- ctlv3 Z3SFMode = no data stored
+- ctlv3 Z3Shortname = no data stored
+- ctlv3 Z3Shortname = no data stored
+- ctlv3 Z3Timer_Config = no data stored
+- ctlv3 Z3Timer_Friday0 = no data stored
+- ctlv3 Z3Timer_Friday1 = no data stored
+- ctlv3 Z3Timer_Friday2 = no data stored
+- ctlv3 Z3Timer_Friday = no data stored
+- ctlv3 Z3Timer_Monday0 = no data stored
+- ctlv3 Z3Timer_Monday1 = no data stored
+- ctlv3 Z3Timer_Monday2 = no data stored
+- ctlv3 Z3Timer_Monday = no data stored
+- ctlv3 Z3Timer_Saturday0 = no data stored
+- ctlv3 Z3Timer_Saturday1 = no data stored
+- ctlv3 Z3Timer_Saturday2 = no data stored
+- ctlv3 Z3Timer_Saturday = no data stored
+- ctlv3 Z3Timer_Sunday0 = no data stored
+- ctlv3 Z3Timer_Sunday1 = no data stored
+- ctlv3 Z3Timer_Sunday2 = no data stored
+- ctlv3 Z3Timer_Sunday = no data stored
+- ctlv3 Z3Timer_Thursday0 = no data stored
+- ctlv3 Z3Timer_Thursday1 = no data stored
+- ctlv3 Z3Timer_Thursday2 = no data stored
+- ctlv3 Z3Timer_Thursday = no data stored
+- ctlv3 Z3Timer_Timeframes = no data stored
+- ctlv3 Z3Timer_Tuesday0 = no data stored
+- ctlv3 Z3Timer_Tuesday1 = no data stored
+- ctlv3 Z3Timer_Tuesday2 = no data stored
+- ctlv3 Z3Timer_Tuesday = no data stored
+- ctlv3 Z3Timer_Wednesday0 = no data stored
+- ctlv3 Z3Timer_Wednesday1 = no data stored
+- ctlv3 Z3Timer_Wednesday2 = no data stored
+- ctlv3 Z3Timer_Wednesday = no data stored
+- ctlv3 Z3ValveStatus = no data stored
+- ctlv3 Z3ValveStatus = no data stored
+- General Valuerange = no data stored
+- hmu BuildingCircuitFlow = 769
+- hmu Clearerrorhistory = no data stored
+- hmu CompressorBlocktime = no data stored
+- hmu CompressorHc = 187179;4337
+- hmu CompressorHwc = 52345;737
+- hmu CopCooling = 6.8
+- hmu CopCoolingMonth = 6.6
+- hmu CopHc = 3.4
+- hmu CopHcMonth = 1.1
+- hmu CopHwc = 2.7
+- hmu CopHwcMonth = 3.5
+- hmu CurrentCompressorUtil = 0.00
+- hmu CurrentConsumedPower = 0.4
+- hmu Currenterror = -;-;-;-;-
+- hmu CurrentYieldPower = 2.5
+- hmu DateTime = nosignal;-:-:-;-.-.-;-
+- hmu EnergyIntegral = no data stored
+- hmu Errorhistory = no data stored
+- hmu FlowPressure = no data stored
+- hmu FlowTemp = 22.62
+- hmu PowerConsumptionHmu = 0.028224209
+- hmu RunDataAirInletTemp = 24.4843
+- hmu RunDataBuildingCPumpPower = 62.5333
+- hmu RunDataCompressorInletTemp = 21.3901
+- hmu RunDataCompressorOutletTemp = 39.6602
+- hmu RunDataCompressorSpeed = 0.0
+- hmu RunDataEEVOutletTemp = 23.9375
+- hmu RunDataEEVPositionAbs = 250
+- hmu RunDataFan1Speed = 506.881
+- hmu RunDataFan2Speed = 0.0
+- hmu RunDataHighPressure = 6.91209
+- hmu RunDataStatuscode = cool_compressor_shutdown
+- hmu RunStats4PortValveHours = 320
+- hmu RunStats4PortValveSwitches = 1305
+- hmu RunStatsBuildingCPumpStarts = 2140
+- hmu RunStatsBuildingPumpHours = 11315
+- hmu RunStatsCompressorHours = 4287
+- hmu RunStatsCompressorStarts = 6150
+- hmu RunStatsFan1Hours = 4725
+- hmu RunStatsFan1Starts = 8489
+- hmu RunStatsFan2Hours = 0
+- hmu RunStatsFan2Starts = 0
+- hmu RunStatsHcHours = 8204
+- hmu RunStatsHMUHours = 17725
+- hmu RunStatsHwcHours = 914
+- hmu SetMode = auto;21.0;-;-;1;1;1;0;0;1
+- hmu SetMode = no data stored
+- hmu Status01 = 20.0;20.0;-;-;-;off
+- hmu Status02 = no data stored
+- hmu Status16 = no data stored
+- hmu Status = no data stored
+- hmu StatusCirPump = off
+- hmu SupplyTempWeighted = 22.00
+- hmu TotalEnergyUsage = 3517
+- hmu YieldCoolDay = 0.0
+- hmu YieldCooling = 0.0
+- hmu YieldCoolingMonth = 0.0
+- hmu YieldHc = 6225
+- hmu YieldHcDay = 0.1
+- hmu YieldHcMonth = no data stored
+- hmu YieldHwc = 1857
+- hmu YieldHwcDay = no data stored
+- hmu YieldHwcMonth = no data stored
+- Memory Eeprom = no data stored
+- Memory Eeprom = no data stored
+- Memory Ram = no data stored
+- Memory Ram = no data stored
+- Scan Id = no data stored
+- scan.08  = Vaillant;HMU00;0902;5103
+- Scan.08 Id = 21;24;18;0010047380;1300;105808;N4
+- scan.15  = Vaillant;CTLV3;0709;3704
+- Scan.15 Id = 21;23;44;0020260921;0953;015178;N9
+- scan.26  = Vaillant;VR_71;0201;0503
+- Scan.26 Id = 21;23;16;0020184847;0082;016128;N6
+- scan.35  = Vaillant;VR_92;0122;9403
+- Scan.35 Id = 21;21;06;0020260925;0953;006869;N7
+- scan.76  = Vaillant;VWZIO;0202;0103
+- Scan.76 Id = 21;24;17;0010031644;0082;009808;N6
+- scan.f6  = Vaillant;NETX3;0129;0404
+- Scan.f6 Id = 21;23;22;0020292012;0933;097000;N1
+- vr_71 Clearerrorhistory = no data stored
+- vr_71 Currenterror = no data stored
+- vr_71 Errorhistory = no data stored
+- vr_71 Mc1Operation = 2;21.0;on;-10
+- vr_71 Mc2Operation = off;0.0;on;-100
+- vr_71 Mc3Operation = no data stored
+- vr_71 SensorData1 = -;19.69;23.12;-;-;-;-;41 01
+- vr_71 SensorData2 = -;-;-;-;0.00;8.00;80 54 05
+- vr_71 SetActorState = -;-;off;on;off;off;-;-;-;-;off;off;00 00
+- vwzio EnableTestHwcTemp = no data stored
+- vwzio EnableTestOutdoorTemp = no data stored
+- vwzio EnableTestThreeWayValve = no data stored
+- vwzio TestHwcTemp = no data stored
+- vwzio TestOutdoorTemp = no data stored
+- vwzio TestThreeWayValve = no data stored
+- ''

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -75,7 +75,7 @@ ANALYSIS = importlib.util.module_from_spec(ANALYSIS_SPEC)
 sys.modules["vaillant_ebus.backend.analysis_service"] = ANALYSIS
 ANALYSIS_SPEC.loader.exec_module(ANALYSIS)
 
-from vaillant_ebus.backend.ebus_service import EbusService  # noqa: E402
+from vaillant_ebus.backend.ebus_service import EbusService, WriteResult  # noqa: E402
 from vaillant_ebus.backend.entity_factory import EntityFactoryService  # noqa: E402
 from vaillant_ebus.backend.models import DeviceGraph, DeviceNode, DeviceType, EbusdRegister  # noqa: E402
 
@@ -448,6 +448,50 @@ async def test_define_custom_registers_skips_when_not_connected() -> None:
 
         await c._define_custom_registers()
         assert mock_ebus.define_register.call_count == 0
+
+
+async def test_async_write_registers_bundles_and_refreshes() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        c = VaillantCoordinator(_hass(tmpdir), _entry())
+
+        mock_ebus = MagicMock(spec=EbusService)
+        mock_ebus.is_connected = True
+        mock_ebus.write_register = AsyncMock(
+            return_value=WriteResult(success=True, verified_value=None)
+        )
+        c.ebus = mock_ebus
+        c.async_request_refresh = MagicMock()
+
+        ok = await c.async_write_registers(
+            [("ctlv2", "ManualCoolingStartDate", "14.08.2026"), ("ctlv2", "ManualCoolingEndDate", "17.08.2026")]
+        )
+
+        assert ok is True
+        assert mock_ebus.write_register.call_count == 2
+        assert c.async_request_refresh.call_count == 1
+
+
+async def test_async_write_registers_stops_on_failure_no_refresh() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        c = VaillantCoordinator(_hass(tmpdir), _entry())
+
+        mock_ebus = MagicMock(spec=EbusService)
+        mock_ebus.is_connected = True
+        mock_ebus.write_register = AsyncMock(
+            side_effect=[
+                WriteResult(success=True, verified_value=None),
+                WriteResult(success=False, error_message="boom"),
+            ]
+        )
+        c.ebus = mock_ebus
+        c.async_request_refresh = MagicMock()
+
+        ok = await c.async_write_registers(
+            [("ctlv2", "A", "1"), ("ctlv2", "B", "2")]
+        )
+
+        assert ok is False
+        assert c.async_request_refresh.call_count == 0
 
 
 async def test_fallback_read_adds_new_registers() -> None:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -429,7 +429,11 @@ async def test_define_custom_registers_delegates_to_ebus() -> None:
         c.ebus = mock_ebus
         await c._define_custom_registers()
 
-        assert mock_ebus.define_register.call_count == 1
+        assert mock_ebus.define_register.call_count == 3
+        calls = [c.args[0] for c in mock_ebus.define_register.call_args_list]
+        assert any("z1RoomHumidity" in d for d in calls)
+        assert any("ManualCoolingStartDate" in d for d in calls)
+        assert any("ManualCoolingEndDate" in d for d in calls)
 
 
 async def test_define_custom_registers_skips_when_not_connected() -> None:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -429,11 +429,13 @@ async def test_define_custom_registers_delegates_to_ebus() -> None:
         c.ebus = mock_ebus
         await c._define_custom_registers()
 
-        assert mock_ebus.define_register.call_count == 3
+        assert mock_ebus.define_register.call_count == 5
         calls = [c.args[0] for c in mock_ebus.define_register.call_args_list]
         assert any("z1RoomHumidity" in d for d in calls)
-        assert any("ManualCoolingStartDate" in d for d in calls)
-        assert any("ManualCoolingEndDate" in d for d in calls)
+        assert any("ManualCoolingStartDate" in d and d.startswith("r5") for d in calls)
+        assert any("ManualCoolingEndDate" in d and d.startswith("r5") for d in calls)
+        assert any("ManualCoolingStartDate" in d and d.startswith("w") for d in calls)
+        assert any("ManualCoolingEndDate" in d and d.startswith("w") for d in calls)
 
 
 async def test_define_custom_registers_skips_when_not_connected() -> None:

--- a/tests/test_discovery_service.py
+++ b/tests/test_discovery_service.py
@@ -526,6 +526,41 @@ def test_arotherm_plus_runs_keep_prenergy_registers() -> None:
             assert reg in graph.placeholder_registers or reg in graph.raw_registers, reg
 
 
+# ctlv2-cooling fixture: Mark's own aroTHERM Plus while cooling is active
+# (status cool_compressor_active). Same heat pump + controller shape as the
+# ctlv3 run dumps, but on a ctlv2 controller without the cooling-program
+# registers (Hc1CoolingEnabled, Z1CoolingOpMode, ... — absent from find).
+AROTHERM_PLUS_CTLV2_COOLING_LINES = load_find_lines("community/arotherm_plus_ctlv2_cooling_discovery.yaml")
+
+
+def _arotherm_plus_ctlv2_cooling_graph() -> DeviceGraph:
+    return DiscoveryService.build_device_graph(AROTHERM_PLUS_CTLV2_COOLING_LINES)
+
+
+def test_arotherm_plus_ctlv2_cooling_graph() -> None:
+    graph = _arotherm_plus_ctlv2_cooling_graph()
+    assert graph.nodes["hmu"].device_type == DeviceType.HEAT_PUMP
+    assert graph.nodes["ctlv2"].device_type == DeviceType.HEATING_CONTROLLER
+    assert "hmu.RunDataStatuscode" in graph.raw_registers
+    assert "ctlv2.Z1CoolingTemp" in graph.raw_registers
+
+
+# The ctlv2 cooling run must not invent cooling-program registers that ebusd
+# does not expose (they only exist with a 720 room panel / Hc1CoolingEnabled=1).
+def test_arotherm_plus_ctlv2_cooling_no_program_registers() -> None:
+    graph = _arotherm_plus_ctlv2_cooling_graph()
+    for reg in (
+        "ctlv2.Hc1CoolingEnabled",
+        "ctlv2.Hc1CoolingFlowTempMin",
+        "ctlv2.Z1CoolingOpMode",
+        "ctlv2.Z1CoolingManualTemp",
+        "ctlv2.Z1CoolingSetbackTemp",
+        "ctlv2.Z1CoolingTempDesired",
+    ):
+        assert reg not in graph.raw_registers, reg
+        assert reg not in graph.placeholder_registers, reg
+
+
 # =============================================================================
 # E. Zone-to-circuit mapping
 # =============================================================================

--- a/tests/test_discovery_service.py
+++ b/tests/test_discovery_service.py
@@ -485,6 +485,48 @@ def test_arotherm_ecotec_zones() -> None:
 
 
 # =============================================================================
+# D. aroTHERM Plus cooling/HWC run dumps (issue #53 follow-up dumps)
+# =============================================================================
+
+AROTHERM_PLUS_COOLING_RUN_LINES = load_find_lines("community/arotherm_plus_cooling_run_discovery.yaml")
+AROTHERM_PLUS_HWC_RUN_LINES = load_find_lines("community/arotherm_plus_hwc_run_discovery.yaml")
+
+
+def _arotherm_plus_cooling_run_graph() -> DeviceGraph:
+    return DiscoveryService.build_device_graph(AROTHERM_PLUS_COOLING_RUN_LINES)
+
+
+def _arotherm_plus_hwc_run_graph() -> DeviceGraph:
+    return DiscoveryService.build_device_graph(AROTHERM_PLUS_HWC_RUN_LINES)
+
+
+# aroTHERM Plus cooling-run dump: graph exposes heat pump + controller
+def test_arotherm_plus_cooling_run_graph() -> None:
+    graph = _arotherm_plus_cooling_run_graph()
+    assert graph.nodes["hmu"].device_type == DeviceType.HEAT_PUMP
+    assert graph.nodes["ctlv3"].device_type == DeviceType.HEATING_CONTROLLER
+    assert graph.nodes["vr_71"].device_type == DeviceType.UNKNOWN
+    assert "hmu.YieldHc" in graph.raw_registers
+
+
+# aroTHERM Plus HWC-run dump: graph exposes heat pump + controller
+def test_arotherm_plus_hwc_run_graph() -> None:
+    graph = _arotherm_plus_hwc_run_graph()
+    assert graph.nodes["hmu"].device_type == DeviceType.HEAT_PUMP
+    assert graph.nodes["ctlv3"].device_type == DeviceType.HEATING_CONTROLLER
+    assert "hmu.YieldHwc" in graph.raw_registers
+    assert "hmu.RunStatsHwcHours" in graph.raw_registers
+
+
+# PrEnergySum* stays no-data in both run dumps — entities must still exist
+# (enabled but unavailable), never dropped because of transient no-data values.
+def test_arotherm_plus_runs_keep_prenergy_registers() -> None:
+    for graph in (_arotherm_plus_cooling_run_graph(), _arotherm_plus_hwc_run_graph()):
+        for reg in ("ctlv3.PrEnergySum", "ctlv3.PrEnergySumHc", "ctlv3.PrEnergySumHwc"):
+            assert reg in graph.placeholder_registers or reg in graph.raw_registers, reg
+
+
+# =============================================================================
 # E. Zone-to-circuit mapping
 # =============================================================================
 

--- a/tests/test_entity_factory.py
+++ b/tests/test_entity_factory.py
@@ -561,6 +561,40 @@ class TestPrEnergySum:
             assert entity.meta.state_class == "total_increasing"
             assert entity.enabled_by_default is True
 
+    # aroTHERM Plus run dumps (#53 follow-up): PrEnergySum* stay no-data even
+    # during active runs, but entities must still be generated (and enabled).
+    def test_run_fixtures_keep_prenergy_entities(self) -> None:
+        for fixture in (
+            "community/arotherm_plus_cooling_run_discovery.yaml",
+            "community/arotherm_plus_hwc_run_discovery.yaml",
+        ):
+            lines = load_find_lines(fixture)
+            graph = DiscoveryService.build_device_graph(lines)
+            entities = EntityFactoryService().generate(graph)
+            pre = [e for e in entities if "PrEnergySum" in e.name]
+            assert pre, f"{fixture}: PrEnergySum entities must be generated"
+            for entity in pre:
+                assert entity.meta.device_class == "energy"
+                assert entity.meta.unit == "kWh"
+                assert entity.meta.state_class == "total_increasing"
+                assert entity.enabled_by_default is True
+
+    # Live yield/energy registers from the run dumps map to energy entities.
+    def test_run_fixtures_live_energy_registers_are_energy(self) -> None:
+        for fixture in (
+            "community/arotherm_plus_cooling_run_discovery.yaml",
+            "community/arotherm_plus_hwc_run_discovery.yaml",
+        ):
+            lines = load_find_lines(fixture)
+            graph = DiscoveryService.build_device_graph(lines)
+            entities = EntityFactoryService().generate(graph)
+            by_key = {e.key: e for e in entities}
+            for reg in ("hmu.YieldHc", "hmu.YieldHwc", "hmu.TotalEnergyUsage", "hmu.YieldCooling"):
+                entity = by_key.get(f"{reg}.value")
+                assert entity is not None, f"{fixture}: missing {reg}"
+                assert entity.meta.device_class == "energy"
+                assert entity.meta.unit == "kWh"
+
 
 class TestBuildingCircuitFlowUnit:
     """Building circuit flow unit (issue #55)."""

--- a/tests/test_entity_factory.py
+++ b/tests/test_entity_factory.py
@@ -619,6 +619,26 @@ class TestPrEnergySum:
         ):
             assert by_key.get(reg) is None, f"unexpected {reg}"
 
+    # The runtime-defined manual cooling dates (GitHub issue #644) must appear as
+    # sensor entities when present in the find output, carrying the mapped
+    # friendly name.
+    def test_manual_cooling_dates_entities(self) -> None:
+        lines = [
+            "ctlv2 ManualCoolingStartDate = 14.08.2026",
+            "ctlv2 ManualCoolingEndDate = 15.08.2026",
+        ]
+        graph = DiscoveryService.build_device_graph(lines)
+        entities = EntityFactoryService().generate(graph)
+        by_key = {e.key: e for e in entities}
+        start = by_key.get("ctlv2.ManualCoolingStartDate.value")
+        end = by_key.get("ctlv2.ManualCoolingEndDate.value")
+        assert start is not None
+        assert end is not None
+        assert start.entity_type == "sensor"
+        assert end.entity_type == "sensor"
+        assert start.meta.friendly_name == "Manual Cooling Start Date"
+        assert end.meta.friendly_name == "Manual Cooling End Date"
+
 
 class TestBuildingCircuitFlowUnit:
     """Building circuit flow unit (issue #55)."""

--- a/tests/test_entity_factory.py
+++ b/tests/test_entity_factory.py
@@ -595,6 +595,30 @@ class TestPrEnergySum:
                 assert entity.meta.device_class == "energy"
                 assert entity.meta.unit == "kWh"
 
+    # ctlv2 cooling fixture (Mark's own system while cooling): the live cooling
+    # data registers exposed by ebusd map to proper entities; the cooling-program
+    # registers that this hardware does not have must not appear as entities.
+    def test_ctlv2_cooling_fixture_entities(self) -> None:
+        lines = load_find_lines("community/arotherm_plus_ctlv2_cooling_discovery.yaml")
+        graph = DiscoveryService.build_device_graph(lines)
+        entities = EntityFactoryService().generate(graph)
+        by_key = {e.key: e for e in entities}
+        for reg in (
+            "hmu.CopCooling.value",
+            "hmu.CopCoolingMonth.value",
+            "hmu.YieldCoolDay.value",
+            "hmu.YieldCooling.value",
+            "hmu.YieldCoolingMonth.value",
+            "ctlv2.Z1CoolingTemp.value",
+        ):
+            assert by_key.get(reg) is not None, f"missing {reg}"
+        for reg in (
+            "ctlv2.Hc1CoolingEnabled.value",
+            "ctlv2.Z1CoolingOpMode.value",
+            "ctlv2.Z1CoolingTempDesired.value",
+        ):
+            assert by_key.get(reg) is None, f"unexpected {reg}"
+
 
 class TestBuildingCircuitFlowUnit:
     """Building circuit flow unit (issue #55)."""

--- a/tests/test_fake_ebusd.py
+++ b/tests/test_fake_ebusd.py
@@ -48,6 +48,7 @@ async def test_arotherm_fixture_loads() -> None:
         ("community/arotherm_plus_prenergy_discovery.yaml", 50),
         ("community/arotherm_plus_cooling_run_discovery.yaml", 50),
         ("community/arotherm_plus_hwc_run_discovery.yaml", 50),
+        ("community/arotherm_plus_ctlv2_cooling_discovery.yaml", 50),
     ],
 )
 async def test_all_fixtures_load(fixture: str, min_registers: int) -> None:

--- a/tests/test_fake_ebusd.py
+++ b/tests/test_fake_ebusd.py
@@ -46,6 +46,8 @@ async def test_arotherm_fixture_loads() -> None:
         ("community/flexocompact_find.txt", 50),
         ("community/arotherm_ecotec_discovery.yaml", 50),
         ("community/arotherm_plus_prenergy_discovery.yaml", 50),
+        ("community/arotherm_plus_cooling_run_discovery.yaml", 50),
+        ("community/arotherm_plus_hwc_run_discovery.yaml", 50),
     ],
 )
 async def test_all_fixtures_load(fixture: str, min_registers: int) -> None:

--- a/tests/test_grab_parser.py
+++ b/tests/test_grab_parser.py
@@ -1,0 +1,87 @@
+"""Unit tests for grab_parser (ebusd grab telegram parsing)."""
+
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import sys
+from pathlib import Path
+
+BACKEND_PATH = Path(__file__).parents[1] / "custom_components/vaillant_ebus/backend"
+COMPONENT_PATH = BACKEND_PATH.parent
+
+for name, path in (
+    ("vaillant_ebus", COMPONENT_PATH),
+    ("vaillant_ebus.backend", BACKEND_PATH),
+):
+    pkg = importlib.util.module_from_spec(importlib.machinery.ModuleSpec(name, None))
+    pkg.__path__ = [str(path)]
+    sys.modules[name] = pkg
+
+spec = importlib.util.spec_from_file_location(
+    "vaillant_ebus.backend.grab_parser", BACKEND_PATH / "grab_parser.py"
+)
+assert spec and spec.loader
+module = importlib.util.module_from_spec(spec)
+sys.modules["vaillant_ebus.backend.grab_parser"] = module
+spec.loader.exec_module(module)
+
+parse_grab_lines = module.parse_grab_lines
+unknown_telegrams = module.unknown_telegrams
+
+GRAB_LINES = [
+    "[grab] grab started",
+    "1008b51009000022ffffff070004 / 0101 = 19: hmu SetMode",
+    "1008b5110100 / 09410111436809000016 = 3",
+    "1076b5040100 / 0a0322581014080526e61b = 3",
+    "10feb505025c01 = 3",
+    "10feb508020900 = 1",
+    "f108b503020002 / 0affffffffffffffffffff = 3",
+    "[grab stop] grab stopped",
+]
+
+
+class TestParseGrabLines:
+    def test_labeled_telegram_parsed(self) -> None:
+        telegrams = parse_grab_lines(GRAB_LINES)
+        labeled = [t for t in telegrams if t["label"]]
+        assert len(labeled) == 1
+        t = labeled[0]
+        assert t["label"] == "hmu SetMode"
+        assert t["msgid"] == "b510"
+        assert t["master"] == "10"
+        assert t["slave"] == "08"
+        assert t["sub"] == "09000022ffffff070004"
+        assert t["resp"] == "0101"
+        assert t["count"] == "19"
+
+    def test_unknown_telegrams_parsed(self) -> None:
+        telegrams = parse_grab_lines(GRAB_LINES)
+        unknown = [t for t in telegrams if t["label"] is None]
+        assert len(unknown) == 5
+        for t in unknown:
+            assert t["label"] is None
+        bc = [t for t in unknown if t["msgid"] == "b505"][0]
+        assert bc["resp"] is None
+        assert bc["master"] == "10"
+        assert bc["slave"] == "fe"
+
+    def test_unknown_telegrams_helper(self) -> None:
+        unknown = unknown_telegrams(GRAB_LINES)
+        assert all(t["label"] is None for t in unknown)
+        assert len(unknown) == 5
+
+    def test_roundtrip_real_fixture(self) -> None:
+        import yaml
+
+        fixture = (
+            Path(__file__).parents[1]
+            / "tests/fixtures/community/arotherm_plus_ctlv2_cooling_discovery.yaml"
+        )
+        data = yaml.safe_load(fixture.read_text())
+        grab = data.get("grab", [])
+        assert grab, "fixture should contain grab data"
+        unknown = unknown_telegrams(grab)
+        labeled = [t for t in parse_grab_lines(grab) if t["label"]]
+        assert unknown, "fixture grab should contain unknown telegrams"
+        assert labeled, "fixture grab should contain labeled telegrams"


### PR DESCRIPTION
## v1.3.0 — Manual cooling via ebusd

Big milestone: cooling can now be controlled over the eBUS bus.

### Highlights

- **Manual cooling start/end dates as read/write datetime entities.** The
  myVaillant "cool until [date]" period is exposed from the ebusd bus via
  runtime `define -r` registers (from `john30/ebusd-configuration` issue #644,
  verified on CTLV2 SW0514/HW1104) using the holiday/away date field layout
  (`value,,IGN:4,,,,value,,HDA:3`) plus a `value,m,HDA:3` write route on the
  `0201...` write-sub.
- **Climate COOL mode starts a manual cooling period.** Selecting COOL writes
  the manual cooling end date (today + configurable `cooling_duration`, default
  3 days) and switches the zone to auto; selecting HEAT clears the end date and
  switches to day. This replaces the ineffective `"cool": "night"` write.
- **Configurable `cooling_duration` option** in the integration settings.
- **Central register write path**: all entities now write through
  `VaillantCoordinator.async_write_registers()`, bundling multi-register writes
  (holiday, DHW mode, manual cooling) with a single refresh.
- Structured grab-telegram dump export (labeled/unknown telegrams) for register
  mining.

### Includes

- The v1.2.5 dump-export improvements (background export, abort message).
- Community discovery fixtures (cooling/HWC run dumps) and grab-parser unit tests.

Closes the cooling investigation tracked in the `debug-cooling-registers` change.
