### PR TITLE
release: v1.3.2 - Pro7 heat pump, energy sensors, write refresh (#50, #53, #56, #68)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@
   central write path called `async_request_refresh()` without `await`, so the
   refresh coroutine was discarded and entity states only updated on the next
   poll cycle. After successful writes the coordinator now refreshes immediately.
+- **aroTHERM Pro 7 recognized as heat pump (#56).** The Pro 7 reports its heat
+  pump under the circuit `HMUX0` instead of `hmu`, so the compressor state and
+  the connection/fault sensors read the wrong device. Circuit detection now
+  classifies `hmux*` as a heat pump and `sol*` as a solar controller, and the
+  coordinator resolves the heat pump circuit from the discovered graph instead of
+  assuming `hmu`.
 
 ## 1.3.1 - 2026-08-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,15 @@
   `Hwc`, `Cool`) is exposed as `kWh` energy sensors with `total_increasing` state
   class.
 
+- **Cooling energy on actively-cooling air/water units (#50).** The flexoCOMPACT
+  (air/water aroTHERM with active cooling) reports `StatElectricEnergySumCool`
+  live on both `hmu` and `ctlv2`, but the register-metadata fallback skipped the
+  `hmu` statistics keys when the circuit was already `ctlv2`, so the sensors lost
+  their energy metadata. The fallback now consults the `hmu` keys for every
+  non-`hmu` circuit (including `ctlv2`). The flexoTHERM (brine-water, no active
+  cooling) never exposes this register — it returns "element not found" and
+  correctly stays absent.
+
 - **Register writes now trigger the expected refresh (#68):** the coordinator's
   central write path called `async_request_refresh()` without `await`, so the
   refresh coroutine was discarded and entity states only updated on the next

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@
 
 ### Fixed
 
+- **Energy statistics on aroTHERM Plus / basv3 controllers (#53).** The electric
+  and environment energy statistics (`StatElectricEnergySum*`,
+  `StatEnvironmentEnergySum*` — including the cooling variants) were defined in
+  the register map under the `hmu` circuit, but these controllers expose them on
+  the `basv3` circuit. The metadata fallback only mapped heating-controller
+  variants onto `ctlv2`, so the sensors appeared without energy metadata.
+  Register metadata now also falls back onto the `hmu` statistics keys, and the
+  full `StatElectricEnergySum` / `StatEnvironmentEnergySum` family (blank, `Hc`,
+  `Hwc`, `Cool`) is exposed as `kWh` energy sensors with `total_increasing` state
+  class.
+
 - **Register writes now trigger the expected refresh (#68):** the coordinator's
   central write path called `async_request_refresh()` without `await`, so the
   refresh coroutine was discarded and entity states only updated on the next

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 1.3.2 - 2026-08-15
+
+### Fixed
+
+- **Register writes now trigger the expected refresh (#68):** the coordinator's
+  central write path called `async_request_refresh()` without `await`, so the
+  refresh coroutine was discarded and entity states only updated on the next
+  poll cycle. After successful writes the coordinator now refreshes immediately.
+
 ## 1.3.1 - 2026-08-14
 
 ### Fixed

--- a/custom_components/vaillant_ebus/backend/discovery_service.py
+++ b/custom_components/vaillant_ebus/backend/discovery_service.py
@@ -94,7 +94,7 @@ class DiscoveryService:
         if low == "netx2":
             return "Broadcast"
         prefix = low.rstrip("0123456789")
-        if prefix in ("hmu", "ctlv", "basv", "bai", "vwz", "vwzio"):
+        if prefix in ("hmu", "hmux", "ctlv", "basv", "bai", "vwz", "vwzio", "sol"):
             return prefix
         return ""
 
@@ -425,6 +425,8 @@ def _apply_relationships(
 _SCAN_TO_DEVICE: dict[str, DeviceType] = {
     "hmu": DeviceType.HEAT_PUMP,
     "hmu00": DeviceType.HEAT_PUMP,
+    "hmux": DeviceType.HEAT_PUMP,
+    "hmux0": DeviceType.HEAT_PUMP,
     "ctlv": DeviceType.HEATING_CONTROLLER,
     "ctlv1": DeviceType.HEATING_CONTROLLER,
     "ctlv2": DeviceType.HEATING_CONTROLLER,
@@ -437,10 +439,13 @@ _SCAN_TO_DEVICE: dict[str, DeviceType] = {
     "netx": DeviceType.BUS,
     "netx2": DeviceType.BUS,
     "v32": DeviceType.VENTILATION,
+    "sol": DeviceType.SOLAR,
+    "sol00": DeviceType.SOLAR,
 }
 
 _PREFIX_TO_DEVICE: dict[str, DeviceType] = {
     "hmu": DeviceType.HEAT_PUMP,
+    "hmux": DeviceType.HEAT_PUMP,
     "ctlv": DeviceType.HEATING_CONTROLLER,
     "basv": DeviceType.HEATING_CONTROLLER,
     "bai": DeviceType.HEATING_CONTROLLER,
@@ -448,6 +453,7 @@ _PREFIX_TO_DEVICE: dict[str, DeviceType] = {
     "vwz": DeviceType.PASSIVE_COOLING,
     "vwzio": DeviceType.PASSIVE_COOLING,
     "v32": DeviceType.VENTILATION,
+    "sol": DeviceType.SOLAR,
 }
 
 

--- a/custom_components/vaillant_ebus/backend/mapping.py
+++ b/custom_components/vaillant_ebus/backend/mapping.py
@@ -1428,10 +1428,13 @@ def get_meta(circuit: str, name: str, field: str = "value") -> RegisterMeta:
         key += f".{field}"
     meta = REGISTER_MAP.get(key)
     # Fallbacks for hardware variants that expose the same register under a
-    # different circuit. Heating controller variants (basv* etc.) map onto the
-    # ctlv2 keys; heat-pump statistics (Stat* energy, etc.) map onto the hmu keys.
-    if meta is None and circuit != "ctlv2":
+    # different circuit. The ctlv2 variant can appear as its own circuit (do not
+    # self-alias), and heat-pump statistics (Stat* energy, etc.) map onto the hmu
+    # keys across controller circuits.
+    if meta is None:
         for alt_circuit in ("ctlv2", "hmu"):
+            if alt_circuit == circuit:
+                continue
             alt = f"{alt_circuit}.{name}"
             if field != "value":
                 alt += f".{field}"

--- a/custom_components/vaillant_ebus/backend/mapping.py
+++ b/custom_components/vaillant_ebus/backend/mapping.py
@@ -266,6 +266,42 @@ REGISTER_MAP: dict[str, RegisterMeta] = {
         unit="kWh",
         state_class="total_increasing",
     ),
+    "hmu.StatElectricEnergySum": RegisterMeta(
+        friendly_name="Electric Energy",
+        device_class="energy",
+        unit="kWh",
+        state_class="total_increasing",
+    ),
+    "hmu.StatElectricEnergySumHc": RegisterMeta(
+        friendly_name="Electric Energy (Heating)",
+        device_class="energy",
+        unit="kWh",
+        state_class="total_increasing",
+    ),
+    "hmu.StatElectricEnergySumHwc": RegisterMeta(
+        friendly_name="Electric Energy (DHW)",
+        device_class="energy",
+        unit="kWh",
+        state_class="total_increasing",
+    ),
+    "hmu.StatEnvironmentEnergySum": RegisterMeta(
+        friendly_name="Environment Energy",
+        device_class="energy",
+        unit="kWh",
+        state_class="total_increasing",
+    ),
+    "hmu.StatEnvironmentEnergySumHc": RegisterMeta(
+        friendly_name="Environment Energy (Heating)",
+        device_class="energy",
+        unit="kWh",
+        state_class="total_increasing",
+    ),
+    "hmu.StatEnvironmentEnergySumHwc": RegisterMeta(
+        friendly_name="Environment Energy (DHW)",
+        device_class="energy",
+        unit="kWh",
+        state_class="total_increasing",
+    ),
     "hmu.RunStatsCompressorHours": RegisterMeta(
         friendly_name="Compressor Runtime",
         device_class="duration",
@@ -1391,10 +1427,15 @@ def get_meta(circuit: str, name: str, field: str = "value") -> RegisterMeta:
     if field != "value":
         key += f".{field}"
     meta = REGISTER_MAP.get(key)
-    # ponytail: fallback for heating controller variants (basv → ctlv2). Add if new variants appear.
+    # Fallbacks for hardware variants that expose the same register under a
+    # different circuit. Heating controller variants (basv* etc.) map onto the
+    # ctlv2 keys; heat-pump statistics (Stat* energy, etc.) map onto the hmu keys.
     if meta is None and circuit != "ctlv2":
-        alt = f"ctlv2.{name}"
-        if field != "value":
-            alt += f".{field}"
-        meta = REGISTER_MAP.get(alt)
+        for alt_circuit in ("ctlv2", "hmu"):
+            alt = f"{alt_circuit}.{name}"
+            if field != "value":
+                alt += f".{field}"
+            meta = REGISTER_MAP.get(alt)
+            if meta is not None:
+                break
     return meta or RegisterMeta()

--- a/custom_components/vaillant_ebus/backend/models.py
+++ b/custom_components/vaillant_ebus/backend/models.py
@@ -209,6 +209,7 @@ class DeviceType(Enum):
     VENTILATION = "ventilation"
     PASSIVE_COOLING = "cooling"
     BUS = "bus"
+    SOLAR = "solar"
     UNKNOWN = "unknown"
 
 

--- a/custom_components/vaillant_ebus/binary_sensor.py
+++ b/custom_components/vaillant_ebus/binary_sensor.py
@@ -107,7 +107,7 @@ class EbusdConnectionSensor(CoordinatorEntity[VaillantCoordinator], BinarySensor
     def __init__(self, coordinator: VaillantCoordinator, entry: ConfigEntry) -> None:
         super().__init__(coordinator)
         self._attr_unique_id = f"{entry.entry_id}_ebusd_online"
-        self._attr_device_info = coordinator.get_device_info("hmu")
+        self._attr_device_info = coordinator.get_device_info(coordinator.heat_pump_circuit)
 
     @property
     def is_on(self) -> bool:
@@ -126,14 +126,15 @@ class EbusdFaultSensor(CoordinatorEntity[VaillantCoordinator], BinarySensorEntit
     def __init__(self, coordinator: VaillantCoordinator, entry: ConfigEntry) -> None:
         super().__init__(coordinator)
         self._attr_unique_id = f"{entry.entry_id}_fault_active"
-        self._attr_device_info = coordinator.get_device_info("hmu")
+        self._attr_device_info = coordinator.get_device_info(coordinator.heat_pump_circuit)
 
     # True when either HMU or CTLV2 has active error codes
     @property
     def is_on(self) -> bool:
         c = self.coordinator.heating_circuit
+        hp = self.coordinator.heat_pump_circuit
         values = (
-            self.coordinator.data.get("ebusd", {}).get("hmu.Currenterror.value"),
+            self.coordinator.data.get("ebusd", {}).get(f"{hp}.Currenterror.value"),
             self.coordinator.data.get("ebusd", {}).get(f"{c}.Currenterror.value"),
         )
         return any(value and any(part.strip() not in {"", "-"} for part in str(value).split(";")) for value in values)

--- a/custom_components/vaillant_ebus/climate.py
+++ b/custom_components/vaillant_ebus/climate.py
@@ -145,7 +145,7 @@ class EbusdClimate(CoordinatorEntity[VaillantCoordinator], ClimateEntity):
         if hc is None:
             pump = _value(self.coordinator, "Hc1PumpStatus")
             zone_active = (pump or "").lower() in ("on", "1", "true", "yes", "running")
-        comp = (_value(self.coordinator, "RunDataStatuscode", "hmu") or "").lower()
+        comp = (_value(self.coordinator, "RunDataStatuscode", self.coordinator.heat_pump_circuit) or "").lower()
         global_heat = comp in HEATING_STATES
         global_cool = comp in COOLING_STATES
         if zone_active:
@@ -373,7 +373,7 @@ class EbusdFlowTempRange(CoordinatorEntity[VaillantCoordinator], ClimateEntity):
     # HVAC action from compressor status (heating/cooling/idle/off)
     @property
     def hvac_action(self) -> HVACAction | None:
-        comp = (_value(self.coordinator, "RunDataStatuscode", "hmu") or "").lower()
+        comp = (_value(self.coordinator, "RunDataStatuscode", self.coordinator.heat_pump_circuit) or "").lower()
         if comp in HEATING_STATES:
             return HVACAction.HEATING
         if comp in COOLING_STATES:

--- a/custom_components/vaillant_ebus/coordinator.py
+++ b/custom_components/vaillant_ebus/coordinator.py
@@ -154,6 +154,14 @@ class VaillantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     return node.circuit
         return self._heating_circuit
 
+    @property
+    def heat_pump_circuit(self) -> str:
+        if self._graph:
+            for node in self._graph.nodes.values():
+                if node.device_type == DeviceType.HEAT_PUMP:
+                    return node.circuit
+        return "hmu"
+
     async def _async_seed_entities_from_cache(self) -> None:
         cache = await self._async_load_cache()
         find_lines: list[str] = []
@@ -415,7 +423,7 @@ class VaillantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             for field, value in reg.value.items():
                 if value is not None:
                     translated = value
-                    if reg.key == "hmu.RunDataStatuscode":
+                    if reg.key == f"{self.heat_pump_circuit}.RunDataStatuscode":
                         translated = COMPRESSOR_STATUS_LABELS.get(value, value)
                     for suffix in EBUSD_STATUS_SUFFIXES:
                         if translated.endswith(suffix):

--- a/custom_components/vaillant_ebus/coordinator.py
+++ b/custom_components/vaillant_ebus/coordinator.py
@@ -629,7 +629,7 @@ class VaillantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 _LOGGER.warning("Write failed %s.%s=%s: %s", circuit, name, value, result.error_message)
                 all_ok = False
         if all_ok:
-            self.async_request_refresh()
+            await self.async_request_refresh()
         return all_ok
 
     # Convenience wrapper for a single-register write through the central path.

--- a/custom_components/vaillant_ebus/manifest.json
+++ b/custom_components/vaillant_ebus/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/MarkBovee/vaillant-ebus/issues",
   "requirements": [],
-  "version": "1.3.1"
+  "version": "1.3.2"
 }

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -493,7 +493,7 @@ async def test_async_write_registers_bundles_and_refreshes() -> None:
             return_value=WriteResult(success=True, verified_value=None)
         )
         c.ebus = mock_ebus
-        c.async_request_refresh = MagicMock()
+        c.async_request_refresh = AsyncMock()
 
         ok = await c.async_write_registers(
             [("ctlv2", "ManualCoolingStartDate", "14.08.2026"), ("ctlv2", "ManualCoolingEndDate", "17.08.2026")]

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -276,6 +276,44 @@ async def test_connect_and_discover_success() -> None:
         assert c.heating_circuit == "ctlv2"
 
 
+# Intent: heat-pump circuit resolves from the graph; defaults to hmu without a heat pump node.
+async def test_heat_pump_circuit_resolves_from_graph() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        c = VaillantCoordinator(_hass(tmpdir), _entry())
+        assert c.heat_pump_circuit == "hmu"
+        c._graph = _make_graph()
+        assert c.heat_pump_circuit == "hmu"
+
+
+async def test_heat_pump_circuit_resolves_hmux0() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        c = VaillantCoordinator(_hass(tmpdir), _entry())
+        graph = DeviceGraph(
+            nodes={
+                "hmux0": DeviceNode(
+                    circuit="hmux0",
+                    device_type=DeviceType.HEAT_PUMP,
+                    registers=["hmux0.RunDataStatuscode"],
+                    has_data=True,
+                    scan_type="HMUX0",
+                ),
+                "ctlv3": DeviceNode(
+                    circuit="ctlv3",
+                    device_type=DeviceType.HEATING_CONTROLLER,
+                    registers=["ctlv3.Z1OpMode"],
+                    has_data=True,
+                    scan_type="CTLV3",
+                    parent="hmux0",
+                ),
+            },
+            raw_registers={"hmux0.RunDataStatuscode": "standby", "ctlv3.Z1OpMode": "day"},
+            placeholder_registers=set(),
+        )
+        c._graph = graph
+        assert c.heat_pump_circuit == "hmux0"
+        assert c.heating_circuit == "ctlv3"
+
+
 # Intent: re-run discovery once after ebusd has had time to populate live values.
 async def test_connect_schedules_one_delayed_rediscovery() -> None:
     with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/test_discovery_service.py
+++ b/tests/test_discovery_service.py
@@ -234,6 +234,30 @@ def test_categorize_bai_by_scan() -> None:
     assert result == DeviceType.HEATING_CONTROLLER
 
 
+# aroTHERM Pro uses HMUX0 as heat pump identifier (issue #56)
+def test_categorize_hmux0_by_scan() -> None:
+    result = DiscoveryService.categorize_circuit("hmux0", [], "HMUX0")
+    assert result == DeviceType.HEAT_PUMP
+
+
+# HMUX0 circuit without scan metadata still resolves via prefix
+def test_categorize_hmux0_by_prefix() -> None:
+    result = DiscoveryService.categorize_circuit("hmux0", [], "")
+    assert result == DeviceType.HEAT_PUMP
+
+
+# SOL00 solar-collector controller is recognized (issue #56)
+def test_categorize_sol00_by_scan() -> None:
+    result = DiscoveryService.categorize_circuit("sol00", [], "SOL00")
+    assert result == DeviceType.SOLAR
+
+
+# SOL00 circuit without scan metadata still resolves via prefix
+def test_categorize_sol00_by_prefix() -> None:
+    result = DiscoveryService.categorize_circuit("sol00", [], "")
+    assert result == DeviceType.SOLAR
+
+
 # =============================================================================
 # C. Device graph construction (integration tests using fixture data)
 # =============================================================================
@@ -428,6 +452,18 @@ def test_arotherm_pro7_graph() -> None:
     assert "hmu" not in graph.nodes
     assert "ctlv3.Z1DayTemp" in graph.raw_registers
     assert "ctlv3.Z1OpMode" in graph.raw_registers
+
+
+# Pro7 scan metadata (HMUX0) classifies as heat pump even without data
+def test_arotherm_pro7_hmux0_scan_classification() -> None:
+    result = DiscoveryService.categorize_circuit("hmux0", [], "HMUX0")
+    assert result == DeviceType.HEAT_PUMP
+
+
+# Pro7 scan metadata (SOL00) classifies as solar even without data
+def test_arotherm_pro7_sol00_scan_classification() -> None:
+    result = DiscoveryService.categorize_circuit("sol00", [], "SOL00")
+    assert result == DeviceType.SOLAR
 
 
 def test_arotherm_pro7_hmu_missing() -> None:

--- a/tests/test_entity_factory.py
+++ b/tests/test_entity_factory.py
@@ -664,6 +664,47 @@ class TestPrEnergySum:
         assert end.meta.friendly_name == "Manual Cooling End Date"
 
 
+class TestStatEnergyRegisters:
+    """Heat-pump statistics energy registers on non-hmu circuits (issue #53)."""
+
+    def test_basv3_gets_hmu_energy_meta(self) -> None:
+        meta = get_meta("basv3", "StatElectricEnergySumCool")
+        assert meta.device_class == "energy"
+        assert meta.unit == "kWh"
+        assert meta.state_class == "total_increasing"
+
+    def test_basv3_fixture_stat_energy_entities(self) -> None:
+        lines = load_find_lines("community/arotherm_plus_basv3_discovery.yaml")
+        graph = DiscoveryService.build_device_graph(lines)
+        entities = EntityFactoryService().generate(graph)
+        by_key = {e.key: e for e in entities}
+        for reg in (
+            "basv3.StatElectricEnergySum.value",
+            "basv3.StatElectricEnergySumCool.value",
+            "basv3.StatElectricEnergySumHc.value",
+            "basv3.StatElectricEnergySumHwc.value",
+            "basv3.StatEnvironmentEnergySum.value",
+            "basv3.StatEnvironmentEnergySumCool.value",
+            "basv3.StatEnvironmentEnergySumHc.value",
+            "basv3.StatEnvironmentEnergySumHwc.value",
+        ):
+            entity = by_key.get(reg)
+            assert entity is not None, f"missing {reg}"
+            assert entity.meta.device_class == "energy", reg
+            assert entity.meta.unit == "kWh", reg
+            assert entity.meta.state_class == "total_increasing", reg
+            assert entity.enabled_by_default is True, reg
+
+    def test_no_data_orphan_circuit_suppressed(self) -> None:
+        lines = load_find_lines("community/arotherm_plus_basv3_discovery.yaml")
+        graph = DiscoveryService.build_device_graph(lines)
+        entities = EntityFactoryService().generate(graph)
+        # vwzio carries no live data and has no parent device, so its registers
+        # are not exposed as standalone entities (consistent no-data handling).
+        by_key = {e.key: e for e in entities}
+        assert "vwzio.StatElectricEnergySumCool.value" not in by_key
+
+
 class TestBuildingCircuitFlowUnit:
     """Building circuit flow unit (issue #55)."""
 

--- a/tests/test_entity_factory.py
+++ b/tests/test_entity_factory.py
@@ -704,6 +704,35 @@ class TestStatEnergyRegisters:
         by_key = {e.key: e for e in entities}
         assert "vwzio.StatElectricEnergySumCool.value" not in by_key
 
+    # flexoTHERM (brine-water, no active cooling) reports the cooling energy
+    # register as "element not found" — it must not appear as an entity.
+    def test_flexotherm_has_no_cooling_energy_entity(self) -> None:
+        graph = DiscoveryService.build_device_graph(
+            load_find_lines("community/flexotherm_discovery.yaml")
+        )
+        by_key = {e.key: e for e in EntityFactoryService().generate(graph)}
+        assert "hmu.StatElectricEnergySumCool.value" not in by_key
+        assert "hmu.StatEnvironmentEnergySumCool.value" not in by_key
+
+    # flexoCOMPACT (air/water aroTHERM with active cooling) reports cooling
+    # energy live on both hmu and ctlv2; both get hmu energy metadata (issue #50).
+    def test_flexocompact_cooling_energy_entities(self) -> None:
+        graph = DiscoveryService.build_device_graph(
+            load_find_lines("community/flexocompact_find.txt")
+        )
+        by_key = {e.key: e for e in EntityFactoryService().generate(graph)}
+        for reg in (
+            "hmu.StatElectricEnergySumCool.value",
+            "hmu.StatEnvironmentEnergySumCool.value",
+            "ctlv2.StatElectricEnergySumCool.value",
+            "ctlv2.StatEnvironmentEnergySumCool.value",
+        ):
+            entity = by_key.get(reg)
+            assert entity is not None, f"missing {reg}"
+            assert entity.meta.device_class == "energy", reg
+            assert entity.meta.unit == "kWh", reg
+            assert entity.meta.state_class == "total_increasing", reg
+
 
 class TestBuildingCircuitFlowUnit:
     """Building circuit flow unit (issue #55)."""


### PR DESCRIPTION
Bundles the pending v1.3.2 fixes into one release.

- #56 aroTHERM Pro 7 (HMUX0) recognized as heat pump, thermostat fixed
- #68 register writes now trigger an immediate refresh
- #53 energy statistics on aroTHERM Plus / basv3 controllers get hmu metadata
- #50 cooling energy on actively-cooling air/water units gets hmu metadata