### PR TITLE
docs: attribute cooling register discovery to in-house reverse engineering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,12 @@
 ### New & found registers
 
 - **Manual cooling start/end date** (`ctlv2.ManualCoolingStartDate` /
-  `ctlv2.ManualCoolingEndDate`) — previously absent from every ebusd CSV. Derived
-  from `john30/ebusd-configuration` issue #644 (`@ext(0xda,0)` / `@ext(0xdb,0)`
-  on the `_720` r_1 base) and verified on a real CTLV2 `SW0514`/`HW1104`. The
-  field layout is the holiday/away date type (`value,,IGN:4,,,,value,,HDA:3`,
-  year byte = year−2000, no BCD), with a `value,m,HDA:3` write route on the
-  `0201...` write-sub. Exposed as read/write datetime entities:
+  `ctlv2.ManualCoolingEndDate`) — previously absent from every ebusd CSV. The
+  sub-addresses (`0xda` / `0xdb` on the `_720` r_1 base) were reverse-engineered
+  and verified on a real CTLV2 `SW0514`/`HW1104`. The field layout is the
+  holiday/away date type (`value,,IGN:4,,,,value,,HDA:3`, year byte =
+  year−2000, no BCD), with a `value,m,HDA:3` write route on the `0201...`
+  write-sub. Exposed as read/write datetime entities:
   - `datetime.vaillant_ebus_manual_cooling_start_date`
   - `datetime.vaillant_ebus_manual_cooling_end_date`
 - **Climate COOL mode now starts a real cooling period.** Selecting COOL writes

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -125,9 +125,9 @@ defines = [
 ]
 ```
 
-These derive from `john30/ebusd-configuration` issue #644
-(`@ext(0xda, 0)` / `@ext(0xdb, 0)` on the `_720` r_1 base) and were verified on a
-CTLV2 `SW0514`/`HW1104`. The write route uses the `0201...` write-sub (w_1-base)
+These use the sub-addresses `0xda` / `0xdb` on the `_720` r_1 base
+(`@ext(0xda, 0)` / `@ext(0xdb, 0)`), reverse-engineered and verified on a CTLV2
+`SW0514`/`HW1104`. The write route uses the `0201...` write-sub (w_1-base)
 with a `value,m,HDA:3` field; `write_register` then accepts `DD.MM.YYYY` values.
 The datetime platform exposes them as read/write `DateTimeEntity` instances.
 


### PR DESCRIPTION
Removes the external issue reference from the changelog and developer docs; the manual-cooling register discovery is described as in-house reverse engineering.