### PR TITLE
fix: suppress phantom ebusd devices

### DIFF
--- a/custom_components/vaillant_ebus/backend/discovery_service.py
+++ b/custom_components/vaillant_ebus/backend/discovery_service.py
@@ -82,6 +82,10 @@ class DiscoveryService:
         parts = rhs.split(";")
         if len(parts) != 4:
             return None
+        if all("=" in part for part in parts):
+            metadata = dict(part.split("=", 1) for part in parts)
+            if {"MF", "ID", "SW", "HW"} <= metadata.keys():
+                return (lhs.strip(), metadata["ID"], metadata["SW"], metadata["HW"])
         return (lhs.strip(), parts[1].strip(), parts[2].strip(), parts[3].strip())
 
     @staticmethod
@@ -202,6 +206,8 @@ class DiscoveryService:
                 continue
             if c_lower in ALWAYS_HIDDEN or any(kw in c_lower for kw in HIDDEN_DEVICE_KEYWORDS):
                 continue
+            if _is_address_circuit(circuit):
+                continue
 
             scan_info = scan_by_circuit.get(circuit)
             scan_type = scan_info[0] if scan_info else ""
@@ -218,11 +224,16 @@ class DiscoveryService:
 
             if any(kw in circuit.lower() for kw in HIDDEN_DEVICE_KEYWORDS):
                 continue
+            device_type = DiscoveryService.categorize_circuit(circuit, regs, scan_type)
+            circuit_has_data = any(raw_registers.get(rk) is not None for rk in regs)
+            if not circuit_has_data and device_type == DeviceType.UNKNOWN:
+                continue
+
             node = DeviceNode(
                 circuit=circuit,
-                device_type=DiscoveryService.categorize_circuit(circuit, regs, scan_type),
+                device_type=device_type,
                 registers=regs,
-                has_data=any(raw_registers.get(rk) is not None for rk in regs),
+                has_data=circuit_has_data,
                 scan_type=scan_type,
                 scan_sw=scan_sw,
                 scan_hw=scan_hw,
@@ -253,6 +264,15 @@ class DiscoveryService:
 # Extract the logical sub-device name from its parent-qualified key.
 def _sub_name(sub_key: str) -> str:
     return sub_key.split("/", 1)[1]
+
+
+def _is_address_circuit(circuit: str) -> bool:
+    """Return whether ebusd used a raw hexadecimal bus address as circuit name."""
+    try:
+        int(circuit, 16)
+    except ValueError:
+        return False
+    return True
 
 
 # Determine whether each source circuit contains at least one live value.

--- a/custom_components/vaillant_ebus/backend/entity_factory.py
+++ b/custom_components/vaillant_ebus/backend/entity_factory.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from copy import copy
 from typing import Any
 
 from .mapping import REGISTER_MAP, RegisterMeta, get_meta, multi_field_fields, split_multi_field
@@ -112,7 +113,7 @@ def _classify_register(
 def _merge_overrides(meta: RegisterMeta, override: dict[str, Any]) -> RegisterMeta:
     """Merge YAML overrides into a RegisterMeta, returning new instance."""
     if not override:
-        return meta
+        return copy(meta)
     merged = RegisterMeta(
         friendly_name=override.get("friendly_name", meta.friendly_name),
         icon=override.get("icon", meta.icon),

--- a/custom_components/vaillant_ebus/coordinator.py
+++ b/custom_components/vaillant_ebus/coordinator.py
@@ -199,6 +199,7 @@ class VaillantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         try:
             await ebus.connect()
         except Exception as exc:
+            self._started = False
             _LOGGER.warning("ebusd connect failed, will retry: %s", exc)
             return
         self.ebus = ebus
@@ -215,6 +216,9 @@ class VaillantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         try:
             graph = await self.discovery.discover()
         except Exception as exc:
+            self._ebusd_connected = False
+            self._started = False
+            await ebus.disconnect()
             _LOGGER.warning("ebusd discovery failed: %s", exc)
             return
 
@@ -255,7 +259,9 @@ class VaillantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         generated_entities = self.entity_factory.generate(graph)
         if is_delayed:
             existing_entity_keys = {entity.key for entity in self.entities}
-            self.entities.extend(entity for entity in generated_entities if entity.key not in existing_entity_keys)
+            additions = [entity for entity in generated_entities if entity.key not in existing_entity_keys]
+            self.entities.extend(additions)
+            self._add_new_entities(additions)
         else:
             self.entities = generated_entities
         platform_counts: dict[str, int] = {}
@@ -528,21 +534,21 @@ class VaillantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                         self.registers[key].value.update(_register_values(key, value))
                         self.registers[key].has_data = True
                     _LOGGER.debug("Fallback read %s = %s", key, value)
-                elif was_new and REGISTER_MAP[key].enabled:
-                    self.registers[key] = EbusdRegister(
-                        circuit=circuit,
-                        name=name,
-                        fields=["value"],
-                        value=_register_values(key, None),
-                        has_data=False,
-                    )
-                    added += 1
-                    _LOGGER.debug("Fallback added empty %s (will populate on poll)", key)
             except Exception as exc:
                 _LOGGER.warning("Fallback read failed: %s (%s)", key, exc)
         if added and self._graph:
-            self.entities = self.entity_factory.generate(self._graph)
-            _LOGGER.info("Regenerated entities after fallback: added %d new", added)
+            for key, register in self.registers.items():
+                if not register.has_data or key in self._graph.raw_registers:
+                    continue
+                node = self._graph.nodes.get(register.circuit)
+                if node is None:
+                    continue
+                self._graph.raw_registers[key] = register.value.get("value", "")
+                if key not in node.registers:
+                    node.registers.append(key)
+                node.has_data = True
+                self._last_find_keys.add(key)
+            _LOGGER.info("Fallback read added %d register(s) to discovery", added)
         else:
             _LOGGER.info("Fallback read complete: %d/%d registers with data", read_with_data, len(to_read))
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -354,6 +354,37 @@ async def test_delayed_rediscovery_only_adds_entities_and_devices() -> None:
         assert {"ctlv2", "v32"} <= set(coordinator._graph.nodes)
 
 
+async def test_delayed_rediscovery_adds_new_platform_entities() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        coordinator = VaillantCoordinator(_hass(tmpdir), _entry())
+        additions = MagicMock()
+        coordinator.register_entity_adder("sensor", additions)
+        mock_ebus = MagicMock(spec=EbusService)
+        mock_ebus.is_connected = True
+        mock_ebus.read_register = AsyncMock(return_value=None)
+        coordinator.ebus = mock_ebus
+        await coordinator._apply_discovery_graph(_make_graph(), "initial")
+
+        await coordinator._apply_discovery_graph(
+            DeviceGraph(
+                nodes={
+                    "v32": DeviceNode(
+                        circuit="v32",
+                        device_type=DeviceType.VENTILATION,
+                        registers=["v32.SupplyAirTemp"],
+                        has_data=True,
+                    )
+                },
+                raw_registers={"v32.SupplyAirTemp": "20.75"},
+                placeholder_registers=set(),
+            ),
+            "delayed",
+        )
+
+        additions.assert_called_once()
+        assert additions.call_args.args[0][0].key == "v32.SupplyAirTemp.value"
+
+
 async def test_apply_discovery_logs_entity_platform_breakdown(caplog) -> None:
     with tempfile.TemporaryDirectory() as tmpdir:
         coordinator = VaillantCoordinator(_hass(tmpdir), _entry())
@@ -374,6 +405,7 @@ async def test_apply_discovery_logs_entity_platform_breakdown(caplog) -> None:
 async def test_connect_failure_no_crash() -> None:
     with tempfile.TemporaryDirectory() as tmpdir:
         c = VaillantCoordinator(_hass(tmpdir), _entry())
+        c._started = True
         entities_before = len(c.entities)
 
         mock_ebus = MagicMock(spec=EbusService)
@@ -387,6 +419,7 @@ async def test_connect_failure_no_crash() -> None:
         finally:
             module.EbusService = orig_ebus
         assert len(c.entities) >= entities_before
+        assert c._started is False
 
 
 async def test_discovery_failure_preserves_cached_entities() -> None:
@@ -516,6 +549,10 @@ async def test_fallback_read_adds_new_registers() -> None:
         await c._fallback_read()
 
         assert len(c.registers) >= before
+        for key, register in c.registers.items():
+            if register.has_data and register.circuit in c._graph.nodes:
+                assert key in c._graph.raw_registers
+                assert key in c._graph.nodes[register.circuit].registers
 
 
 async def test_fallback_read_no_ebus_skips() -> None:

--- a/tests/test_discovery_service.py
+++ b/tests/test_discovery_service.py
@@ -126,6 +126,12 @@ def test_parse_scan_metadata_vwz() -> None:
     assert result[1] == "VWZ00"
 
 
+def test_parse_scan_metadata_current_ebusd_format() -> None:
+    result = DiscoveryService._parse_scan("scan.76 = MF=Vaillant;ID=VWZ00;SW=0522;HW=5103")
+    assert result is not None
+    assert result[1:] == ("VWZ00", "0522", "5103")
+
+
 def test_parse_scan_metadata_netx2() -> None:
     result = DiscoveryService._parse_scan("scan.04 = Vaillant;NETX2;4039;5703")
     assert result is not None
@@ -296,6 +302,25 @@ def test_duplicate_find_lines_preserve_live_value_regardless_of_order(
     graph = DiscoveryService.build_device_graph(find_lines)
     assert graph.raw_registers["v32.SupplyAirTemp"] == "20.75;ok"
     assert graph.nodes["v32"].has_data is True
+
+
+def test_address_and_empty_unknown_circuits_are_suppressed() -> None:
+    graph = DiscoveryService.build_device_graph(
+        [
+            "scan.76 = MF=Vaillant;ID=VWZ00;SW=0522;HW=5103",
+            "76 VWZ_Status01b = 42",
+            "B504 VWZ_Status_0100 =  (ERR: invalid position)",
+            "B512 VWZ_Status_030f0101 =  (ERR: invalid position)",
+            "sc Col = no data stored",
+            "vwz TestHwcTemp = no data stored",
+        ]
+    )
+    assert "76" not in graph.nodes
+    assert "B504" not in graph.nodes
+    assert "B512" not in graph.nodes
+    assert "sc" not in graph.nodes
+    assert graph.nodes["vwz"].device_type == DeviceType.PASSIVE_COOLING
+
 
 
 # =============================================================================

--- a/tests/test_entity_factory.py
+++ b/tests/test_entity_factory.py
@@ -266,6 +266,30 @@ class TestEnabledByDefault:
         assert result is False
 
 
+class TestMetadataIsolation:
+    """Generated entities must not mutate shared register mapping metadata."""
+
+    def test_register_classification_does_not_leak_between_generations(self) -> None:
+        graph = DeviceGraph(
+            nodes={
+                "custom": DeviceNode(
+                    circuit="custom",
+                    device_type=DeviceType.UNKNOWN,
+                    registers=["custom.Value"],
+                    has_data=True,
+                )
+            },
+            raw_registers={"custom.Value": "1"},
+            placeholder_registers=set(),
+        )
+        first = EntityFactoryService().generate(graph)[0]
+        graph.raw_registers["custom.Value"] = "hello"
+        second = EntityFactoryService().generate(graph)[0]
+
+        assert first.meta.entity_type == "binary_sensor"
+        assert second.meta.entity_type == "sensor"
+
+
 class TestYamlOverrides:
     """YAML override handling."""
 


### PR DESCRIPTION
Filters raw hexadecimal ebusd address circuits (B504/B512/76) and empty unknown circuits from the device graph; correctly parses current ebusd scan metadata. Also fixes reconnect retry, delayed entity registration, fallback graph propagation, and metadata mutation found during review.\n\nValidation: .venv/bin/pytest -q (299 passed), ruff, compileall.