### PR TITLE
Release v1.3.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,7 @@ captures/
 strings.json
 data-dump/
 discovery_dumps/
+
+
+# GitHub inbox local state
+.gh-inbox-state.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,3 +99,9 @@ telegrams; capture them with `grab` and mine the unknown ones for new registers.
 .venv/bin/pytest -q
 python3 -m compileall -f custom_components/vaillant_ebus/
 ```
+
+## GitHub Communication
+
+- Write GitHub issue, discussion, and pull request replies in clear English.
+- Use clean Markdown with complete sentences, correct punctuation, and blank lines between paragraphs.
+- Put lists and distinct points on separate lines. Never post compressed, run-on, or caveman-style prose.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 1.3.4 - 2026-08-17
+
+### Fixed
+
+- **`analyze_registers` no longer crashes on current Home Assistant (#72).** Entity
+  registry access now uses the supported `entity_registry.async_get(hass)` API.
+- **Energy and yield statistics are refreshed when ebusd initially reports no data
+  (#71).** Enabled placeholder registers are retried through direct ebusd reads every
+  15 minutes, allowing values that become available later to update normally without
+  increasing the regular polling frequency.
+
 ## 1.3.3 - 2026-08-15
 
 ### Fixed

--- a/custom_components/vaillant_ebus/coordinator.py
+++ b/custom_components/vaillant_ebus/coordinator.py
@@ -11,6 +11,7 @@ from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
@@ -53,6 +54,7 @@ EBUSD_STATUS_SUFFIXES: tuple[str, ...] = (
 )
 DELAYED_REDISCOVERY_DELAY = timedelta(minutes=5)
 ANALYSIS_INTERVAL = timedelta(minutes=15)
+PLACEHOLDER_POLL_INTERVAL = timedelta(minutes=15)
 
 
 # Build the per-field value dict for a register (split multi-field values).
@@ -125,6 +127,7 @@ class VaillantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._live_since_analysis: set[str] = set()
         self._cancel_analysis: Callable[[], None] | None = None
         self._analysis_scheduled = False
+        self._last_placeholder_poll = datetime.min
         self._analysis = AnalysisService()
         self.entity_adders: dict[str, Callable[[list[EntityDescription]], None]] = {}
 
@@ -376,20 +379,20 @@ class VaillantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
     # Enable entities that map to recently live registers (respect user choice).
     async def _enable_registry_entities(self, register_keys: list[str]) -> list[str]:
-        entity_registry = self.hass.helpers.entity_registry.async_get(self.hass)
+        registry = entity_registry.async_get(self.hass)
         desired_uids = {
             f"ebusd_{key.split('.')[0]}_{key.split('.', 1)[1].lower().replace(' ', '_')}"
             for key in register_keys
         }
         enabled: list[str] = []
-        for entity_id, entry in entity_registry.entities.items():
+        for entity_id, entry in registry.entities.items():
             if entry.config_entry_id != self._entry.entry_id:
                 continue
             if entry.unique_id not in desired_uids:
                 continue
             if entry.disabled_by != "integration":
                 continue
-            entity_registry.async_update_entity(entity_id, disabled_by=None)
+            registry.async_update_entity(entity_id, disabled_by=None)
             enabled.append(entity_id)
         if enabled:
             _LOGGER.info("Auto-enabled entities with live data: %s", ", ".join(enabled))
@@ -520,11 +523,17 @@ class VaillantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             via_device=via_device,
         )
 
-    async def _fallback_read(self) -> None:
+    async def _fallback_read(self, include_placeholders: bool = False) -> None:
         if not self.ebus or not self.ebus.is_connected:
             return
         graph_keys = self._last_find_keys
         to_read = [k for k in REGISTER_MAP if REGISTER_MAP[k].enabled and k not in graph_keys]
+        if include_placeholders and self._graph:
+            to_read.extend(
+                key
+                for key in self._graph.placeholder_registers
+                if key in REGISTER_MAP and REGISTER_MAP[key].enabled and key not in to_read
+            )
         if not to_read:
             return
         _LOGGER.info("Fallback reading %d known register(s)", len(to_read))
@@ -622,7 +631,11 @@ class VaillantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                         self.registers[key].has_data = True
                         updated += 1
                 self._last_find_keys = {k for k in self.registers}
-                await self._fallback_read()
+                now = datetime.now()
+                poll_placeholders = now - self._last_placeholder_poll >= PLACEHOLDER_POLL_INTERVAL
+                if poll_placeholders:
+                    self._last_placeholder_poll = now
+                await self._fallback_read(include_placeholders=poll_placeholders)
                 zero_idle_registers(self.registers)
                 if updated:
                     _LOGGER.info("Poll updated %d registers", updated)

--- a/custom_components/vaillant_ebus/manifest.json
+++ b/custom_components/vaillant_ebus/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/MarkBovee/vaillant-ebus/issues",
   "requirements": [],
-  "version": "1.3.3"
+  "version": "1.3.4"
 }

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -600,6 +600,26 @@ async def test_fallback_read_no_ebus_skips() -> None:
         await c._fallback_read()
 
 
+async def test_fallback_read_polls_known_placeholders() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        c = VaillantCoordinator(_hass(tmpdir), _entry())
+        mock_ebus = MagicMock(spec=EbusService)
+        mock_ebus.is_connected = True
+        mock_ebus.read_register = AsyncMock(return_value="25")
+        c.ebus = mock_ebus
+        c._graph = DeviceGraph(
+            nodes=_make_graph().nodes,
+            raw_registers=_make_graph().raw_registers,
+            placeholder_registers={"hmu.YieldHc"},
+        )
+        c._last_find_keys = set(c._graph.raw_registers) | {"hmu.YieldHc"}
+
+        await c._fallback_read(include_placeholders=True)
+
+        mock_ebus.read_register.assert_any_await("hmu", "YieldHc")
+        assert c.registers["hmu.YieldHc"].has_data is True
+
+
 async def test_get_device_info_uses_graph() -> None:
     with tempfile.TemporaryDirectory() as tmpdir:
         c = VaillantCoordinator(_hass(tmpdir), _entry())
@@ -883,7 +903,9 @@ async def test_enable_registry_entities_respects_user_choice() -> None:
         registry.async_update_entity = MagicMock(
             side_effect=lambda entity_id, **kwargs: updated.append(entity_id)
         )
-        hass.helpers.entity_registry.async_get = MagicMock(return_value=registry)
+        from homeassistant.helpers import entity_registry
+
+        entity_registry.async_get = MagicMock(return_value=registry)
 
         entry = _entry()
         entry.entry_id = "entry-1"


### PR DESCRIPTION
## Summary

- Fix `analyze_registers` entity registry access for current Home Assistant.
- Retry enabled placeholder energy and yield registers every 15 minutes.
- Update release metadata and changelog.
- Include existing `.gitignore` and `AGENTS.md` changes from the worktree.

## Validation

- `.venv/bin/ruff check .`
- `.venv/bin/pytest -q` (317 passed)
- `python3 -m compileall -f custom_components/vaillant_ebus/`
