### PR TITLE
release: v1.4.0 - per-zone climate + aroTHERM Plus energy circuit fix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,30 @@ telegrams; capture them with `grab` and mine the unknown ones for new registers.
 - Register candidates found this way must be verified against ebusd (message format,
   read-back value) before adding a `define -r` to `_define_custom_registers()`.
 
+## Upstream Issues/PRs as a Register Source
+
+The shipped CSVs in `john30/ebusd-configuration` and the compiled CDN copies run far
+behind the bus (see `john30/ebusd-configuration#632`). Do **not** expect unknown
+register definitions, field layouts, or message IDs to exist in the `.tsp`/CSV source.
+The working knowledge lives in that repo's **issues and pull requests** — people post
+CSV snippets, `define` strings, `find` output, and per-hardware field layouts there.
+
+- Search issues and PRs with `tools/search_upstream.sh`, which wraps `gh search`
+  against `john30/ebusd-configuration`:
+  - `tools/search_upstream.sh "PrEnergySum"` — issues matching title/body.
+  - `tools/search_upstream.sh --comments "YieldHwcDay"` — also match comment bodies
+    (most CSV snippets and layouts are pasted in comments).
+  - `tools/search_upstream.sh --all "SourceTempInput"` — issues and PRs.
+  - `tools/search_upstream.sh "query" "john30/ebusd"` — search another repo.
+- The ebusd-configuration repo has discussions **disabled**; search issues and PRs only.
+- When a promising thread is found, open it (`gh issue view <n> --comments`) and read
+  the full conversation before trusting a snippet. Prefer definitions that the reporter
+  verified against a live device.
+- Always cross-check candidates against a live ebusd (message format + read-back value)
+  before adding a `define -r` to `_define_custom_registers()` or a `REGISTER_MAP`/
+  `MULTI_FIELD_FIELDS` entry. Do not fabricate layouts from a single untested comment.
+- Never modify or upload ebusd CSV files and never set `--configpath`; that is addon-side.
+
 ## Known Limitations
 
 - Many heat-pump registers return `no data stored` while the compressor is idle.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,11 @@
   zone-scoped registers (`Z2DayTemp`, `Z2OpMode`, ...), unique ids, and devices.
   The `COOL` mode is only offered where the zone has a cooling register, and the
   `BOOST` preset only where quick-veto duration exists. Ghost zones (a zone that
-  exists on the bus but is unused — `RoomZoneMapping = none` and no live data) are
-  excluded so they never produce a permanently-unavailable climate entity.
-  Single-zone systems keep the existing `z1` entity ids unchanged.
+  exists on the bus but is unused — `RoomZoneMapping = none` and no measured
+  room temperature) are excluded so they never produce a permanently-unavailable
+  climate entity; static set-point defaults like `Z2DayTemp = 21` do not count as
+  live zone activity. Single-zone systems keep the existing `z1` entity ids
+  unchanged.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## 1.4.0 - 2026-08-19
+
+### Added
+
+- **Per-zone climate entities (#75).** One thermostat and flow-temperature-range
+  entity is now created for every discovered heating zone (zone 1, 2, 3), with
+  zone-scoped registers (`Z2DayTemp`, `Z2OpMode`, ...), unique ids, and devices.
+  The `COOL` mode is only offered where the zone has a cooling register, and the
+  `BOOST` preset only where quick-veto duration exists. Ghost zones (a zone that
+  exists on the bus but is unused — `RoomZoneMapping = none` and no live data) are
+  excluded so they never produce a permanently-unavailable climate entity.
+  Single-zone systems keep the existing `z1` entity ids unchanged.
+
+### Fixed
+
+- **Energy and yield sensors on aroTHERM Plus now populate from the correct
+  circuit (#53, #76, #77).** The fallback read used to read `PrEnergySum*` and
+  `StatElectricEnergySum*` / `StatEnvironmentEnergySum*` from the circuit where
+  their metadata lives (`ctlv2` / `hmu`), but aroTHERM Plus exposes them on the
+  `ctlv3` / `basv3` / `vwzio` controller circuit, so ebusd replied `ERR: element
+  not found` and the sensors stayed unavailable. The fallback read now resolves
+  the circuit where a register was actually discovered (mirroring the `get_meta`
+  alias) and reads it there, including the periodic retry of no-data registers.
+- **Missing yield day/month registers mapped.** `hmu.YieldHcMonth`,
+  `hmu.YieldHwcDay`, and `hmu.YieldHwcMonth` are now registered as energy sensors
+  (#77), so they are treated as enabled and picked up by the placeholder retry.
+
 ## 1.3.4 - 2026-08-17
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ The normal data flow is: connect to ebusd, define any runtime-only registers, di
 - Direct TCP connection to ebusd — zero MQTT setup required
 - Dynamically discovers available circuits and registers on connect
 - Generates native Home Assistant entities for sensors, controls, climate, water heating, calendars, and dates
-- Climate entities with quick veto and away mode (calendar-based scheduling)
+- Climate entities with quick veto and away mode (calendar-based scheduling) — one thermostat and flow-temperature-range per discovered heating zone on multi-zone systems
 - **Cooling control** — read and write the manual cooling period ("cool until [date]") via the climate COOL mode and dedicated datetime entities
 - Water heater entities with DHW boost and temperature control
 - Room humidity (CTLV2) — not available via standard ebusd MQTT

--- a/custom_components/vaillant_ebus/backend/mapping.py
+++ b/custom_components/vaillant_ebus/backend/mapping.py
@@ -234,11 +234,26 @@ REGISTER_MAP: dict[str, RegisterMeta] = {
         device_class="energy",
         unit="kWh",
     ),
+    "hmu.YieldHcMonth": RegisterMeta(
+        friendly_name="Yield Heating Month",
+        device_class="energy",
+        unit="kWh",
+    ),
     "hmu.YieldHwc": RegisterMeta(
         friendly_name="Yield DHW",
         device_class="energy",
         unit="kWh",
         state_class="total_increasing",
+    ),
+    "hmu.YieldHwcDay": RegisterMeta(
+        friendly_name="Yield DHW Today",
+        device_class="energy",
+        unit="kWh",
+    ),
+    "hmu.YieldHwcMonth": RegisterMeta(
+        friendly_name="Yield DHW Month",
+        device_class="energy",
+        unit="kWh",
     ),
     "hmu.YieldCoolDay": RegisterMeta(
         friendly_name="Yield Cooling Today",

--- a/custom_components/vaillant_ebus/climate.py
+++ b/custom_components/vaillant_ebus/climate.py
@@ -1,4 +1,4 @@
-"""Climate platform for the primary heating zone."""
+"""Climate platform: one thermostat and flow-temperature-range per heating zone."""
 
 from __future__ import annotations
 
@@ -31,8 +31,6 @@ from .coordinator import VaillantCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
-ZONE = "z1"
-
 HEATING_STATES = frozenset(
     {
         "heat_compressor_active",
@@ -52,6 +50,10 @@ COOLING_STATES = frozenset(
 DATE_FMT = "%d.%m.%Y"
 HOLIDAY_RESET = "01.01.2015"
 
+# Registers that gate per-zone features on the zone's owning circuit.
+COOLING_REGISTER = "CoolingTemp"
+QUICK_VETO_DURATION_REGISTER = "QuickVetoDuration"
+
 
 # Look up a string value from coordinator ebusd data by register name
 def _value(coordinator: VaillantCoordinator, register: str, circuit: str | None = None) -> str | None:
@@ -65,7 +67,7 @@ def _value(coordinator: VaillantCoordinator, register: str, circuit: str | None 
 def _float(value: str | None) -> float | None:
     try:
         return float(value) if value is not None else None
-    except TypeError, ValueError:
+    except (TypeError, ValueError):
         return None
 
 
@@ -75,50 +77,99 @@ def _hvac_mode(value: str | None) -> HVACMode | None:
     return HVACMode(ha) if ha else None
 
 
-# Create climate entities: zone thermostat and flow temperature range
+# Create climate entities: one thermostat and flow-temperature-range per zone
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     coordinator: VaillantCoordinator = hass.data[DOMAIN][entry.entry_id]
-    async_add_entities([EbusdClimate(coordinator, entry), EbusdFlowTempRange(coordinator, entry)])
+    created_zones: set[str] = set()
+
+    # Create thermostat + flow-temp-range for every zone not yet added. Runs at
+    # setup (falling back to z1 before discovery) and again after each applied
+    # discovery graph so zones that appear later still get their entities.
+    def _ensure_zone_entities() -> None:
+        zone_circuits = coordinator.zone_circuits()
+        if not zone_circuits:
+            zone_circuits = {"z1": coordinator.heating_circuit}
+        missing = [zone for zone in zone_circuits if zone not in created_zones]
+        if not missing:
+            return
+        entities: list[ClimateEntity] = []
+        for zone in missing:
+            created_zones.add(zone)
+            circuit = zone_circuits[zone]
+            entities.append(EbusdClimate(coordinator, entry, zone, circuit))
+            entities.append(EbusdFlowTempRange(coordinator, entry, zone, circuit))
+        async_add_entities(entities)
+
+    _ensure_zone_entities()
+    coordinator.register_post_discovery_callback(_ensure_zone_entities)
 
 
 class EbusdClimate(CoordinatorEntity[VaillantCoordinator], ClimateEntity):
     _attr_has_entity_name = True
-    _attr_name = "Home"
-    _attr_hvac_modes = [HVACMode.OFF, HVACMode.HEAT, HVACMode.COOL, HVACMode.AUTO]
-    _attr_preset_modes = [PRESET_NONE, PRESET_BOOST, PRESET_AWAY]
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
     _attr_min_temp = 5
     _attr_max_temp = 30
     _attr_target_temperature_step = 0.5
 
-    # Initialize zone climate entity with device info and optimistic state tracking
-    def __init__(self, coordinator: VaillantCoordinator, entry: ConfigEntry) -> None:
+    # Initialize zone climate entity with zone-scoped registers, identity, and
+    # per-zone feature support derived from the discovery graph.
+    def __init__(
+        self,
+        coordinator: VaillantCoordinator,
+        entry: ConfigEntry,
+        zone: str,
+        circuit: str,
+    ) -> None:
         super().__init__(coordinator)
-        self._attr_unique_id = f"{entry.entry_id}_climate_z1"
-        self._attr_device_info = coordinator.get_device_info(ZONE)
+        self._zone = zone
+        self._circuit = circuit
+        self._zn = zone.upper()
+        self._attr_unique_id = f"{entry.entry_id}_climate_{zone}"
+        self._attr_device_info = coordinator.get_device_info(zone)
+        self._attr_name = "Home" if zone == "z1" else f"Zone {zone[1:]}"
         self._optimistic_hvac_mode: HVACMode | None = None
         self._quick_veto_until: datetime | None = None
 
-    # Current room temperature from Z1RoomTemp
+    # HVAC modes are computed per zone from the discovery graph: COOL only where
+    # the zone's cooling register exists. Computed dynamically so a cache-seeded
+    # graph or late discovery self-corrects on the next coordinator update.
+    @property
+    def hvac_modes(self) -> list[HVACMode]:
+        modes = [HVACMode.OFF, HVACMode.HEAT]
+        if self.coordinator.has_zone_register(self._circuit, self._zone, COOLING_REGISTER):
+            modes.append(HVACMode.COOL)
+        modes.append(HVACMode.AUTO)
+        return modes
+
+    # Presets are computed per zone: BOOST only where quick-veto duration exists.
+    @property
+    def preset_modes(self) -> list[str]:
+        presets = [PRESET_NONE]
+        if self.coordinator.has_zone_register(self._circuit, self._zone, QUICK_VETO_DURATION_REGISTER):
+            presets.append(PRESET_BOOST)
+        presets.append(PRESET_AWAY)
+        return presets
+
+    # Current room temperature from the zone's room temp register
     @property
     def current_temperature(self) -> float | None:
-        return _float(_value(self.coordinator, "Z1RoomTemp"))
+        return _float(_value(self.coordinator, f"{self._zn}RoomTemp", self._circuit))
 
     # Target temperature: quick veto temp (boost) or actual/target, filtered to valid range
     @property
     def target_temperature(self) -> float | None:
         if self.preset_mode == PRESET_BOOST:
-            qv = _float(_value(self.coordinator, "Z1QuickVetoTemp"))
+            qv = _float(_value(self.coordinator, f"{self._zn}QuickVetoTemp", self._circuit))
             if qv is not None and 5 <= qv <= 30:
                 return qv
-        value = _float(_value(self.coordinator, "Z1ActualRoomTempDesired"))
+        value = _float(_value(self.coordinator, f"{self._zn}ActualRoomTempDesired", self._circuit))
         if value is not None and 5 <= value <= 30:
             return value
-        return _float(_value(self.coordinator, "Z1DayTemp"))
+        return _float(_value(self.coordinator, f"{self._zn}DayTemp", self._circuit))
 
     # Supported features: preset mode, target temp, turn on/off
     @property
@@ -130,20 +181,20 @@ class EbusdClimate(CoordinatorEntity[VaillantCoordinator], ClimateEntity):
             | ClimateEntityFeature.TURN_OFF
         )
 
-    # Current HVAC mode: optimistic value or ebusd Z1OpMode
+    # Current HVAC mode: optimistic value or ebusd zone op mode
     @property
     def hvac_mode(self) -> HVACMode | None:
         if self._optimistic_hvac_mode is not None:
             return self._optimistic_hvac_mode
-        return _hvac_mode(_value(self.coordinator, "Z1OpMode"))
+        return _hvac_mode(_value(self.coordinator, f"{self._zn}OpMode", self._circuit))
 
-    # HVAC action derived from HC1 status, pump, and compressor state
+    # HVAC action derived from zone status, pump, and heat-pump-global compressor state
     @property
     def hvac_action(self) -> HVACAction | None:
-        hc = _float(_value(self.coordinator, "Hc1Status"))
+        hc = _float(_value(self.coordinator, f"Hc{self._zone[1:]}Status", self._circuit))
         zone_active = hc is not None and hc > 0
         if hc is None:
-            pump = _value(self.coordinator, "Hc1PumpStatus")
+            pump = _value(self.coordinator, f"Hc{self._zone[1:]}PumpStatus", self._circuit)
             zone_active = (pump or "").lower() in ("on", "1", "true", "yes", "running")
         comp = (_value(self.coordinator, "RunDataStatuscode", self.coordinator.heat_pump_circuit) or "").lower()
         global_heat = comp in HEATING_STATES
@@ -169,8 +220,8 @@ class EbusdClimate(CoordinatorEntity[VaillantCoordinator], ClimateEntity):
     def preset_mode(self) -> str | None:
         if self._quick_veto_until and self._quick_veto_until > datetime.now():
             return PRESET_BOOST
-        h_start = _value(self.coordinator, "Z1HolidayStartPeriod")
-        h_end = _value(self.coordinator, "Z1HolidayEndPeriod")
+        h_start = _value(self.coordinator, f"{self._zn}HolidayStartPeriod", self._circuit)
+        h_end = _value(self.coordinator, f"{self._zn}HolidayEndPeriod", self._circuit)
         if h_start and h_end and h_start != HOLIDAY_RESET:
             try:
                 now = datetime.now().date()
@@ -197,7 +248,7 @@ class EbusdClimate(CoordinatorEntity[VaillantCoordinator], ClimateEntity):
         elif hvac_mode == HVACMode.HEAT:
             ok = await self._cancel_manual_cooling()
             if ok:
-                ok = await self._write("Z1OpMode", "day")
+                ok = await self._write(f"{self._zn}OpMode", "day")
         else:
             ebusd_mode = HA_TO_EBUSD_HVAC.get(hvac_mode.value)
             if ebusd_mode is None:
@@ -205,7 +256,7 @@ class EbusdClimate(CoordinatorEntity[VaillantCoordinator], ClimateEntity):
                 self.async_write_ha_state()
                 return
             try:
-                ok = await self._write("Z1OpMode", ebusd_mode)
+                ok = await self._write(f"{self._zn}OpMode", ebusd_mode)
             except Exception as exc:
                 _LOGGER.exception("set_hvac_mode failed: %s", exc)
                 ok = False
@@ -213,7 +264,7 @@ class EbusdClimate(CoordinatorEntity[VaillantCoordinator], ClimateEntity):
             self._optimistic_hvac_mode = None
             self.async_write_ha_state()
 
-    # Start manual cooling: write the end date (today + the configurable
+    # Start manual cooling: write the shared end date (today + the configurable
     # cooling_duration) through the central write path, then set the zone to
     # auto so the controller engages cooling. The controller manages the start
     # date itself, so only the end date is written.
@@ -224,14 +275,14 @@ class EbusdClimate(CoordinatorEntity[VaillantCoordinator], ClimateEntity):
             end = today + timedelta(days=days)
             writes = [
                 ("ctlv2", "ManualCoolingEndDate", end.strftime(DATE_FMT)),
-                (self.coordinator.heating_circuit, "Z1OpMode", "auto"),
+                (self._circuit, f"{self._zn}OpMode", "auto"),
             ]
             return await self.coordinator.async_write_registers(writes)
         except Exception as exc:
             _LOGGER.exception("start manual cooling failed: %s", exc)
             return False
 
-    # Cancel manual cooling by clearing the end date (reset to the holiday
+    # Cancel manual cooling by clearing the shared end date (reset to the holiday
     # reset sentinel) so the controller stops keeping a cooling period active.
     # The controller manages the start date itself.
     async def _cancel_manual_cooling(self) -> bool:
@@ -243,7 +294,7 @@ class EbusdClimate(CoordinatorEntity[VaillantCoordinator], ClimateEntity):
 
     # Set preset: boost (quick veto), away (holiday), or cancel
     async def async_set_preset_mode(self, preset_mode: str) -> None:
-        if preset_mode not in self._attr_preset_modes:
+        if preset_mode not in self.preset_modes:
             raise ValueError(f"Unsupported preset: {preset_mode}")
         current = self.preset_mode
         if current == PRESET_BOOST and preset_mode != PRESET_BOOST:
@@ -255,30 +306,30 @@ class EbusdClimate(CoordinatorEntity[VaillantCoordinator], ClimateEntity):
         elif preset_mode != PRESET_AWAY and current == PRESET_AWAY:
             await self._cancel_holiday()
 
-    # Set target temperature: write Z1DayTemp (manual) or Z1QuickVetoTemp (boost)
+    # Set target temperature: write zone day temp (manual) or quick veto temp (boost)
     async def async_set_temperature(self, **kwargs: Any) -> None:
         temp = kwargs.get(ATTR_TEMPERATURE)
         if temp is None:
             return
         if self.preset_mode == PRESET_BOOST:
-            await self._write("Z1QuickVetoTemp", str(temp))
+            await self._write(f"{self._zn}QuickVetoTemp", str(temp))
         else:
-            await self._write("Z1DayTemp", str(temp))
+            await self._write(f"{self._zn}DayTemp", str(temp))
 
     # Turn on by setting operation mode to auto
     async def async_turn_on(self) -> None:
-        await self._write("Z1OpMode", "auto")
+        await self._write(f"{self._zn}OpMode", "auto")
 
     # Turn off
     async def async_turn_off(self) -> None:
-        await self._write("Z1OpMode", "off")
+        await self._write(f"{self._zn}OpMode", "off")
 
     # Clear optimistic mode when ebusd confirms, expire quick veto timer
     def _handle_coordinator_update(self) -> None:
         if self._quick_veto_until and self._quick_veto_until <= datetime.now():
             self._quick_veto_until = None
         if self._optimistic_hvac_mode is not None:
-            confirmed = _hvac_mode(_value(self.coordinator, "Z1OpMode"))
+            confirmed = _hvac_mode(_value(self.coordinator, f"{self._zn}OpMode", self._circuit))
             if confirmed == self._optimistic_hvac_mode:
                 self._optimistic_hvac_mode = None
         super()._handle_coordinator_update()
@@ -287,17 +338,17 @@ class EbusdClimate(CoordinatorEntity[VaillantCoordinator], ClimateEntity):
     async def _cancel_quick_veto(self) -> None:
         self._quick_veto_until = None
         self.async_write_ha_state()
-        day_temp = _float(_value(self.coordinator, "Z1DayTemp"))
+        day_temp = _float(_value(self.coordinator, f"{self._zn}DayTemp", self._circuit))
         if day_temp is not None:
-            await self._write("Z1QuickVetoTemp", str(day_temp))
-        await self._write("Z1QuickVetoDuration", "0")
+            await self._write(f"{self._zn}QuickVetoTemp", str(day_temp))
+        await self._write(f"{self._zn}QuickVetoDuration", "0")
 
     # Start quick veto with specified temp or config-based default for N hours
     async def _start_quick_veto(self, temp_override: float | None = None) -> None:
         if temp_override is not None:
             veto_temp = temp_override
         else:
-            temp = _float(_value(self.coordinator, "Z1RoomTemp"))
+            temp = _float(_value(self.coordinator, f"{self._zn}RoomTemp", self._circuit))
             options = self.coordinator._entry.options
             veto_temp = options.get("quick_veto_temp")
             if veto_temp is None and temp is not None:
@@ -307,70 +358,81 @@ class EbusdClimate(CoordinatorEntity[VaillantCoordinator], ClimateEntity):
         options = self.coordinator._entry.options
         veto_duration = options.get("quick_veto_duration", 3)
         self._quick_veto_until = datetime.now() + timedelta(hours=veto_duration)
-        await self._write("Z1QuickVetoTemp", str(veto_temp))
-        await self._write("Z1QuickVetoDuration", str(veto_duration))
+        await self._write(f"{self._zn}QuickVetoTemp", str(veto_temp))
+        await self._write(f"{self._zn}QuickVetoDuration", str(veto_duration))
         self.async_write_ha_state()
 
-    # Start holiday period: set Z1HolidayStartPeriod/EndPeriod from today
+    # Start holiday period: set zone holiday start/end periods from today
     async def _start_holiday(self) -> None:
         today = datetime.now().date()
         away_duration = self.coordinator._entry.options.get("away_duration", 7)
-        await self._write("Z1HolidayStartPeriod", today.strftime(DATE_FMT))
-        await self._write("Z1HolidayEndPeriod", (today + timedelta(days=away_duration)).strftime(DATE_FMT))
-        ht = _float(_value(self.coordinator, "Z1HolidayTemp"))
+        await self._write(f"{self._zn}HolidayStartPeriod", today.strftime(DATE_FMT))
+        await self._write(f"{self._zn}HolidayEndPeriod", (today + timedelta(days=away_duration)).strftime(DATE_FMT))
+        ht = _float(_value(self.coordinator, f"{self._zn}HolidayTemp", self._circuit))
         if ht is None:
-            await self._write("Z1HolidayTemp", "15.0")
+            await self._write(f"{self._zn}HolidayTemp", "15.0")
 
     # Cancel holiday: reset dates to unset value
     async def _cancel_holiday(self) -> None:
-        await self._write("Z1HolidayStartPeriod", HOLIDAY_RESET)
-        await self._write("Z1HolidayEndPeriod", HOLIDAY_RESET)
+        await self._write(f"{self._zn}HolidayStartPeriod", HOLIDAY_RESET)
+        await self._write(f"{self._zn}HolidayEndPeriod", HOLIDAY_RESET)
 
-    # Write register to heating circuit through the central write path
+    # Write register to the zone's owning circuit through the central write path
     async def _write(self, name: str, value: str) -> bool:
-        return await self._write_raw(self.coordinator.heating_circuit, name, value)
-
-    # Write register to arbitrary circuit through the central write path
-    async def _write_raw(self, circuit: str, name: str, value: str) -> bool:
-        return await self.coordinator.async_write_register(circuit, name, value)
+        return await self.coordinator.async_write_register(self._circuit, name, value)
 
 
 class EbusdFlowTempRange(CoordinatorEntity[VaillantCoordinator], ClimateEntity):
     _attr_has_entity_name = True
-    _attr_name = "Flow Temperature Range"
     _attr_hvac_modes = [HVACMode.AUTO]
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
     _attr_min_temp = 5
     _attr_max_temp = 75
     _attr_target_temperature_step = 1
 
-    # Initialize flow temp range entity on z1 device
-    def __init__(self, coordinator: VaillantCoordinator, entry: ConfigEntry) -> None:
+    # Initialize flow temp range entity on the zone's device; zone 1 keeps the
+    # legacy unique id so existing single-zone installs are unchanged.
+    def __init__(
+        self,
+        coordinator: VaillantCoordinator,
+        entry: ConfigEntry,
+        zone: str,
+        circuit: str,
+    ) -> None:
         super().__init__(coordinator)
-        self._attr_unique_id = f"{entry.entry_id}_climate_flow_temp_range"
-        self._attr_device_info = coordinator.get_device_info("z1")
+        self._zone = zone
+        self._circuit = circuit
+        self._zn = zone.upper()
+        self._hc = f"Hc{zone[1:]}"
+        if zone == "z1":
+            self._attr_unique_id = f"{entry.entry_id}_climate_flow_temp_range"
+            self._attr_name = "Flow Temperature Range"
+        else:
+            self._attr_unique_id = f"{entry.entry_id}_climate_flow_temp_range_{zone}"
+            self._attr_name = f"Flow Temperature Range Zone {zone[1:]}"
+        self._attr_device_info = coordinator.get_device_info(zone)
 
     # Supports target temperature range (min/max flow temp)
     @property
     def supported_features(self) -> ClimateEntityFeature:
         return ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
 
-    # Current flow temperature from Hc1FlowTemp
+    # Current flow temperature from the zone's circuit flow temp register
     @property
     def current_temperature(self) -> float | None:
-        return _float(_value(self.coordinator, "Hc1FlowTemp"))
+        return _float(_value(self.coordinator, f"{self._hc}FlowTemp", self._circuit))
 
-    # Minimum flow temperature target from Hc1MinFlowTempDesired
+    # Minimum flow temperature target
     @property
     def target_temperature_low(self) -> float | None:
-        return _float(_value(self.coordinator, "Hc1MinFlowTempDesired"))
+        return _float(_value(self.coordinator, f"{self._hc}MinFlowTempDesired", self._circuit))
 
-    # Maximum flow temperature target from Hc1MaxFlowTempDesired
+    # Maximum flow temperature target
     @property
     def target_temperature_high(self) -> float | None:
-        return _float(_value(self.coordinator, "Hc1MaxFlowTempDesired"))
+        return _float(_value(self.coordinator, f"{self._hc}MaxFlowTempDesired", self._circuit))
 
-    # HVAC action from compressor status (heating/cooling/idle/off)
+    # HVAC action from heat-pump-global compressor status (heating/cooling/idle/off)
     @property
     def hvac_action(self) -> HVACAction | None:
         comp = (_value(self.coordinator, "RunDataStatuscode", self.coordinator.heat_pump_circuit) or "").lower()
@@ -384,24 +446,24 @@ class EbusdFlowTempRange(CoordinatorEntity[VaillantCoordinator], ClimateEntity):
             return HVACAction.IDLE
         return HVACAction.OFF
 
-    # HVAC mode from Z1OpMode
+    # HVAC mode from the zone's op mode register
     @property
     def hvac_mode(self) -> HVACMode | None:
-        return _hvac_mode(_value(self.coordinator, "Z1OpMode"))
+        return _hvac_mode(_value(self.coordinator, f"{self._zn}OpMode", self._circuit))
 
     @property
     def available(self) -> bool:
         return self.coordinator.last_update_success
 
-    # Set min/max flow temperature range via Hc1Min/MaxFlowTempDesired
+    # Set min/max flow temperature range via the zone's circuit registers
     async def async_set_temperature(self, **kwargs: Any) -> None:
         low = kwargs.get("target_temp_low")
         high = kwargs.get("target_temp_high")
         if low is not None:
-            await self._write("Hc1MinFlowTempDesired", str(int(low)))
+            await self._write(f"{self._hc}MinFlowTempDesired", str(int(low)))
         if high is not None:
-            await self._write("Hc1MaxFlowTempDesired", str(int(high)))
+            await self._write(f"{self._hc}MaxFlowTempDesired", str(int(high)))
 
-    # Write register to heating circuit through the central write path
+    # Write register to the zone's owning circuit through the central write path
     async def _write(self, name: str, value: str) -> bool:
-        return await self.coordinator.async_write_register(self.coordinator.heating_circuit, name, value)
+        return await self.coordinator.async_write_register(self._circuit, name, value)

--- a/custom_components/vaillant_ebus/coordinator.py
+++ b/custom_components/vaillant_ebus/coordinator.py
@@ -56,8 +56,16 @@ DELAYED_REDISCOVERY_DELAY = timedelta(minutes=5)
 ANALYSIS_INTERVAL = timedelta(minutes=15)
 PLACEHOLDER_POLL_INTERVAL = timedelta(minutes=15)
 
-# Core registers whose live data mark a discovered zone as genuinely present.
-ZONE_CORE_REGISTERS: tuple[str, ...] = ("RoomTemp", "DayTemp", "OpMode", "ActualRoomTempDesired")
+# Registers whose live (non-sentinel) value marks a discovered zone as
+# genuinely present. DayTemp/OpMode are excluded: ebusd reports static
+# defaults for these even on unused zones, so they cannot distinguish a real
+# zone from a ghost.
+ZONE_LIVE_REGISTERS: tuple[str, ...] = ("RoomTemp", "ActualRoomTempDesired")
+
+# ebusd values that mean "no usable data" rather than a measured value.
+ZONE_SENTINEL_VALUES: frozenset[str] = frozenset(
+    {"", "-", "empty", "unknown", "unavailable", "no data stored", "none"}
+)
 
 
 # Build the per-field value dict for a register (split multi-field values).
@@ -197,11 +205,16 @@ class VaillantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         mapping = self._graph.raw_registers.get(f"{circuit}.{zn}RoomZoneMapping")
         if mapping is not None:
             normalized = mapping.strip().lower()
-            if normalized and normalized != "none":
+            if normalized and normalized not in ZONE_SENTINEL_VALUES:
                 return True
-        return any(
-            f"{circuit}.{zn}{name}" in self._graph.raw_registers for name in ZONE_CORE_REGISTERS
-        )
+        # Fall back to a measured value on a live register. Static defaults
+        # (DayTemp/OpMode) and sentinel values (empty/unknown/no data stored)
+        # do not prove the zone is real.
+        for name in ZONE_LIVE_REGISTERS:
+            value = self._graph.raw_registers.get(f"{circuit}.{zn}{name}")
+            if value is not None and value.strip().lower() not in ZONE_SENTINEL_VALUES:
+                return True
+        return False
 
     # Whether `circuit.<ZN><name>` was discovered on the bus. Both live values
     # and no-data placeholders count as present: ebusd returns `no data stored`

--- a/custom_components/vaillant_ebus/coordinator.py
+++ b/custom_components/vaillant_ebus/coordinator.py
@@ -523,27 +523,73 @@ class VaillantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             via_device=via_device,
         )
 
+    def _fallback_candidate(self, name: str) -> str | None:
+        """Return the circuit to read a register from.
+
+        Prefer the circuit where the register was discovered (its raw or
+        placeholder graph key); otherwise fall back to the literal map circuit.
+        Mirrors the ctlv2/hmu aliasing used by get_meta() so registers that
+        live under basv3/ctlv3/vwzio are read from the correct circuit.
+        """
+        if self._graph:
+            for rk in self._graph.raw_registers:
+                if rk.endswith(f".{name}"):
+                    return rk.split(".", 1)[0]
+            for rk in self._graph.placeholder_registers:
+                if rk.endswith(f".{name}"):
+                    return rk.split(".", 1)[0]
+        return None
+
     async def _fallback_read(self, include_placeholders: bool = False) -> None:
         if not self.ebus or not self.ebus.is_connected:
             return
         graph_keys = self._last_find_keys
-        to_read = [k for k in REGISTER_MAP if REGISTER_MAP[k].enabled and k not in graph_keys]
+        # Resolve the REGISTER_MAP entry for a discovered register, applying the
+        # same ctlv2/hmu circuit aliasing as get_meta().
+        def _meta_key(circuit: str, name: str) -> str | None:
+            for alt in (circuit, "ctlv2", "hmu"):
+                key = f"{alt}.{name}"
+                if key in REGISTER_MAP:
+                    return key
+            return None
+
+        candidates: list[tuple[str, str]] = []
+        seen: set[tuple[str, str]] = set()
+
+        def _add(circuit: str, name: str) -> None:
+            key = (circuit, name)
+            if key not in seen:
+                seen.add(key)
+                candidates.append(key)
+
+        # Map-driven reads: registers with metadata not yet in the graph.
+        for key in REGISTER_MAP:
+            meta = REGISTER_MAP[key]
+            if not meta.enabled or key in graph_keys:
+                continue
+            map_circuit, name = key.split(".", 1)
+            circuit = self._fallback_candidate(name)
+            _add(circuit or map_circuit, name)
+
+        # Placeholder reads: discovered no-data registers whose metadata
+        # resolves via the circuit alias (15-minute interval).
         if include_placeholders and self._graph:
-            to_read.extend(
-                key
-                for key in self._graph.placeholder_registers
-                if key in REGISTER_MAP and REGISTER_MAP[key].enabled and key not in to_read
-            )
-        if not to_read:
+            for key in self._graph.placeholder_registers:
+                parts = key.split(".", 1)
+                if len(parts) != 2:
+                    continue
+                circuit, name = parts
+                meta_key = _meta_key(circuit, name)
+                if meta_key and REGISTER_MAP[meta_key].enabled:
+                    _add(circuit, name)
+
+        if not candidates:
             return
-        _LOGGER.info("Fallback reading %d known register(s)", len(to_read))
+        _LOGGER.info("Fallback reading %d known register(s)", len(candidates))
         added = 0
         read_with_data = 0
-        for key in to_read:
-            parts = key.split(".", 1)
-            if len(parts) != 2:
-                continue
-            circuit, name = parts
+        for circuit, name in candidates:
+            key = f"{circuit}.{name}"
             try:
                 value = await self.ebus.read_register(circuit, name)
                 was_new = key not in self.registers
@@ -585,7 +631,7 @@ class VaillantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 self._last_find_keys.add(key)
             _LOGGER.info("Fallback read added %d register(s) to discovery", added)
         else:
-            _LOGGER.info("Fallback read complete: %d/%d registers with data", read_with_data, len(to_read))
+            _LOGGER.info("Fallback read complete: %d/%d registers with data", read_with_data, len(candidates))
 
     async def _async_update_data(self) -> dict[str, Any]:
         if not self._cache_seeded:

--- a/custom_components/vaillant_ebus/coordinator.py
+++ b/custom_components/vaillant_ebus/coordinator.py
@@ -56,6 +56,9 @@ DELAYED_REDISCOVERY_DELAY = timedelta(minutes=5)
 ANALYSIS_INTERVAL = timedelta(minutes=15)
 PLACEHOLDER_POLL_INTERVAL = timedelta(minutes=15)
 
+# Core registers whose live data mark a discovered zone as genuinely present.
+ZONE_CORE_REGISTERS: tuple[str, ...] = ("RoomTemp", "DayTemp", "OpMode", "ActualRoomTempDesired")
+
 
 # Build the per-field value dict for a register (split multi-field values).
 def _register_values(register_key: str, raw: str | None) -> dict[str, str | None]:
@@ -130,6 +133,7 @@ class VaillantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._last_placeholder_poll = datetime.min
         self._analysis = AnalysisService()
         self.entity_adders: dict[str, Callable[[list[EntityDescription]], None]] = {}
+        self._post_discovery_callbacks: list[Callable[[], None]] = []
 
         scan_interval = entry.data.get(CONF_SCAN_INTERVAL, DEFAULT_EBUSD_POLL_INTERVAL)
         super().__init__(
@@ -164,6 +168,57 @@ class VaillantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 if node.device_type == DeviceType.HEAT_PUMP:
                     return node.circuit
         return "hmu"
+
+    # Active heating zones (zone id -> hosting circuit) derived from the
+    # discovery graph. A zone counts as active when it has a room-zone mapping
+    # (ZNRoomZoneMapping with a value other than none/empty) or live data on a
+    # core register (ZNRoomTemp / ZNDayTemp / ZNOpMode / ZNActualRoomTempDesired).
+    # Ghost zones - every ZN register present but unused (mapping none and no
+    # live data) - are skipped so they never produce a permanently-unavailable
+    # climate entity. Deliberately NOT filtered on the zone node's has_data:
+    # ebusd reports ghost mapping values like "none" as real register values.
+    def zone_circuits(self) -> dict[str, str]:
+        zones: dict[str, str] = {}
+        if not self._graph:
+            return zones
+        for node in self._graph.nodes.values():
+            for zone in node.zone_circuits:
+                if zone in zones:
+                    continue
+                if self._zone_is_valid(node.circuit, zone):
+                    zones[zone] = node.circuit
+        return zones
+
+    # Whether a discovered zone is a real heating zone rather than a ghost.
+    def _zone_is_valid(self, circuit: str, zone: str) -> bool:
+        if self._graph is None:
+            return False
+        zn = zone.upper()
+        mapping = self._graph.raw_registers.get(f"{circuit}.{zn}RoomZoneMapping")
+        if mapping is not None:
+            normalized = mapping.strip().lower()
+            if normalized and normalized != "none":
+                return True
+        return any(
+            f"{circuit}.{zn}{name}" in self._graph.raw_registers for name in ZONE_CORE_REGISTERS
+        )
+
+    # Whether `circuit.<ZN><name>` was discovered on the bus. Both live values
+    # and no-data placeholders count as present: ebusd returns `no data stored`
+    # for registers the hardware supports while they are idle. Until a real
+    # discovery has populated the find set, absence is not proof of hardware
+    # absence (cache-seeded graphs only carry live values), so the register is
+    # assumed present to preserve the pre-per-zone behavior.
+    def has_zone_register(self, circuit: str, zone: str, name: str) -> bool:
+        if not self._graph or not self._last_find_keys:
+            return True
+        key = f"{circuit}.{zone.upper()}{name}"
+        if key in self._graph.raw_registers or key in self._graph.placeholder_registers:
+            return True
+        lower = key.lower()
+        return any(rk.lower() == lower for rk in self._graph.raw_registers) or any(
+            rk.lower() == lower for rk in self._graph.placeholder_registers
+        )
 
     async def _async_seed_entities_from_cache(self) -> None:
         cache = await self._async_load_cache()
@@ -286,6 +341,11 @@ class VaillantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             ", ".join(f"{count} {ptype}" for ptype, count in sorted(platform_counts.items())),
         )
         self.async_update_listeners()
+        for callback in self._post_discovery_callbacks:
+            try:
+                callback()
+            except Exception:
+                _LOGGER.warning("Post-discovery callback failed", exc_info=True)
 
     # Schedule exactly one delayed pass for ebusd values unavailable at startup.
     def _schedule_delayed_rediscovery(self) -> None:
@@ -355,6 +415,11 @@ class VaillantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self, entity_type: str, callback: Callable[[list[EntityDescription]], None]
     ) -> None:
         self.entity_adders[entity_type] = callback
+
+    # Register a callback invoked after every applied discovery graph, so
+    # hand-built platforms (climate) can add entities once the graph exists.
+    def register_post_discovery_callback(self, callback: Callable[[], None]) -> None:
+        self._post_discovery_callbacks.append(callback)
 
     # Run a background analysis pass on-demand (used by the analyze service).
     async def async_run_analysis(self) -> None:

--- a/custom_components/vaillant_ebus/manifest.json
+++ b/custom_components/vaillant_ebus/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/MarkBovee/vaillant-ebus/issues",
   "requirements": [],
-  "version": "1.3.4"
+  "version": "1.4.0"
 }

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -1,0 +1,480 @@
+"""Unit tests for the climate platform — per-zone thermostat and flow range.
+
+Reuses the homeassistant mock scaffolding from tests.test_coordinator so both
+files share one set of sys.modules entries (importing a test module does not
+re-collect it under pytest).
+"""
+
+from __future__ import annotations
+
+import enum
+import importlib.machinery
+import importlib.util
+import sys
+import tempfile
+from datetime import datetime, timedelta
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+from tests import test_coordinator as tc  # noqa: F401 — installs shared HA mocks
+
+PROJECT_ROOT = Path(__file__).parents[1]
+COMPONENT_PATH = PROJECT_ROOT / "custom_components/vaillant_ebus"
+
+mock_homeassistant = sys.modules["homeassistant"]
+
+
+class HVACMode(enum.StrEnum):
+    OFF = "off"
+    HEAT = "heat"
+    COOL = "cool"
+    AUTO = "auto"
+
+
+class HVACAction(enum.StrEnum):
+    OFF = "off"
+    HEATING = "heating"
+    COOLING = "cooling"
+    IDLE = "idle"
+
+
+class ClimateEntityFeature(enum.IntFlag):
+    TARGET_TEMPERATURE = 1
+    TARGET_TEMPERATURE_RANGE = 2
+    PRESET_MODE = 4
+    TURN_ON = 8
+    TURN_OFF = 16
+
+
+class _MockClimateEntity:
+    @property
+    def unique_id(self) -> str | None:
+        return getattr(self, "_attr_unique_id", None)
+
+    @property
+    def hvac_modes(self) -> list:
+        return getattr(self, "_attr_hvac_modes", [])
+
+    @property
+    def preset_modes(self) -> list:
+        return getattr(self, "_attr_preset_modes", [])
+
+
+class _MockCoordinatorEntity(_MockClimateEntity):
+    def __init__(self, coordinator) -> None:
+        self.coordinator = coordinator
+
+    def async_write_ha_state(self) -> None:
+        pass
+
+    def _handle_coordinator_update(self) -> None:
+        pass
+
+    async def async_update(self) -> None:
+        pass
+
+    def __class_getitem__(cls, item):
+        return cls
+
+
+class _UnitOfTemperature:
+    CELSIUS = "°C"
+
+
+components_pkg = importlib.util.module_from_spec(importlib.machinery.ModuleSpec("homeassistant.components", None))
+climate_pkg = importlib.util.module_from_spec(
+    importlib.machinery.ModuleSpec("homeassistant.components.climate", None)
+)
+climate_const = importlib.util.module_from_spec(
+    importlib.machinery.ModuleSpec("homeassistant.components.climate.const", None)
+)
+climate_pkg.ClimateEntity = _MockClimateEntity
+climate_pkg.ClimateEntityFeature = ClimateEntityFeature
+climate_const.PRESET_AWAY = "away"
+climate_const.PRESET_BOOST = "boost"
+climate_const.PRESET_NONE = "none"
+climate_const.HVACAction = HVACAction
+climate_const.HVACMode = HVACMode
+sys.modules["homeassistant.components"] = components_pkg
+sys.modules["homeassistant.components.climate"] = climate_pkg
+sys.modules["homeassistant.components.climate.const"] = climate_const
+
+ha_const = sys.modules["homeassistant.const"]
+ha_const.ATTR_TEMPERATURE = "temperature"
+ha_const.UnitOfTemperature = _UnitOfTemperature
+
+entity_platform = importlib.util.module_from_spec(
+    importlib.machinery.ModuleSpec("homeassistant.helpers.entity_platform", None)
+)
+entity_platform.AddEntitiesCallback = object
+sys.modules["homeassistant.helpers.entity_platform"] = entity_platform
+
+mock_homeassistant.helpers.update_coordinator.CoordinatorEntity = _MockCoordinatorEntity
+mock_homeassistant.config_entries.ConfigEntry = object
+mock_homeassistant.core.HomeAssistant = object
+
+const_module = sys.modules["vaillant_ebus.const"]
+const_module.CONF_COOLING_DURATION = "cooling_duration"
+const_module.DEFAULT_COOLING_DURATION = 3
+const_module.EBUSD_TO_HA_HVAC = {
+    "off": "off",
+    "auto": "auto",
+    "day": "heat",
+    "night": "cool",
+    "heat": "heat",
+    "cool": "cool",
+}
+const_module.HA_TO_EBUSD_HVAC = {"off": "off", "auto": "auto", "heat": "day"}
+
+CLIMATE_SPEC = importlib.util.spec_from_file_location("vaillant_ebus.climate", COMPONENT_PATH / "climate.py")
+assert CLIMATE_SPEC and CLIMATE_SPEC.loader
+CLIMATE = importlib.util.module_from_spec(CLIMATE_SPEC)
+sys.modules["vaillant_ebus.climate"] = CLIMATE
+CLIMATE_SPEC.loader.exec_module(CLIMATE)
+
+from vaillant_ebus.backend.models import DeviceGraph, DeviceNode, DeviceType  # noqa: E402
+from vaillant_ebus.climate import EbusdClimate, EbusdFlowTempRange  # noqa: E402
+from vaillant_ebus.coordinator import VaillantCoordinator  # noqa: E402
+
+
+def _entry(entry_id: str = "entry-1", options: dict | None = None) -> MagicMock:
+    e = MagicMock()
+    e.entry_id = entry_id
+    e.options = options or {}
+    e.data = {}
+    return e
+
+
+def _coordinator(
+    tmpdir: str, graph: DeviceGraph | None, data: dict | None = None, options: dict | None = None
+) -> VaillantCoordinator:
+    c = VaillantCoordinator(tc._hass(tmpdir), _entry(options=options))
+    c._graph = graph
+    if graph is not None:
+        # Mirrors _apply_discovery_graph: the find set marks discovery complete.
+        c._last_find_keys = set(graph.raw_registers)
+    c.ebus = MagicMock()
+    c.ebus.version = "23.2"
+    c.data = data or {"ebusd": {}}
+    return c
+
+
+# Two-zone graph on ctlv2 (mirrors the #75 multizone fixture). With full
+# parity, the Z2 cooling/quick-veto registers are present as placeholders.
+def _graph_two_zone(full_parity: bool = True) -> DeviceGraph:
+    raw_registers = {
+        "hmu.RunDataStatuscode": "standby",
+        "ctlv2.Z1RoomTemp": "21.5",
+        "ctlv2.Z1DayTemp": "22.0",
+        "ctlv2.Z1OpMode": "day",
+        "ctlv2.Z1ActualRoomTempDesired": "22.0",
+        "ctlv2.Z2RoomTemp": "20.5",
+        "ctlv2.Z2DayTemp": "21.0",
+        "ctlv2.Z2OpMode": "auto",
+        "ctlv2.Z2ActualRoomTempDesired": "21.0",
+        "ctlv2.Hc1FlowTemp": "35.0",
+        "ctlv2.Hc2FlowTemp": "30.0",
+    }
+    placeholders: set[str] = set()
+    if full_parity:
+        placeholders.update(
+            {
+                "ctlv2.Z1CoolingTemp",
+                "ctlv2.Z1QuickVetoDuration",
+                "ctlv2.Z2CoolingTemp",
+                "ctlv2.Z2QuickVetoDuration",
+            }
+        )
+    nodes = {
+        "hmu": DeviceNode(
+            circuit="hmu",
+            device_type=DeviceType.HEAT_PUMP,
+            registers=["hmu.RunDataStatuscode"],
+            has_data=True,
+            scan_type="HMU00",
+        ),
+        "ctlv2": DeviceNode(
+            circuit="ctlv2",
+            device_type=DeviceType.HEATING_CONTROLLER,
+            registers=[],
+            has_data=True,
+            zone_circuits=["z1", "z2"],
+            parent="hmu",
+            scan_type="CTLV2",
+        ),
+        "z1": DeviceNode(
+            circuit="z1",
+            device_type=DeviceType.ZONE,
+            registers=["ctlv2.Z1RoomTemp"],
+            has_data=True,
+            parent="ctlv2",
+        ),
+        "z2": DeviceNode(
+            circuit="z2",
+            device_type=DeviceType.ZONE,
+            registers=["ctlv2.Z2RoomTemp"],
+            has_data=True,
+            parent="ctlv2",
+        ),
+    }
+    return DeviceGraph(nodes=nodes, raw_registers=raw_registers, placeholder_registers=placeholders)
+
+
+# Single-zone graph: only z1 carries live data; z2 registers are placeholders.
+def _graph_single_zone() -> DeviceGraph:
+    graph = _graph_two_zone(full_parity=True)
+    graph.nodes["z2"].has_data = False
+    for name in ("Z2RoomTemp", "Z2DayTemp", "Z2OpMode", "Z2ActualRoomTempDesired"):
+        graph.raw_registers.pop(f"ctlv2.{name}")
+        graph.placeholder_registers.add(f"ctlv2.{name}")
+    return graph
+
+
+# Ghost-zone graph: every Z2 register exists but is unused — mapping "none" and
+# no live core data — so z2 must NOT get a climate entity.
+def _graph_ghost_zone() -> DeviceGraph:
+    graph = _graph_single_zone()
+    graph.raw_registers["ctlv2.Z2RoomZoneMapping"] = "none"
+    graph.nodes["z2"].has_data = True
+    return graph
+
+
+# Real-but-idle graph: z2 has a real thermostat mapping but no live data yet,
+# so the climate entity exists but reports unavailable values.
+def _graph_idle_zone() -> DeviceGraph:
+    graph = _graph_single_zone()
+    graph.raw_registers["ctlv2.Z2RoomZoneMapping"] = "VR91_1"
+    return graph
+
+
+def _setup_data() -> dict:
+    return {
+        "ebusd": {
+            "ctlv2.Z1RoomTemp.value": "21.5",
+            "ctlv2.Z2RoomTemp.value": "20.5",
+            "ctlv2.Hc2FlowTemp.value": "30.0",
+        }
+    }
+
+
+async def test_async_setup_entry_creates_per_zone_entities() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        coordinator = _coordinator(tmpdir, _graph_two_zone(), _setup_data())
+        hass = MagicMock()
+        hass.data = {"vaillant_ebus": {"entry-1": coordinator}}
+        added: list = []
+        await CLIMATE.async_setup_entry(hass, _entry(), lambda entities: added.extend(entities))
+
+        climates = [e for e in added if isinstance(e, EbusdClimate)]
+        ranges = [e for e in added if isinstance(e, EbusdFlowTempRange)]
+        assert len(climates) == 2
+        assert len(ranges) == 2
+        z1 = next(e for e in climates if e._attr_unique_id.endswith("_climate_z1"))
+        z2 = next(e for e in climates if e._attr_unique_id.endswith("_climate_z2"))
+        assert z1._attr_unique_id == "entry-1_climate_z1"
+        assert z2._attr_unique_id == "entry-1_climate_z2"
+        assert z1._attr_device_info["identifiers"] == {("vaillant_ebus", "z1")}
+        assert z2._attr_device_info["identifiers"] == {("vaillant_ebus", "z2")}
+        assert {r._attr_unique_id for r in ranges} == {
+            "entry-1_climate_flow_temp_range",
+            "entry-1_climate_flow_temp_range_z2",
+        }
+
+
+# Intent: a zone-2 thermostat reads its own Z2 registers, not Z1's.
+async def test_zone2_reads_own_registers() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        coordinator = _coordinator(tmpdir, _graph_two_zone(), _setup_data())
+        z2 = EbusdClimate(coordinator, _entry(), "z2", "ctlv2")
+        z1 = EbusdClimate(coordinator, _entry(), "z1", "ctlv2")
+        assert z2.current_temperature == 20.5
+        assert z1.current_temperature == 21.5
+
+
+# Intent: target-temperature writes go to the zone's own registers on its circuit.
+async def test_zone2_set_temperature_writes_z2_registers() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        coordinator = _coordinator(tmpdir, _graph_two_zone())
+        coordinator.async_write_register = AsyncMock(return_value=True)
+        z2 = EbusdClimate(coordinator, _entry(), "z2", "ctlv2")
+        await z2.async_set_temperature(temperature=22.0)
+        coordinator.async_write_register.assert_awaited_once_with("ctlv2", "Z2DayTemp", "22.0")
+
+
+# Intent: boost on a zone with quick-veto support writes the zone's veto registers.
+async def test_zone2_boost_writes_quick_veto() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        coordinator = _coordinator(
+            tmpdir,
+            _graph_two_zone(),
+            data={"ebusd": {"ctlv2.Z2RoomTemp.value": "20.5"}},
+            options={"quick_veto_temp": 23.0},
+        )
+        coordinator.async_write_register = AsyncMock(return_value=True)
+        z2 = EbusdClimate(coordinator, _entry(), "z2", "ctlv2")
+        await z2.async_set_preset_mode("boost")
+        calls = [(c.args[0], c.args[1], c.args[2]) for c in coordinator.async_write_register.call_args_list]
+        assert ("ctlv2", "Z2QuickVetoTemp", "23.0") in calls
+        assert ("ctlv2", "Z2QuickVetoDuration", "3") in calls
+
+
+# Intent: COOL and BOOST are hidden for zones without the supporting registers.
+async def test_cool_and_boost_omitted_without_registers() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        coordinator = _coordinator(tmpdir, _graph_two_zone(full_parity=False))
+        z2 = EbusdClimate(coordinator, _entry(), "z2", "ctlv2")
+        z1 = EbusdClimate(coordinator, _entry(), "z1", "ctlv2")
+        assert HVACMode.COOL not in z2.hvac_modes
+        assert "boost" not in z2.preset_modes
+        assert HVACMode.COOL not in z1.hvac_modes
+        assert "boost" not in z1.preset_modes
+
+
+# Intent: a zone with full parity offers COOL, HEAT, AUTO and all presets.
+async def test_cool_and_boost_offered_with_registers() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        coordinator = _coordinator(tmpdir, _graph_two_zone(full_parity=True))
+        z2 = EbusdClimate(coordinator, _entry(), "z2", "ctlv2")
+        assert z2.hvac_modes == [HVACMode.OFF, HVACMode.HEAT, HVACMode.COOL, HVACMode.AUTO]
+        assert z2.preset_modes == ["none", "boost", "away"]
+
+
+# Intent: single-zone systems keep exactly the legacy z1 entities and ids.
+async def test_single_zone_setup_keeps_z1_identity() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        coordinator = _coordinator(tmpdir, _graph_single_zone(), _setup_data())
+        hass = MagicMock()
+        hass.data = {"vaillant_ebus": {"entry-1": coordinator}}
+        added: list = []
+        await CLIMATE.async_setup_entry(hass, _entry(), lambda entities: added.extend(entities))
+
+        assert len(added) == 2
+        assert added[0]._attr_unique_id == "entry-1_climate_z1"
+        assert added[1]._attr_unique_id == "entry-1_climate_flow_temp_range"
+        assert added[0]._attr_name == "Home"
+
+
+# Intent: ghost zones (mapping "none", no live core data) get no climate entity.
+async def test_ghost_zone_gets_no_climate_entity() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        coordinator = _coordinator(tmpdir, _graph_ghost_zone(), _setup_data())
+        hass = MagicMock()
+        hass.data = {"vaillant_ebus": {"entry-1": coordinator}}
+        added: list = []
+        await CLIMATE.async_setup_entry(hass, _entry(), lambda entities: added.extend(entities))
+
+        assert len(added) == 2
+        assert {e._attr_unique_id for e in added} == {
+            "entry-1_climate_z1",
+            "entry-1_climate_flow_temp_range",
+        }
+
+
+# Intent: with no discovery graph yet, setup falls back to z1 with full
+# features (COOL/BOOST assumed present), preserving pre-per-zone behavior.
+async def test_setup_with_empty_graph_keeps_z1_full_features() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        coordinator = _coordinator(tmpdir, None, _setup_data())
+        hass = MagicMock()
+        hass.data = {"vaillant_ebus": {"entry-1": coordinator}}
+        added: list = []
+        await CLIMATE.async_setup_entry(hass, _entry(), lambda entities: added.extend(entities))
+
+        assert len(added) == 2
+        z1 = added[0]
+        assert z1._attr_unique_id == "entry-1_climate_z1"
+        assert HVACMode.COOL in z1.hvac_modes
+        assert "boost" in z1.preset_modes
+
+
+# Intent: zones discovered after setup still get their climate entities via the
+# post-discovery callback, so a fresh install does not require an entry reload.
+async def test_post_discovery_adds_missing_zone_entities() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        coordinator = _coordinator(tmpdir, None, _setup_data())
+        hass = MagicMock()
+        hass.data = {"vaillant_ebus": {"entry-1": coordinator}}
+        added: list = []
+        await CLIMATE.async_setup_entry(hass, _entry(), lambda entities: added.extend(entities))
+        assert len(added) == 2
+
+        graph = _graph_two_zone()
+        coordinator._graph = graph
+        coordinator._last_find_keys = set(graph.raw_registers)
+        for callback in coordinator._post_discovery_callbacks:
+            callback()
+
+        assert len(added) == 4
+        assert {e._attr_unique_id for e in added} == {
+            "entry-1_climate_z1",
+            "entry-1_climate_flow_temp_range",
+            "entry-1_climate_z2",
+            "entry-1_climate_flow_temp_range_z2",
+        }
+
+
+# Intent: a real but idle zone still gets a climate entity; reads are unavailable.
+async def test_real_idle_zone_gets_climate_entity() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        coordinator = _coordinator(tmpdir, _graph_idle_zone(), {"ebusd": {"ctlv2.Z1RoomTemp.value": "21.5"}})
+        hass = MagicMock()
+        hass.data = {"vaillant_ebus": {"entry-1": coordinator}}
+        added: list = []
+        await CLIMATE.async_setup_entry(hass, _entry(), lambda entities: added.extend(entities))
+
+        assert len(added) == 4
+        z2 = next(e for e in added if e._attr_unique_id == "entry-1_climate_z2")
+        assert z2.current_temperature is None
+        assert z2.hvac_mode is None
+
+
+# Intent: the per-zone flow range reads and writes the zone's HcN registers.
+async def test_flow_temp_range_zone2_reads_and_writes_hc2() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        coordinator = _coordinator(tmpdir, _graph_two_zone(), _setup_data())
+        coordinator.async_write_register = AsyncMock(return_value=True)
+        r2 = EbusdFlowTempRange(coordinator, _entry(), "z2", "ctlv2")
+        assert r2.current_temperature == 30.0
+        assert r2._attr_unique_id == "entry-1_climate_flow_temp_range_z2"
+        await r2.async_set_temperature(target_temp_low=25, target_temp_high=45)
+        calls = [(c.args[0], c.args[1], c.args[2]) for c in coordinator.async_write_register.call_args_list]
+        assert ("ctlv2", "Hc2MinFlowTempDesired", "25") in calls
+        assert ("ctlv2", "Hc2MaxFlowTempDesired", "45") in calls
+
+
+# Intent: hvac_action stays heat-pump-global while zone status gates it.
+async def test_hvac_action_uses_shared_compressor_state() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        coordinator = _coordinator(
+            tmpdir,
+            _graph_two_zone(),
+            data={
+                "ebusd": {
+                    "hmu.RunDataStatuscode.value": "heat_compressor_active",
+                    "ctlv2.Hc2Status.value": "1",
+                    "ctlv2.Z2OpMode.value": "day",
+                }
+            },
+        )
+        z2 = EbusdClimate(coordinator, _entry(), "z2", "ctlv2")
+        assert z2.hvac_action == HVACAction.HEATING
+
+
+# Intent: manual cooling keeps the shared date register and writes the zone op mode.
+async def test_zone2_manual_cooling_uses_shared_date() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        coordinator = _coordinator(tmpdir, _graph_two_zone())
+        coordinator.async_write_registers = AsyncMock(return_value=True)
+        z2 = EbusdClimate(coordinator, _entry(), "z2", "ctlv2")
+        await z2.async_set_hvac_mode(HVACMode.COOL)
+        writes = coordinator.async_write_registers.await_args.args[0]
+        expected_end = (datetime.now().date() + timedelta(days=3)).strftime("%d.%m.%Y")
+        assert ("ctlv2", "ManualCoolingEndDate", expected_end) in writes
+        assert ("ctlv2", "Z2OpMode", "auto") in writes
+
+
+async def test_available_tracks_coordinator() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        coordinator = _coordinator(tmpdir, _graph_two_zone())
+        z2 = EbusdClimate(coordinator, _entry(), "z2", "ctlv2")
+        assert z2.available is True

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -232,9 +232,16 @@ def _graph_single_zone() -> DeviceGraph:
 
 # Ghost-zone graph: every Z2 register exists but is unused — mapping "none" and
 # no live core data — so z2 must NOT get a climate entity.
+# Ghost zone: mapping "none", room temp sentinel, and only static set-point
+# defaults on DayTemp/OpMode — exactly what ebusd reports on an unused zone.
+# These defaults must NOT count as live data (regression: they used to make
+# _zone_is_valid accept the ghost zone).
 def _graph_ghost_zone() -> DeviceGraph:
     graph = _graph_single_zone()
     graph.raw_registers["ctlv2.Z2RoomZoneMapping"] = "none"
+    graph.raw_registers["ctlv2.Z2RoomTemp"] = "empty"
+    graph.raw_registers["ctlv2.Z2DayTemp"] = "21.0"
+    graph.raw_registers["ctlv2.Z2OpMode"] = "auto"
     graph.nodes["z2"].has_data = True
     return graph
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -620,6 +620,85 @@ async def test_fallback_read_polls_known_placeholders() -> None:
         assert c.registers["hmu.YieldHc"].has_data is True
 
 
+# aroTHERM Plus exposes energy registers under basv3/ctlv3 while REGISTER_MAP
+# stores them under ctlv2/hmu; the fallback read must read the discovered
+# circuit (mirrors get_meta's aliasing). Regression for #53/#76/#77.
+async def test_fallback_read_aliases_discovered_placeholder_circuit() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        c = VaillantCoordinator(_hass(tmpdir), _entry())
+        mock_ebus = MagicMock(spec=EbusService)
+        mock_ebus.is_connected = True
+        mock_ebus.read_register = AsyncMock(return_value="42")
+        c.ebus = mock_ebus
+        basv3_node = DeviceNode(
+            circuit="basv3",
+            device_type=DeviceType.HEATING_CONTROLLER,
+            registers=[],
+            has_data=True,
+            scan_type="BASV3",
+        )
+        c._graph = DeviceGraph(
+            nodes={"basv3": basv3_node},
+            raw_registers={},
+            placeholder_registers={
+                "basv3.PrEnergySumHc",
+                "basv3.StatElectricEnergySum",
+            },
+        )
+        c._last_find_keys = set()
+
+        await c._fallback_read(include_placeholders=True)
+
+        mock_ebus.read_register.assert_any_await("basv3", "PrEnergySumHc")
+        mock_ebus.read_register.assert_any_await("basv3", "StatElectricEnergySum")
+        assert c.registers["basv3.PrEnergySumHc"].has_data is True
+        assert c.registers["basv3.StatElectricEnergySum"].has_data is True
+        assert "basv3.PrEnergySumHc" in c._graph.raw_registers
+        assert "basv3.PrEnergySumHc" in basv3_node.registers
+
+
+async def test_fallback_read_map_reads_discovered_circuit() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        c = VaillantCoordinator(_hass(tmpdir), _entry())
+        mock_ebus = MagicMock(spec=EbusService)
+        mock_ebus.is_connected = True
+        mock_ebus.read_register = AsyncMock(return_value="42")
+        c.ebus = mock_ebus
+        ctlv3_node = DeviceNode(
+            circuit="ctlv3",
+            device_type=DeviceType.HEATING_CONTROLLER,
+            registers=[],
+            has_data=True,
+            scan_type="CTLV3",
+        )
+        c._graph = DeviceGraph(
+            nodes={"ctlv3": ctlv3_node},
+            raw_registers={},
+            placeholder_registers={"ctlv3.PrEnergySumHwc"},
+        )
+        c._last_find_keys = set()
+
+        await c._fallback_read()
+
+        mock_ebus.read_register.assert_any_await("ctlv3", "PrEnergySumHwc")
+        calls = {args[0] for args, _ in mock_ebus.read_register.call_args_list}
+        assert ("ctlv2", "PrEnergySumHwc") not in calls
+        assert c.registers["ctlv3.PrEnergySumHwc"].has_data is True
+
+
+# The Yield day/month variants from #77 must be mapped so they get entities
+# and placeholder retries.
+def test_fallback_read_yield_day_month_variants_mapped() -> None:
+    from vaillant_ebus.backend.mapping import REGISTER_MAP
+
+    for key in ("hmu.YieldHcMonth", "hmu.YieldHwcDay", "hmu.YieldHwcMonth"):
+        assert key in REGISTER_MAP
+        meta = REGISTER_MAP[key]
+        assert meta.enabled is True
+        assert meta.device_class == "energy"
+        assert meta.unit == "kWh"
+
+
 async def test_get_device_info_uses_graph() -> None:
     with tempfile.TemporaryDirectory() as tmpdir:
         c = VaillantCoordinator(_hass(tmpdir), _entry())

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1017,3 +1017,212 @@ async def test_coordinator_seed_dedups_case_variants() -> None:
         assert len(sfmode) == 1, f"expected one HwcSfMode entity, got {len(sfmode)}"
         uids = [e.unique_id for e in coordinator.entities]
         assert len(uids) == len(set(uids))
+
+
+# Intent: active zones are derived from the discovery graph, mapping each zone
+# to the circuit hosting its registers for per-zone climate entities.
+async def test_zone_circuits_two_zone_graph() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        c = VaillantCoordinator(_hass(tmpdir), _entry())
+        c._graph = DeviceGraph(
+            nodes={
+                "ctlv2": DeviceNode(
+                    circuit="ctlv2",
+                    device_type=DeviceType.HEATING_CONTROLLER,
+                    registers=[],
+                    has_data=True,
+                    zone_circuits=["z1", "z2"],
+                ),
+                "z1": DeviceNode(
+                    circuit="z1",
+                    device_type=DeviceType.ZONE,
+                    registers=["ctlv2.Z1RoomTemp", "ctlv2.Z1DayTemp"],
+                    has_data=True,
+                    parent="ctlv2",
+                ),
+                "z2": DeviceNode(
+                    circuit="z2",
+                    device_type=DeviceType.ZONE,
+                    registers=["ctlv2.Z2RoomTemp", "ctlv2.Z2DayTemp"],
+                    has_data=True,
+                    parent="ctlv2",
+                ),
+            },
+            raw_registers={
+                "ctlv2.Z1RoomTemp": "21.5",
+                "ctlv2.Z2RoomTemp": "20.5",
+            },
+            placeholder_registers=set(),
+        )
+        assert c.zone_circuits() == {"z1": "ctlv2", "z2": "ctlv2"}
+
+
+# Intent: zones whose registers were found but carry no data are not active,
+# so a single-zone system keeps exactly one climate entity.
+async def test_zone_circuits_skips_no_data_zone() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        c = VaillantCoordinator(_hass(tmpdir), _entry())
+        c._graph = DeviceGraph(
+            nodes={
+                "ctlv2": DeviceNode(
+                    circuit="ctlv2",
+                    device_type=DeviceType.HEATING_CONTROLLER,
+                    registers=[],
+                    has_data=True,
+                    zone_circuits=["z1", "z2"],
+                ),
+                "z1": DeviceNode(
+                    circuit="z1",
+                    device_type=DeviceType.ZONE,
+                    registers=["ctlv2.Z1RoomTemp"],
+                    has_data=True,
+                ),
+                "z2": DeviceNode(
+                    circuit="z2",
+                    device_type=DeviceType.ZONE,
+                    registers=["ctlv2.Z2RoomTemp"],
+                    has_data=False,
+                ),
+            },
+            raw_registers={"ctlv2.Z1RoomTemp": "21.5"},
+            placeholder_registers={"ctlv2.Z2RoomTemp"},
+        )
+        assert c.zone_circuits() == {"z1": "ctlv2"}
+
+
+# Intent: an empty graph yields no zones; the climate platform falls back to z1.
+async def test_zone_circuits_empty_graph() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        c = VaillantCoordinator(_hass(tmpdir), _entry())
+        assert c.zone_circuits() == {}
+
+
+# Intent: feature gating treats live values and no-data placeholders alike.
+async def test_has_zone_register_checks_raw_and_placeholder() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        c = VaillantCoordinator(_hass(tmpdir), _entry())
+        c._graph = DeviceGraph(
+            nodes={},
+            raw_registers={"ctlv2.Z2CoolingTemp": "26"},
+            placeholder_registers={"ctlv2.Z2QuickVetoDuration"},
+        )
+        c._last_find_keys = {"ctlv2.Z2CoolingTemp"}
+        assert c.has_zone_register("ctlv2", "z2", "CoolingTemp") is True
+        assert c.has_zone_register("ctlv2", "z2", "QuickVetoDuration") is True
+        assert c.has_zone_register("ctlv2", "z2", "RoomTemp") is False
+        assert c.has_zone_register("ctlv2", "z1", "CoolingTemp") is False
+
+
+# Intent: before discovery populates the find set, absence is not proof of
+# hardware absence, so the register is assumed present (pre-per-zone behavior).
+async def test_has_zone_register_assumes_present_until_discovery() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        c = VaillantCoordinator(_hass(tmpdir), _entry())
+        assert c.has_zone_register("ctlv2", "z1", "CoolingTemp") is True
+        c._graph = DeviceGraph(nodes={}, raw_registers={}, placeholder_registers=set())
+        assert c.has_zone_register("ctlv2", "z1", "CoolingTemp") is True
+        c._last_find_keys = {"ctlv2.Z1RoomTemp"}
+        assert c.has_zone_register("ctlv2", "z1", "CoolingTemp") is False
+
+
+# Intent: platforms can add entities once a discovery graph has been applied.
+async def test_post_discovery_callbacks_fire_on_apply() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        c = VaillantCoordinator(_hass(tmpdir), _entry())
+        fired: list[str] = []
+        c.register_post_discovery_callback(lambda: fired.append("initial"))
+        c.register_post_discovery_callback(lambda: fired.append("delayed"))
+
+        mock_ebus = MagicMock(spec=EbusService)
+        mock_ebus.is_connected = True
+        mock_ebus.read_register = AsyncMock(return_value=None)
+        c.ebus = mock_ebus
+        await c._apply_discovery_graph(_make_graph(), "initial")
+        await c._apply_discovery_graph(
+            DeviceGraph(
+                nodes={
+                    "v32": DeviceNode(
+                        circuit="v32",
+                        device_type=DeviceType.VENTILATION,
+                        registers=["v32.SupplyAirTemp"],
+                        has_data=True,
+                    )
+                },
+                raw_registers={"v32.SupplyAirTemp": "20.75"},
+                placeholder_registers=set(),
+            ),
+            "delayed",
+        )
+        assert fired == ["initial", "delayed", "initial", "delayed"]
+
+
+# Intent: a ghost zone (mapping "none", no live core registers) must not get a
+# climate entity, even though ebusd reports its registers as real values.
+async def test_zone_circuits_skips_ghost_zone() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        c = VaillantCoordinator(_hass(tmpdir), _entry())
+        c._graph = DeviceGraph(
+            nodes={
+                "ctlv2": DeviceNode(
+                    circuit="ctlv2",
+                    device_type=DeviceType.HEATING_CONTROLLER,
+                    registers=[],
+                    has_data=True,
+                    zone_circuits=["z1", "z2"],
+                ),
+                "z1": DeviceNode(
+                    circuit="z1",
+                    device_type=DeviceType.ZONE,
+                    registers=["ctlv2.Z1RoomTemp"],
+                    has_data=True,
+                ),
+                "z2": DeviceNode(
+                    circuit="z2",
+                    device_type=DeviceType.ZONE,
+                    registers=["ctlv2.Z2RoomZoneMapping", "ctlv2.Z2RoomTemp"],
+                    has_data=True,
+                ),
+            },
+            raw_registers={
+                "ctlv2.Z1RoomTemp": "21.5",
+                "ctlv2.Z2RoomZoneMapping": "none",
+            },
+            placeholder_registers={"ctlv2.Z2RoomTemp", "ctlv2.Z2DayTemp", "ctlv2.Z2OpMode"},
+        )
+        assert c.zone_circuits() == {"z1": "ctlv2"}
+
+
+# Intent: a real but idle zone (real mapping, no live data yet) still gets a
+# climate entity; it simply reports unavailable values while inactive.
+async def test_zone_circuits_keeps_real_idle_zone() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        c = VaillantCoordinator(_hass(tmpdir), _entry())
+        c._graph = DeviceGraph(
+            nodes={
+                "ctlv2": DeviceNode(
+                    circuit="ctlv2",
+                    device_type=DeviceType.HEATING_CONTROLLER,
+                    registers=[],
+                    has_data=True,
+                    zone_circuits=["z1", "z2"],
+                ),
+                "z1": DeviceNode(
+                    circuit="z1",
+                    device_type=DeviceType.ZONE,
+                    registers=["ctlv2.Z1RoomTemp"],
+                    has_data=True,
+                ),
+                "z2": DeviceNode(
+                    circuit="z2",
+                    device_type=DeviceType.ZONE,
+                    registers=["ctlv2.Z2RoomZoneMapping", "ctlv2.Z2RoomTemp"],
+                    has_data=False,
+                ),
+            },
+            raw_registers={
+                "ctlv2.Z1RoomTemp": "21.5",
+                "ctlv2.Z2RoomZoneMapping": "VR91_1",
+            },
+            placeholder_registers={"ctlv2.Z2RoomTemp", "ctlv2.Z2DayTemp", "ctlv2.Z2OpMode"},
+        )
+        assert c.zone_circuits() == {"z1": "ctlv2", "z2": "ctlv2"}

--- a/tools/search_upstream.sh
+++ b/tools/search_upstream.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Search john30/ebusd-configuration issues and PRs for register knowledge.
+# The shipped CSVs in that repo lag behind the bus and the CDN (#632); the
+# field layouts, define strings, and find outputs people share in the
+# conversations are the real source. This wraps `gh search` for that repo.
+#
+# Usage:
+#   tools/search_upstream.sh "<query>"                  # issues (default)
+#   tools/search_upstream.sh --prs "<query>"            # pull requests
+#   tools/search_upstream.sh --comments "<query>"       # match in comments too
+#   tools/search_upstream.sh --all "<query>"            # issues + PRs
+#   tools/search_upstream.sh --limit 20 "<query>"
+#   tools/search_upstream.sh "<query>" "owner/repo"     # other repo (e.g. john30/ebusd)
+set -euo pipefail
+
+REPO="john30/ebusd-configuration"
+QUERY=""
+MATCH="title,body"
+LIMIT=10
+DO_ISSUES=1
+DO_PRS=0
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --prs) DO_ISSUES=0; DO_PRS=1; shift ;;
+        --all) DO_ISSUES=1; DO_PRS=1; shift ;;
+        --comments) MATCH="title,body,comments"; shift ;;
+        --limit) LIMIT="$2"; shift 2 ;;
+        --repo) REPO="$2"; shift 2 ;;
+        -*) echo "unknown option: $1" >&2; exit 2 ;;
+        *) QUERY="$1"; shift ;;
+    esac
+done
+
+if [[ -z "$QUERY" ]]; then
+    echo "usage: $0 [--prs|--all] [--comments] [--limit N] [--repo owner/repo] \"<query>\"" >&2
+    exit 2
+fi
+
+run() {
+    local kind="$1"
+    echo "── $kind in $REPO (match: $MATCH, limit: $LIMIT) ──"
+    gh search "$kind" --repo "$REPO" "$QUERY" --match "$MATCH" --limit "$LIMIT" \
+        --json number,title,state,updatedAt,url \
+        --jq '.[] | "#\(.number) [\(.state)] \(.title)  (\(.updatedAt))\n    \(.url)"'
+    echo
+}
+
+if [[ "$DO_ISSUES" -eq 1 ]]; then run issues; fi
+if [[ "$DO_PRS" -eq 1 ]]; then run prs; fi


### PR DESCRIPTION
## v1.4.0

### Added
- **Per-zone climate entities (#75).** One thermostat and flow-temperature-range entity per discovered heating zone, with zone-scoped registers, unique ids, and devices. COOL/BOOST gated per zone. Ghost zones (unused: `RoomZoneMapping = none`, no measured room temp) are excluded; static set-point defaults do not count as live activity.

### Fixed
- **Energy and yield sensors on aroTHERM Plus now populate from the correct circuit (#53, #76, #77).** Fallback read resolves the discovered circuit (`ctlv3`/`basv3`/`vwzio`) instead of reading the literal map circuit (`ctlv2`/`hmu`).
- **Missing yield day/month registers mapped (#77):** `hmu.YieldHcMonth`, `hmu.YieldHwcDay`, `hmu.YieldHwcMonth`.

See CHANGELOG.md for details.