### PR TITLE
release: v1.4.2 - flexoTHERM cooling-yield fixture (#50)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 1.4.2 - 2026-08-21
+
+### Fixed
+
+- **flexoTHERM cooling-yield data backed by a community dump (#50).** A new
+  discovery-dump fixture
+  (`tests/fixtures/community/flexotherm_133_cooling_discovery.yaml`) confirms
+  the flexoTHERM reports the daily cooling yield (`hmu.YieldCoolDay`, kWh) and
+  cooling runtime (`hmu.HoursCool`, h) as live values, while the cumulative
+  cooling totals (`StatElectricEnergySumCool`, `StatEnvironmentEnergySumCool`,
+  `YieldCooling`, `YieldCoolingMonth`, `CopCooling`, `CopCoolingMonth`) return
+  `ERR: element not found`. Regression tests assert the daily yield/runtime
+  entities are generated and the element-not-found totals stay hidden. No
+  production code change was required — the previous fixture simply had no live
+  cooling data.
+
 ## 1.4.1 - 2026-08-21
 
 ### Fixed

--- a/custom_components/vaillant_ebus/manifest.json
+++ b/custom_components/vaillant_ebus/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/MarkBovee/vaillant-ebus/issues",
   "requirements": [],
-  "version": "1.4.1"
+  "version": "1.4.2"
 }

--- a/tests/fixtures/community/flexotherm_133_cooling_discovery.yaml
+++ b/tests/fixtures/community/flexotherm_133_cooling_discovery.yaml
@@ -1,0 +1,11291 @@
+# Discovery dump for vaillant_ebus
+# Review this file for sensitive information before sharing
+metadata:
+  timestamp: '2026-08-16T17:42:58.143734'
+  ebusd_version: null
+  register_count: 225
+  grab_duration: 300
+  dump_version: 3
+raw_find_lines:
+- Broadcast Datetime = no data stored
+- Broadcast Error = no data stored
+- Broadcast HwcStatus = no data stored
+- Broadcast Id = no data stored
+- Broadcast IdAnswer = no data stored
+- Broadcast IdQuery = no data stored
+- Broadcast Load = no data stored
+- Broadcast Outsidetemp = 31.438
+- Broadcast Queryexistence =  (empty for 31fe07fe00 / )
+- Broadcast Signoflife = no data stored
+- Broadcast Vdatetime = 17:36:24;16.08.2026
+- Broadcast Vdatetime = no data stored
+- ctlv2 ManualCoolingEndDate = no data stored
+- ctlv2 ManualCoolingEndDate = no data stored
+- ctlv2 ManualCoolingStartDate = 10.08.2026
+- ctlv2 ManualCoolingStartDate = no data stored
+- ctlv2 z1RoomHumidity = 70
+- ctlv3 AdaptHeatCurve = no
+- ctlv3 AdaptHeatCurve = no data stored
+- ctlv3 CcTimer_Config = no data stored
+- ctlv3 CcTimer_Friday0 = 06:00;23:00
+- ctlv3 CcTimer_Friday1 = no data stored
+- ctlv3 CcTimer_Friday2 = no data stored
+- ctlv3 CcTimer_Friday = no data stored
+- ctlv3 CcTimer_Monday0 = 06:00;23:00
+- ctlv3 CcTimer_Monday1 = no data stored
+- ctlv3 CcTimer_Monday2 = no data stored
+- ctlv3 CcTimer_Monday = no data stored
+- ctlv3 CcTimer_Saturday0 = 06:00;23:00
+- ctlv3 CcTimer_Saturday1 = no data stored
+- ctlv3 CcTimer_Saturday2 = no data stored
+- ctlv3 CcTimer_Saturday = no data stored
+- ctlv3 CcTimer_Sunday0 = 06:00;23:00
+- ctlv3 CcTimer_Sunday1 = no data stored
+- ctlv3 CcTimer_Sunday2 = no data stored
+- ctlv3 CcTimer_Sunday = no data stored
+- ctlv3 CcTimer_Thursday0 = 06:00;23:00
+- ctlv3 CcTimer_Thursday1 = no data stored
+- ctlv3 CcTimer_Thursday2 = no data stored
+- ctlv3 CcTimer_Thursday = no data stored
+- ctlv3 CcTimer_Timeframes = 1;1;1;1;1;1;1
+- ctlv3 CcTimer_Tuesday0 = 06:00;23:00
+- ctlv3 CcTimer_Tuesday1 = no data stored
+- ctlv3 CcTimer_Tuesday2 = no data stored
+- ctlv3 CcTimer_Tuesday = no data stored
+- ctlv3 CcTimer_Wednesday0 = 06:00;23:00
+- ctlv3 CcTimer_Wednesday1 = no data stored
+- ctlv3 CcTimer_Wednesday2 = no data stored
+- ctlv3 CcTimer_Wednesday = no data stored
+- ctlv3 Clearerrorhistory = no data stored
+- ctlv3 ContinuousHeating = -26
+- ctlv3 ContinuousHeating = no data stored
+- ctlv3 Currenterror = -;-;-;-;-
+- ctlv3 CylinderChargeHyst = 5
+- ctlv3 CylinderChargeHyst = no data stored
+- ctlv3 CylinderChargeOffset = 8
+- ctlv3 CylinderChargeOffset = no data stored
+- ctlv3 Date = 16.08.2026
+- ctlv3 Date = no data stored
+- ctlv3 DisplayedOutsideTemp = 31.4375
+- ctlv3 Errorhistory = no data stored
+- ctlv3 FrostOverRideTime = no data stored
+- ctlv3 FrostOverRideTime = no data stored
+- ctlv3 Hc1ActualFlowTempDesired = 19.485
+- ctlv3 Hc1AutoOffMode = night
+- ctlv3 Hc1AutoOffMode = no data stored
+- ctlv3 Hc1CircuitType = mixer
+- ctlv3 Hc1ExcessTemp = 0.0
+- ctlv3 Hc1ExcessTemp = no data stored
+- ctlv3 Hc1FlowTemp = 19.875
+- ctlv3 Hc1HeatCurve = 0.3
+- ctlv3 Hc1HeatCurve = no data stored
+- ctlv3 Hc1HeatCurveAdaption = 0.0
+- ctlv3 Hc1MaxFlowTempDesired = 50
+- ctlv3 Hc1MaxFlowTempDesired = no data stored
+- ctlv3 Hc1MinCoolingTempDesired = 19
+- ctlv3 Hc1MinCoolingTempDesired = no data stored
+- ctlv3 Hc1MinFlowTempDesired = 15
+- ctlv3 Hc1MinFlowTempDesired = no data stored
+- ctlv3 Hc1MixerMovement = 5
+- ctlv3 Hc1PumpStatus = 2
+- ctlv3 Hc1PumpStatus = no data stored
+- ctlv3 Hc1RoomTempSwitchOn = modulating
+- ctlv3 Hc1RoomTempSwitchOn = no data stored
+- ctlv3 Hc1Status = no data stored
+- ctlv3 Hc1Status = no data stored
+- ctlv3 Hc1SummerTempLimit = 16
+- ctlv3 Hc1SummerTempLimit = no data stored
+- ctlv3 Hc2ActualFlowTempDesired = no data stored
+- ctlv3 Hc2AutoOffMode = no data stored
+- ctlv3 Hc2AutoOffMode = no data stored
+- ctlv3 Hc2CircuitType = inactive
+- ctlv3 Hc2ExcessTemp = no data stored
+- ctlv3 Hc2ExcessTemp = no data stored
+- ctlv3 Hc2FlowTemp = no data stored
+- ctlv3 Hc2HeatCurve = no data stored
+- ctlv3 Hc2HeatCurve = no data stored
+- ctlv3 Hc2HeatCurveAdaption = no data stored
+- ctlv3 Hc2MaxFlowTempDesired = no data stored
+- ctlv3 Hc2MaxFlowTempDesired = no data stored
+- ctlv3 Hc2MinCoolingTempDesired = no data stored
+- ctlv3 Hc2MinCoolingTempDesired = no data stored
+- ctlv3 Hc2MinFlowTempDesired = no data stored
+- ctlv3 Hc2MinFlowTempDesired = no data stored
+- ctlv3 Hc2MixerMovement = no data stored
+- ctlv3 Hc2PumpStatus = no data stored
+- ctlv3 Hc2PumpStatus = no data stored
+- ctlv3 Hc2RoomTempSwitchOn = no data stored
+- ctlv3 Hc2RoomTempSwitchOn = no data stored
+- ctlv3 Hc2Status = no data stored
+- ctlv3 Hc2Status = no data stored
+- ctlv3 Hc2SummerTempLimit = no data stored
+- ctlv3 Hc2SummerTempLimit = no data stored
+- ctlv3 Hc3ActualFlowTempDesired = no data stored
+- ctlv3 Hc3AutoOffMode = no data stored
+- ctlv3 Hc3AutoOffMode = no data stored
+- ctlv3 Hc3CircuitType = inactive
+- ctlv3 Hc3ExcessTemp = no data stored
+- ctlv3 Hc3ExcessTemp = no data stored
+- ctlv3 Hc3FlowTemp = no data stored
+- ctlv3 Hc3HeatCurve = no data stored
+- ctlv3 Hc3HeatCurve = no data stored
+- ctlv3 Hc3HeatCurveAdaption = no data stored
+- ctlv3 Hc3MaxFlowTempDesired = no data stored
+- ctlv3 Hc3MaxFlowTempDesired = no data stored
+- ctlv3 Hc3MinCoolingTempDesired = no data stored
+- ctlv3 Hc3MinCoolingTempDesired = no data stored
+- ctlv3 Hc3MinFlowTempDesired = no data stored
+- ctlv3 Hc3MinFlowTempDesired = no data stored
+- ctlv3 Hc3MixerMovement = no data stored
+- ctlv3 Hc3PumpStatus = no data stored
+- ctlv3 Hc3PumpStatus = no data stored
+- ctlv3 Hc3RoomTempSwitchOn = no data stored
+- ctlv3 Hc3RoomTempSwitchOn = no data stored
+- ctlv3 Hc3Status = no data stored
+- ctlv3 Hc3Status = no data stored
+- ctlv3 Hc3SummerTempLimit = no data stored
+- ctlv3 Hc3SummerTempLimit = no data stored
+- ctlv3 HcStorageTempBottom =  (empty for f115b5240602000000a000 / 080000a000ffffff7f)
+- ctlv3 HcStorageTempTop =  (empty for f115b52406020000009f00 / 0800009f00ffffff7f)
+- ctlv3 HwcBankHolidayEndPeriod = no data stored
+- ctlv3 HwcBankHolidayEndPeriod = no data stored
+- ctlv3 HwcBankHolidayStartPeriod = no data stored
+- ctlv3 HwcBankHolidayStartPeriod = no data stored
+- ctlv3 HwcFlowTemp = no data stored
+- ctlv3 HwcHolidayEndPeriod = 01.01.2015
+- ctlv3 HwcHolidayEndPeriod = no data stored
+- ctlv3 HwcHolidayStartPeriod = 01.01.2015
+- ctlv3 HwcHolidayStartPeriod = no data stored
+- ctlv3 HwcLockTime = 60
+- ctlv3 HwcLockTime = no data stored
+- ctlv3 HwcMaxFlowTempDesired = 80
+- ctlv3 HwcMaxFlowTempDesired = no data stored
+- ctlv3 HwcOpMode = auto
+- ctlv3 HwcOpMode = no data stored
+- ctlv3 HwcParallelLoading = off
+- ctlv3 HwcParallelLoading = no data stored
+- ctlv3 HwcSFMode = no data stored
+- ctlv3 HwcSFMode = no data stored
+- ctlv3 HwcStorageTemp = 46.5
+- ctlv3 HwcStorageTempBottom =  (empty for f115b52406020000009e00 / 0800009e00ffffff7f)
+- ctlv3 HwcStorageTempTop =  (empty for f115b52406020000009d00 / 0800009d00ffffff7f)
+- ctlv3 HwcTempDesired = 47
+- ctlv3 HwcTempDesired = no data stored
+- ctlv3 HwcTimer_Config = no data stored
+- ctlv3 HwcTimer_Friday0 = 09:00;22:00;47.0
+- ctlv3 HwcTimer_Friday1 = no data stored
+- ctlv3 HwcTimer_Friday2 = no data stored
+- ctlv3 HwcTimer_Friday = no data stored
+- ctlv3 HwcTimer_Monday0 = 09:00;22:00;47.0
+- ctlv3 HwcTimer_Monday1 = no data stored
+- ctlv3 HwcTimer_Monday2 = no data stored
+- ctlv3 HwcTimer_Monday = no data stored
+- ctlv3 HwcTimer_Saturday0 = 09:00;22:00;47.0
+- ctlv3 HwcTimer_Saturday1 = no data stored
+- ctlv3 HwcTimer_Saturday2 = no data stored
+- ctlv3 HwcTimer_Saturday = no data stored
+- ctlv3 HwcTimer_Sunday0 = 09:00;22:00;47.0
+- ctlv3 HwcTimer_Sunday1 = no data stored
+- ctlv3 HwcTimer_Sunday2 = no data stored
+- ctlv3 HwcTimer_Sunday = no data stored
+- ctlv3 HwcTimer_Thursday0 = 09:00;22:00;47.0
+- ctlv3 HwcTimer_Thursday1 = no data stored
+- ctlv3 HwcTimer_Thursday2 = no data stored
+- ctlv3 HwcTimer_Thursday = no data stored
+- ctlv3 HwcTimer_Timeframes = 1;1;1;1;1;1;1
+- ctlv3 HwcTimer_Tuesday0 = 09:00;22:00;47.0
+- ctlv3 HwcTimer_Tuesday1 = no data stored
+- ctlv3 HwcTimer_Tuesday2 = no data stored
+- ctlv3 HwcTimer_Tuesday = no data stored
+- ctlv3 HwcTimer_Wednesday0 = 09:00;22:00;47.0
+- ctlv3 HwcTimer_Wednesday1 = no data stored
+- ctlv3 HwcTimer_Wednesday2 = no data stored
+- ctlv3 HwcTimer_Wednesday = no data stored
+- ctlv3 HydraulicScheme = 8
+- ctlv3 HydraulicScheme = no data stored
+- ctlv3 Installer1 = no data stored
+- ctlv3 Installer1 = no data stored
+- ctlv3 Installer2 = no data stored
+- ctlv3 Installer2 = no data stored
+- ctlv3 KeyCodeforConfigMenu = no data stored
+- ctlv3 KeyCodeforConfigMenu = no data stored
+- ctlv3 MaintenanceDate = no data stored
+- ctlv3 MaintenanceDate = no data stored
+- ctlv3 MaintenanceDue = no
+- ctlv3 MaxCylinderChargeTime = 90
+- ctlv3 MaxCylinderChargeTime = no data stored
+- ctlv3 MaxRoomHumidity = no data stored
+- ctlv3 MaxRoomHumidity = no data stored
+- ctlv3 MultiRelaySetting = circulation
+- ctlv3 MultiRelaySetting = no data stored
+- ctlv3 OutsideTempAvg = 26.2734
+- ctlv3 OutsideTempAvg = no data stored
+- ctlv3 PhoneNumber1 = no data stored
+- ctlv3 PhoneNumber1 = no data stored
+- ctlv3 PhoneNumber2 = no data stored
+- ctlv3 PhoneNumber2 = no data stored
+- ctlv3 PrEnergySum = no data stored
+- ctlv3 PrEnergySum = no data stored
+- ctlv3 PrEnergySumHc = 6606
+- ctlv3 PrEnergySumHc = no data stored
+- ctlv3 PrEnergySumHcLastMonth = no data stored
+- ctlv3 PrEnergySumHcLastMonth = no data stored
+- ctlv3 PrEnergySumHcThisMonth = no data stored
+- ctlv3 PrEnergySumHcThisMonth = no data stored
+- ctlv3 PrEnergySumHwc = 2070
+- ctlv3 PrEnergySumHwc = no data stored
+- ctlv3 PrEnergySumHwcLastMonth = no data stored
+- ctlv3 PrEnergySumHwcLastMonth = no data stored
+- ctlv3 PrEnergySumHwcThisMonth = no data stored
+- ctlv3 PrEnergySumHwcThisMonth = no data stored
+- ctlv3 PrFuelSum = no data stored
+- ctlv3 PrFuelSum = no data stored
+- ctlv3 PrFuelSumHc = no data stored
+- ctlv3 PrFuelSumHc = no data stored
+- ctlv3 PrFuelSumHcLastMonth = no data stored
+- ctlv3 PrFuelSumHcLastMonth = no data stored
+- ctlv3 PrFuelSumHcThisMonth = no data stored
+- ctlv3 PrFuelSumHcThisMonth = no data stored
+- ctlv3 PrFuelSumHwc = no data stored
+- ctlv3 PrFuelSumHwc = no data stored
+- ctlv3 PrFuelSumHwcLastMonth = no data stored
+- ctlv3 PrFuelSumHwcLastMonth = no data stored
+- ctlv3 PrFuelSumHwcThisMonth = no data stored
+- ctlv3 PrFuelSumHwcThisMonth = no data stored
+- ctlv3 PumpAdditionalTime = no data stored
+- ctlv3 PumpAdditionalTime = no data stored
+- ctlv3 SolarYieldTotal = no data stored
+- ctlv3 SolarYieldTotal = no data stored
+- ctlv3 SystemFlowTemp = 28.5
+- ctlv3 Time = 17:37:21
+- ctlv3 Time = no data stored
+- ctlv3 WaterPressure = 1.9
+- ctlv3 YieldTotal = 25260
+- ctlv3 YieldTotal = no data stored
+- ctlv3 Z1ActualRoomTempDesired = 0.0
+- ctlv3 Z1ActualRoomTempDesired = no data stored
+- ctlv3 Z1BankHolidayEndPeriod = no data stored
+- ctlv3 Z1BankHolidayEndPeriod = no data stored
+- ctlv3 Z1BankHolidayStartPeriod = no data stored
+- ctlv3 Z1BankHolidayStartPeriod = no data stored
+- ctlv3 Z1CoolingTemp = 20
+- ctlv3 Z1CoolingTemp = no data stored
+- ctlv3 Z1DayTemp = 22
+- ctlv3 Z1DayTemp = no data stored
+- ctlv3 Z1HolidayEndPeriod = 01.01.2015
+- ctlv3 Z1HolidayEndPeriod = no data stored
+- ctlv3 Z1HolidayStartPeriod = 01.01.2015
+- ctlv3 Z1HolidayStartPeriod = no data stored
+- ctlv3 Z1HolidayTemp = 15
+- ctlv3 Z1HolidayTemp = no data stored
+- 'ctlv3 Z1Name1 =  (ERR: invalid position for f115b52406020003001700 / 080303170046626800)'
+- ctlv3 Z1Name1 = no data stored
+- 'ctlv3 Z1Name2 =  (ERR: invalid position for f115b52406020003001800 / 050303180000)'
+- ctlv3 Z1Name2 = no data stored
+- ctlv3 Z1NightTemp = 18
+- ctlv3 Z1NightTemp = no data stored
+- ctlv3 Z1OpMode = day
+- ctlv3 Z1OpMode = no data stored
+- ctlv3 Z1QuickVetoDuration = no data stored
+- ctlv3 Z1QuickVetoDuration = no data stored
+- ctlv3 Z1QuickVetoEndDate = no data stored
+- ctlv3 Z1QuickVetoEndTime = 00:00:00
+- ctlv3 Z1QuickVetoTemp = no data stored
+- ctlv3 Z1QuickVetoTemp = no data stored
+- ctlv3 Z1RoomTemp = 23.225
+- ctlv3 Z1RoomZoneMapping = VR91_1
+- ctlv3 Z1RoomZoneMapping = no data stored
+- ctlv3 Z1SFMode = no data stored
+- ctlv3 Z1SFMode = no data stored
+- ctlv3 Z1Shortname = no data stored
+- ctlv3 Z1Shortname = no data stored
+- ctlv3 Z1Timer_Config = no data stored
+- ctlv3 Z1Timer_Friday0 = 09:00;22:00;21.5
+- ctlv3 Z1Timer_Friday1 = no data stored
+- ctlv3 Z1Timer_Friday2 = no data stored
+- ctlv3 Z1Timer_Friday = no data stored
+- ctlv3 Z1Timer_Monday0 = 09:00;22:00;21.5
+- ctlv3 Z1Timer_Monday1 = no data stored
+- ctlv3 Z1Timer_Monday2 = no data stored
+- ctlv3 Z1Timer_Monday = no data stored
+- ctlv3 Z1Timer_Saturday0 = 09:00;22:00;21.5
+- ctlv3 Z1Timer_Saturday1 = no data stored
+- ctlv3 Z1Timer_Saturday2 = no data stored
+- ctlv3 Z1Timer_Saturday = no data stored
+- ctlv3 Z1Timer_Sunday0 = 09:00;22:00;21.5
+- ctlv3 Z1Timer_Sunday1 = no data stored
+- ctlv3 Z1Timer_Sunday2 = no data stored
+- ctlv3 Z1Timer_Sunday = no data stored
+- ctlv3 Z1Timer_Thursday0 = 09:00;22:00;21.5
+- ctlv3 Z1Timer_Thursday1 = no data stored
+- ctlv3 Z1Timer_Thursday2 = no data stored
+- ctlv3 Z1Timer_Thursday = no data stored
+- ctlv3 Z1Timer_Timeframes = 1;1;1;1;1;1;1
+- ctlv3 Z1Timer_Tuesday0 = 09:00;22:00;21.5
+- ctlv3 Z1Timer_Tuesday1 = no data stored
+- ctlv3 Z1Timer_Tuesday2 = no data stored
+- ctlv3 Z1Timer_Tuesday = no data stored
+- ctlv3 Z1Timer_Wednesday0 = 09:00;22:00;21.5
+- ctlv3 Z1Timer_Wednesday1 = no data stored
+- ctlv3 Z1Timer_Wednesday2 = no data stored
+- ctlv3 Z1Timer_Wednesday = no data stored
+- ctlv3 Z1ValveStatus = no data stored
+- ctlv3 Z1ValveStatus = no data stored
+- ctlv3 Z2ActualRoomTempDesired = no data stored
+- ctlv3 Z2ActualRoomTempDesired = no data stored
+- ctlv3 Z2BankHolidayEndPeriod = no data stored
+- ctlv3 Z2BankHolidayEndPeriod = no data stored
+- ctlv3 Z2BankHolidayStartPeriod = no data stored
+- ctlv3 Z2BankHolidayStartPeriod = no data stored
+- ctlv3 Z2CoolingTemp = no data stored
+- ctlv3 Z2CoolingTemp = no data stored
+- ctlv3 Z2DayTemp = no data stored
+- ctlv3 Z2DayTemp = no data stored
+- ctlv3 Z2HolidayEndPeriod = no data stored
+- ctlv3 Z2HolidayEndPeriod = no data stored
+- ctlv3 Z2HolidayStartPeriod = no data stored
+- ctlv3 Z2HolidayStartPeriod = no data stored
+- ctlv3 Z2HolidayTemp = no data stored
+- ctlv3 Z2HolidayTemp = no data stored
+- ctlv3 Z2Name1 = no data stored
+- ctlv3 Z2Name1 = no data stored
+- ctlv3 Z2Name2 = no data stored
+- ctlv3 Z2Name2 = no data stored
+- ctlv3 Z2NightTemp = no data stored
+- ctlv3 Z2NightTemp = no data stored
+- ctlv3 Z2OpMode = no data stored
+- ctlv3 Z2OpMode = no data stored
+- ctlv3 Z2QuickVetoDuration = no data stored
+- ctlv3 Z2QuickVetoDuration = no data stored
+- ctlv3 Z2QuickVetoEndDate = no data stored
+- ctlv3 Z2QuickVetoEndTime = no data stored
+- ctlv3 Z2QuickVetoTemp = no data stored
+- ctlv3 Z2QuickVetoTemp = no data stored
+- ctlv3 Z2RoomTemp = no data stored
+- ctlv3 Z2RoomZoneMapping = none
+- ctlv3 Z2RoomZoneMapping = no data stored
+- ctlv3 Z2SFMode = no data stored
+- ctlv3 Z2SFMode = no data stored
+- ctlv3 Z2Shortname = no data stored
+- ctlv3 Z2Shortname = no data stored
+- ctlv3 Z2Timer_Config = no data stored
+- ctlv3 Z2Timer_Friday0 = no data stored
+- ctlv3 Z2Timer_Friday1 = no data stored
+- ctlv3 Z2Timer_Friday2 = no data stored
+- ctlv3 Z2Timer_Friday = no data stored
+- ctlv3 Z2Timer_Monday0 = no data stored
+- ctlv3 Z2Timer_Monday1 = no data stored
+- ctlv3 Z2Timer_Monday2 = no data stored
+- ctlv3 Z2Timer_Monday = no data stored
+- ctlv3 Z2Timer_Saturday0 = no data stored
+- ctlv3 Z2Timer_Saturday1 = no data stored
+- ctlv3 Z2Timer_Saturday2 = no data stored
+- ctlv3 Z2Timer_Saturday = no data stored
+- ctlv3 Z2Timer_Sunday0 = no data stored
+- ctlv3 Z2Timer_Sunday1 = no data stored
+- ctlv3 Z2Timer_Sunday2 = no data stored
+- ctlv3 Z2Timer_Sunday = no data stored
+- ctlv3 Z2Timer_Thursday0 = no data stored
+- ctlv3 Z2Timer_Thursday1 = no data stored
+- ctlv3 Z2Timer_Thursday2 = no data stored
+- ctlv3 Z2Timer_Thursday = no data stored
+- ctlv3 Z2Timer_Timeframes = no data stored
+- ctlv3 Z2Timer_Tuesday0 = no data stored
+- ctlv3 Z2Timer_Tuesday1 = no data stored
+- ctlv3 Z2Timer_Tuesday2 = no data stored
+- ctlv3 Z2Timer_Tuesday = no data stored
+- ctlv3 Z2Timer_Wednesday0 = no data stored
+- ctlv3 Z2Timer_Wednesday1 = no data stored
+- ctlv3 Z2Timer_Wednesday2 = no data stored
+- ctlv3 Z2Timer_Wednesday = no data stored
+- ctlv3 Z2ValveStatus = no data stored
+- ctlv3 Z2ValveStatus = no data stored
+- ctlv3 Z3ActualRoomTempDesired = no data stored
+- ctlv3 Z3ActualRoomTempDesired = no data stored
+- ctlv3 Z3BankHolidayEndPeriod = no data stored
+- ctlv3 Z3BankHolidayEndPeriod = no data stored
+- ctlv3 Z3BankHolidayStartPeriod = no data stored
+- ctlv3 Z3BankHolidayStartPeriod = no data stored
+- ctlv3 Z3DayTemp = no data stored
+- ctlv3 Z3DayTemp = no data stored
+- ctlv3 Z3HolidayEndPeriod = no data stored
+- ctlv3 Z3HolidayEndPeriod = no data stored
+- ctlv3 Z3HolidayStartPeriod = no data stored
+- ctlv3 Z3HolidayStartPeriod = no data stored
+- ctlv3 Z3HolidayTemp = no data stored
+- ctlv3 Z3HolidayTemp = no data stored
+- ctlv3 Z3Name1 = no data stored
+- ctlv3 Z3Name1 = no data stored
+- ctlv3 Z3Name2 = no data stored
+- ctlv3 Z3Name2 = no data stored
+- ctlv3 Z3NightTemp = no data stored
+- ctlv3 Z3NightTemp = no data stored
+- ctlv3 Z3OpMode = no data stored
+- ctlv3 Z3OpMode = no data stored
+- ctlv3 Z3QuickVetoDuration = no data stored
+- ctlv3 Z3QuickVetoDuration = no data stored
+- ctlv3 Z3QuickVetoEndDate = no data stored
+- ctlv3 Z3QuickVetoEndTime = no data stored
+- ctlv3 Z3QuickVetoTemp = no data stored
+- ctlv3 Z3QuickVetoTemp = no data stored
+- ctlv3 Z3RoomTemp = no data stored
+- ctlv3 Z3RoomZoneMapping = none
+- ctlv3 Z3RoomZoneMapping = no data stored
+- ctlv3 Z3SFMode = no data stored
+- ctlv3 Z3SFMode = no data stored
+- ctlv3 Z3Shortname = no data stored
+- ctlv3 Z3Shortname = no data stored
+- ctlv3 Z3Timer_Config = no data stored
+- ctlv3 Z3Timer_Friday0 = no data stored
+- ctlv3 Z3Timer_Friday1 = no data stored
+- ctlv3 Z3Timer_Friday2 = no data stored
+- ctlv3 Z3Timer_Friday = no data stored
+- ctlv3 Z3Timer_Monday0 = no data stored
+- ctlv3 Z3Timer_Monday1 = no data stored
+- ctlv3 Z3Timer_Monday2 = no data stored
+- ctlv3 Z3Timer_Monday = no data stored
+- ctlv3 Z3Timer_Saturday0 = no data stored
+- ctlv3 Z3Timer_Saturday1 = no data stored
+- ctlv3 Z3Timer_Saturday2 = no data stored
+- ctlv3 Z3Timer_Saturday = no data stored
+- ctlv3 Z3Timer_Sunday0 = no data stored
+- ctlv3 Z3Timer_Sunday1 = no data stored
+- ctlv3 Z3Timer_Sunday2 = no data stored
+- ctlv3 Z3Timer_Sunday = no data stored
+- ctlv3 Z3Timer_Thursday0 = no data stored
+- ctlv3 Z3Timer_Thursday1 = no data stored
+- ctlv3 Z3Timer_Thursday2 = no data stored
+- ctlv3 Z3Timer_Thursday = no data stored
+- ctlv3 Z3Timer_Timeframes = no data stored
+- ctlv3 Z3Timer_Tuesday0 = no data stored
+- ctlv3 Z3Timer_Tuesday1 = no data stored
+- ctlv3 Z3Timer_Tuesday2 = no data stored
+- ctlv3 Z3Timer_Tuesday = no data stored
+- ctlv3 Z3Timer_Wednesday0 = no data stored
+- ctlv3 Z3Timer_Wednesday1 = no data stored
+- ctlv3 Z3Timer_Wednesday2 = no data stored
+- ctlv3 Z3Timer_Wednesday = no data stored
+- ctlv3 Z3ValveStatus = no data stored
+- ctlv3 Z3ValveStatus = no data stored
+- General Valuerange = no data stored
+- hmu AirIntakeTemp = no data stored
+- 'hmu BuildingCircuitFlow =  (ERR: invalid position for 3108b51a0405ff323c / 02ff01)'
+- hmu BuildingPumpHours = no data stored
+- hmu BuildingPumpHours = 7103
+- hmu BuildingPumpStarts = no data stored
+- hmu BuildingPumpStarts = 9458
+- hmu Clearerrorhistory = no data stored
+- hmu CompressorHours = no data stored
+- hmu CompressorHours = 1794
+- hmu CompressorHysteresisCooling = no data stored
+- hmu CompressorHysteresisHc = no data stored
+- hmu CompressorStarts = no data stored
+- hmu CompressorStarts = 8578
+- hmu ConsumptionThisYear10 = no data stored
+- hmu ConsumptionThisYear11 = no data stored
+- hmu ConsumptionThisYear12 = no data stored
+- hmu ConsumptionThisYear1 = no data stored
+- hmu ConsumptionThisYear2 = no data stored
+- hmu ConsumptionThisYear3 = no data stored
+- hmu ConsumptionThisYear4 = no data stored
+- hmu ConsumptionThisYear5 = no data stored
+- hmu ConsumptionThisYear6 = no data stored
+- hmu ConsumptionThisYear7 = no data stored
+- hmu ConsumptionThisYear8 = no data stored
+- hmu ConsumptionThisYear9 = no data stored
+- hmu ConsumptionTotal = no data stored
+- hmu CopHc = 3.9
+- hmu CopHcMonth = 1.0
+- hmu CopHwc = 3.8
+- hmu CopHwcMonth = 4.3
+- 'hmu CurrentCompressorUtil =  (ERR: invalid position for 3108b51a0405ff3225 / 02ff01)'
+- hmu CurrentConsumedPower = 0.4
+- hmu Currenterror = -;-;-;-;-
+- hmu CurrentYieldPower = 0.0
+- hmu DateTime = valid;17:36:28;16.08.2026;31.438
+- hmu EEVSteps = no data stored
+- hmu EEVSteps = no data stored
+- hmu EnableiveMonitorMain =  (empty for f108b503020003 / 0a7700ffffffffffffffff)
+- hmu EnableTestCompressorExitTemp = no data stored
+- hmu EnableTestCompressorIntakeTemp = no data stored
+- hmu EnableTestCompressorSpeed = no data stored
+- hmu EnableTestCondensateTemp = no data stored
+- hmu EnableTestEEVPosition = no data stored
+- hmu EnableTestEEVTemp = no data stored
+- hmu EnableTestEvaporationTemp = no data stored
+- hmu EnableTestFlowTemp = no data stored
+- hmu EnableTestHighPress = no data stored
+- hmu EnableTestReturnTemp = no data stored
+- hmu EnableTestWaterThroughput = no data stored
+- hmu EnergyIntegral = 500
+- hmu Errorhistory = no data stored
+- hmu Fan1Hours = no data stored
+- hmu Fan1Hours = no data stored
+- hmu Fan1Starts = no data stored
+- hmu Fan1Starts = no data stored
+- hmu Fan2Hours = no data stored
+- hmu Fan2Hours = no data stored
+- hmu Fan2Starts = no data stored
+- hmu Fan2Starts = no data stored
+- hmu FlowPressure = 1.97
+- hmu FlowTemp = 19.31
+- hmu FourWayValveHours = no data stored
+- hmu FourWayValveHours = 0
+- hmu FourWayValveSwitches = no data stored
+- hmu FourWayValveSwitches = 0
+- hmu FourWayValveSwitchingOperations = no data stored
+- hmu FourWayValveSwitchingOperations = no data stored
+- hmu HcBivalencePoint = no data stored
+- hmu HcModeActive = no data stored
+- hmu HeatCurve = no data stored
+- hmu Hours = 15575
+- hmu HoursCool = 0
+- hmu HoursHc = 1963
+- hmu HoursHwc = 469
+- hmu HwcBivalencePoint = no data stored
+- hmu HwcChargeHysteresis = no data stored
+- hmu HwcMode = no data stored
+- hmu HwcModeActive = no data stored
+- hmu ImmersionHeaterMode = no data stored
+- hmu LiveMonitorAirIntakeTemp = no data stored
+- hmu LiveMonitorCurrentCompressorUtil = no data stored
+- hmu LiveMonitorCurrentConsumedPower = no data stored
+- hmu LiveMonitorCurrentSupplyTemp = no data stored
+- hmu LiveMonitorCurrentYieldPower = no data stored
+- hmu LiveMonitorDesiredSupplyTemp = no data stored
+- hmu LiveMonitorMain = no data stored
+- hmu MaxFlowTemp = no data stored
+- hmu MinFlowTemp = no data stored
+- hmu RunDataAirInletTemp = 7.70574e-42
+- 'hmu RunDataBuildingCPumpPower =  (ERR: invalid position for 3108b50905540200c509
+  / 050201c50900)'
+- 'hmu RunDataCompressorInletTemp =  (ERR: invalid position for 3108b509055402009808
+  / 0402089808)'
+- 'hmu RunDataCompressorOutletTemp =  (ERR: invalid position for 3108b50905540200a208
+  / 040208a208)'
+- 'hmu RunDataCompressorSpeed =  (ERR: invalid position for 3108b509055402000d0a /
+  0502010d0a01)'
+- 'hmu RunDataEEVOutletTemp =  (ERR: invalid position for 3108b50905540200ac08 / 040208ac08)'
+- 'hmu RunDataEEVPositionAbs =  (ERR: invalid position for 3108b50905540200280a /
+  040208280a)'
+- hmu RunDataElectricPowerConsumption = no data stored
+- 'hmu RunDataFan1Speed =  (ERR: invalid position for 3108b50905540200470a / 040208470a)'
+- 'hmu RunDataFan2Speed =  (ERR: invalid position for 3108b50905540200490a / 040208490a)'
+- hmu RunDataFlowTemp = no data stored
+- 'hmu RunDataHighPressure =  (ERR: invalid position for 3108b509055402006a09 / 0502016a0900)'
+- hmu RunDataReturnTemp = no data stored
+- hmu RunDataStatuscode = 0
+- 'hmu RunStats4PortValveHours =  (ERR: invalid position for 3108b50905540200c80b
+  / 040208c80b)'
+- 'hmu RunStats4PortValveSwitches =  (ERR: invalid position for 3108b50905540200c90b
+  / 040208c90b)'
+- 'hmu RunStatsBuildingCPumpStarts =  (ERR: invalid position for 3108b50905540200c50b
+  / 040208c50b)'
+- 'hmu RunStatsBuildingPumpHours =  (ERR: invalid position for 3108b50905540200c40b
+  / 040208c40b)'
+- 'hmu RunStatsCompressorHc =  (ERR: invalid position for f108b511021801 / 00)'
+- hmu RunStatsCompressorHours = 304
+- 'hmu RunStatsCompressorHwc =  (ERR: invalid position for f108b511021802 / 00)'
+- hmu RunStatsCompressorStarts = 303
+- 'hmu RunStatsFan1Hours =  (ERR: invalid position for 3108b50905540200d70b / 050201d70b00)'
+- hmu RunStatsFan1Starts = 1305
+- 'hmu RunStatsFan2Hours =  (ERR: invalid position for 3108b50905540200d90b / 050201d90b01)'
+- 'hmu RunStatsFan2Starts =  (ERR: invalid position for 3108b50905540200da0b / 050201da0b01)'
+- hmu RunStatsHcHours = -
+- 'hmu RunStatsHMUHours =  (ERR: invalid position for 3108b50905540200b80b / 040208b80b)'
+- hmu RunStatsHwcHours = -
+- hmu SetMode = auto;19.0;-;-;1;1;1;0;0;1
+- hmu SetMode = no data stored
+- hmu SourcePressure = no data stored
+- hmu SourceTempOutput = 17.12
+- hmu StatBuildingPumpHours = no data stored
+- hmu StatBuildingPumpStarts = no data stored
+- hmu StatCompressorHours = no data stored
+- hmu StatCompressorStarts = no data stored
+- hmu State = no data stored
+- hmu StatEEVSteps = no data stored
+- hmu StatFan1Hours = no data stored
+- hmu StatFan1Starts = no data stored
+- hmu StatFourWayValveHours = no data stored
+- hmu StatFourWayValveSwitchingOperations = no data stored
+- hmu Status01 = 19.0;20.0;31.438;-;46.5;off
+- hmu Status02 = no data stored
+- hmu Status16 = no data stored
+- hmu Status = no data stored
+- hmu StatusCirPump = on
+- hmu SummerSwitchOffTemp = no data stored
+- hmu TargetFlowTemp = no data stored
+- hmu TargetTempHc = no data stored
+- hmu TargetTempHwc = no data stored
+- hmu TestAirIntakeTemp = no data stored
+- hmu TestBuildingPumpPower = no data stored
+- hmu TestBuildingWaterPress = no data stored
+- hmu TestCompressorExitTemp = no data stored
+- hmu TestCompressorInletTemp = no data stored
+- hmu TestCompressorSpeed = no data stored
+- hmu TestCondensateTemp = no data stored
+- hmu TestCondensateTrayHeater = no data stored
+- hmu TestCondensorInletTemp = no data stored
+- hmu TestCondensorOutletTemp = no data stored
+- hmu TestCylinderTemp = no data stored
+- hmu TestDCFStatus = no data stored
+- hmu TestEEVOutletTemp = no data stored
+- hmu TestEEVPosition = no data stored
+- hmu TestEEVTemp = no data stored
+- hmu TestEvaporationTemp = no data stored
+- hmu TestFan1 = no data stored
+- hmu TestFan2 = no data stored
+- hmu TestFlowTemp = no data stored
+- hmu TestFlowTempImmersionHeater = no data stored
+- hmu TestFourWayValve = no data stored
+- hmu TestHeatingCoilCompressor = no data stored
+- hmu TestHighPress = no data stored
+- hmu TestHighPressureSwitch = no data stored
+- hmu TestImmersionHeaterSafetyCutOut = no data stored
+- hmu TestLockoutContactS20 = no data stored
+- hmu TestLockoutContactS21 = no data stored
+- hmu TestLowPress = no data stored
+- hmu TestMA1Output = no data stored
+- hmu TestMIInput = no data stored
+- hmu TestMO2Output = no data stored
+- hmu TestMO3Output = no data stored
+- hmu TestOutdoorTemp = no data stored
+- hmu TestOverheatingActualValue = no data stored
+- hmu TestOverheatingTargetValue = no data stored
+- hmu TestPrioritySwitchingValve = no data stored
+- hmu TestReturnTemp = no data stored
+- hmu TestSubcoolingActualValue = no data stored
+- hmu TestSubcoolingTargetValue = no data stored
+- hmu TestSystemTemp = no data stored
+- hmu TestTempSwitchCompressorOutlet = no data stored
+- hmu TestWaterThroughput = no data stored
+- 'hmu TotalEnergyUsage =  (ERR: invalid position for 3108b51a0405ff324d / 02ff01)'
+- hmu YieldCoolDay = 0.0
+- hmu YieldHc = 19383
+- hmu YieldHcDay = 0.0
+- hmu YieldHcMonth = no data stored
+- hmu YieldHwc = 5847
+- hmu YieldHwcDay = no data stored
+- hmu YieldHwcMonth = no data stored
+- hmu YieldThisYear10 = no data stored
+- hmu YieldThisYear11 = no data stored
+- hmu YieldThisYear12 = no data stored
+- hmu YieldThisYear1 = no data stored
+- hmu YieldThisYear2 = no data stored
+- hmu YieldThisYear3 = no data stored
+- hmu YieldThisYear4 = no data stored
+- hmu YieldThisYear5 = no data stored
+- hmu YieldThisYear6 = no data stored
+- hmu YieldThisYear7 = no data stored
+- hmu YieldThisYear8 = no data stored
+- hmu YieldThisYear9 = no data stored
+- hmu YieldTotal = no data stored
+- Memory Eeprom = no data stored
+- Memory Eeprom = no data stored
+- Memory Ram = no data stored
+- Memory Ram = no data stored
+- Scan Id = no data stored
+- scan.08  = Vaillant;HMU00;0308;0403
+- scan.15  = Vaillant;CTLV3;0709;3704
+- Scan.15 Id = 21;23;24;0010045478;0953;008392;N5
+- scan.26  = Vaillant;VR_71;0201;0503
+- Scan.26 Id = 21;24;24;0020184846;0082;011935;N1
+- scan.35  = Vaillant;VR_92;0709;3904
+- Scan.35 Id = 21;24;21;0020260923;0953;006799;N8
+- scan.36  = no data stored
+- scan.76  = Vaillant;VWZ00;0308;0403
+- 'Scan.76 Id =  (ERR: invalid position for f176b5090124 / 00)'
+- scan.f6  = Vaillant;NETX3;0129;0404
+- Scan.f6 Id = 21;24;10;8000015501;0933;032476;N6
+- vr_71 Clearerrorhistory = no data stored
+- vr_71 Currenterror = -;-;-;-;-
+- vr_71 Errorhistory = no data stored
+- vr_71 Mc1Operation = 2;19.0;on;5
+- vr_71 Mc2Operation = no data stored
+- vr_71 Mc3Operation = no data stored
+- vr_71 SensorData1 = 28.50;19.88;-;-;-;-;-;50 3d
+- vr_71 SensorData2 = -;-;-;-;0.00;8.00;80 57 05
+- vr_71 SetActorState = -;off;off;off;off;off;-;-;off;off;off;off;00 00
+- ''
+before_registers:
+- circuit: Broadcast
+  name: Datetime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Error
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: Broadcast
+  name: HwcStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Id
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: IdAnswer
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: IdQuery
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Load
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Outsidetemp
+  fields:
+  - value
+  values:
+  - '31.438'
+  writable: false
+  has_data: true
+- circuit: Broadcast
+  name: Queryexistence
+  fields:
+  - value
+  values:
+  - (empty for 31fe07fe00 / )
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Signoflife
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Vdatetime
+  fields:
+  - value
+  values:
+  - 17:36:24;16.08.2026
+  writable: false
+  has_data: true
+- circuit: Broadcast
+  name: Vdatetime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: WaterPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: General
+  name: Valuerange
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Eeprom
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Eeprom
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Ram
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Ram
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Scan
+  name: Id
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Scan.15
+  name: Id
+  fields:
+  - value
+  values:
+  - 21;23;24;0010045478;0953;008392;N5
+  writable: false
+  has_data: true
+- circuit: Scan.26
+  name: Id
+  fields:
+  - value
+  values:
+  - 21;24;24;0020184846;0082;011935;N1
+  writable: false
+  has_data: true
+- circuit: Scan.35
+  name: Id
+  fields:
+  - value
+  values:
+  - 21;24;21;0020260923;0953;006799;N8
+  writable: false
+  has_data: true
+- circuit: Scan.76
+  name: Id
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for f176b5090124 / 00)'
+  writable: false
+  has_data: false
+- circuit: Scan.f6
+  name: Id
+  fields:
+  - value
+  values:
+  - 21;24;10;8000015501;0933;032476;N6
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: AdaptHeatCurve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: CcTimer_Config
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: CcTimer_Timeframes
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: ContinuousHeating
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: CylinderChargeHyst
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: CylinderChargeOffset
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Date
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: DisplayedOutsideTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: FrostOverRideTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1AutoOffMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1CircuitType
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1CoolingEnabled
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1CoolingFlowTempMin
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1DewPointMonitoring
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1DewPointOffset
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1ExcessTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1HeatCurve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MixerMovement
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1PumpStatus
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1RoomTempModulation
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1Status
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1SummerTempLimit
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2AutoOffMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2CircuitType
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2ExcessTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2HeatCurve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MixerMovement
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2PumpStatus
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2Status
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2SummerTempLimit
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3AutoOffMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3CircuitType
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3ExcessTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3HeatCurve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MixerMovement
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3PumpStatus
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3Status
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3SummerTempLimit
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HcStorageTempBottom
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: ctlv2
+  name: HcStorageTempTop
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: ctlv2
+  name: HwcFlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcLockTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcMaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcOpMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcParallelLoading
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcSFMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcSfMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcStorageTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcStorageTempBottom
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcStorageTempTop
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HydraulicScheme
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: ManualCoolingEndDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: ManualCoolingEndDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: ManualCoolingStartDate
+  fields:
+  - value
+  values:
+  - 10.08.2026
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: ManualCoolingStartDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: MaxCylinderChargeTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: MaxRoomHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: MultiRelaySetting
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: OutsideTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: OutsideTempAvg
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySum
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHcLastMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHcThisMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHwcLastMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHwcThisMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: SystemFlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: WaterPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingManualTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingOpMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingSetbackTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1DayTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1HolidayTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1NightTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1OpMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoDuration
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoEndDate
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoEndTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1RoomTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1SFMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z2RoomTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: z1RoomHumidity
+  fields:
+  - value
+  values:
+  - '70'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: AdaptHeatCurve
+  fields:
+  - value
+  values:
+  - 'no'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: AdaptHeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Config
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Friday0
+  fields:
+  - value
+  values:
+  - 06:00;23:00
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CcTimer_Friday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Friday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Monday0
+  fields:
+  - value
+  values:
+  - 06:00;23:00
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CcTimer_Monday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Monday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Saturday0
+  fields:
+  - value
+  values:
+  - 06:00;23:00
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CcTimer_Saturday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Saturday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Sunday0
+  fields:
+  - value
+  values:
+  - 06:00;23:00
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CcTimer_Sunday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Sunday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Thursday0
+  fields:
+  - value
+  values:
+  - 06:00;23:00
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CcTimer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Timeframes
+  fields:
+  - value
+  values:
+  - 1;1;1;1;1;1;1
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CcTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Tuesday0
+  fields:
+  - value
+  values:
+  - 06:00;23:00
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CcTimer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Wednesday0
+  fields:
+  - value
+  values:
+  - 06:00;23:00
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CcTimer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Clearerrorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: ContinuousHeating
+  fields:
+  - value
+  values:
+  - '-26'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: ContinuousHeating
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - -;-;-;-;-
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CylinderChargeHyst
+  fields:
+  - value
+  values:
+  - '5'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CylinderChargeHyst
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CylinderChargeOffset
+  fields:
+  - value
+  values:
+  - '8'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CylinderChargeOffset
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Date
+  fields:
+  - value
+  values:
+  - 16.08.2026
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Date
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: DisplayedOutsideTemp
+  fields:
+  - value
+  values:
+  - '31.4375'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: FrostOverRideTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: FrostOverRideTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - '19.485'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1AutoOffMode
+  fields:
+  - value
+  values:
+  - night
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1AutoOffMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1CircuitType
+  fields:
+  - value
+  values:
+  - mixer
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1ExcessTemp
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1ExcessTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1FlowTemp
+  fields:
+  - value
+  values:
+  - '19.875'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1HeatCurve
+  fields:
+  - value
+  values:
+  - '0.3'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1HeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '50'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - '19'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - '15'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1MixerMovement
+  fields:
+  - value
+  values:
+  - '5'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1PumpStatus
+  fields:
+  - value
+  values:
+  - '2'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1PumpStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - modulating
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1SummerTempLimit
+  fields:
+  - value
+  values:
+  - '16'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1SummerTempLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2AutoOffMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2AutoOffMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2CircuitType
+  fields:
+  - value
+  values:
+  - inactive
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2ExcessTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2ExcessTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2FlowTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2HeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2HeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2MixerMovement
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2PumpStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2PumpStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2SummerTempLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2SummerTempLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3AutoOffMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3AutoOffMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3CircuitType
+  fields:
+  - value
+  values:
+  - inactive
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3ExcessTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3ExcessTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3FlowTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3HeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3HeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3MixerMovement
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3PumpStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3PumpStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3SummerTempLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3SummerTempLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HcStorageTempBottom
+  fields:
+  - value
+  values:
+  - (empty for f115b5240602000000a000 / 080000a000ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HcStorageTempTop
+  fields:
+  - value
+  values:
+  - (empty for f115b52406020000009f00 / 0800009f00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcBankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcBankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcBankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcBankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcFlowTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 01.01.2015
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 01.01.2015
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcLockTime
+  fields:
+  - value
+  values:
+  - '60'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcLockTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcMaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '80'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcMaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcOpMode
+  fields:
+  - value
+  values:
+  - auto
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcOpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcParallelLoading
+  fields:
+  - value
+  values:
+  - 'off'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcParallelLoading
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcSFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcSFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcStorageTemp
+  fields:
+  - value
+  values:
+  - '46.5'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcStorageTempBottom
+  fields:
+  - value
+  values:
+  - (empty for f115b52406020000009e00 / 0800009e00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcStorageTempTop
+  fields:
+  - value
+  values:
+  - (empty for f115b52406020000009d00 / 0800009d00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTempDesired
+  fields:
+  - value
+  values:
+  - '47'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Config
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Friday0
+  fields:
+  - value
+  values:
+  - 09:00;22:00;47.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcTimer_Friday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Friday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Monday0
+  fields:
+  - value
+  values:
+  - 09:00;22:00;47.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcTimer_Monday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Monday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Saturday0
+  fields:
+  - value
+  values:
+  - 09:00;22:00;47.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcTimer_Saturday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Saturday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Sunday0
+  fields:
+  - value
+  values:
+  - 09:00;22:00;47.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcTimer_Sunday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Sunday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Thursday0
+  fields:
+  - value
+  values:
+  - 09:00;22:00;47.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcTimer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Timeframes
+  fields:
+  - value
+  values:
+  - 1;1;1;1;1;1;1
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Tuesday0
+  fields:
+  - value
+  values:
+  - 09:00;22:00;47.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcTimer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Wednesday0
+  fields:
+  - value
+  values:
+  - 09:00;22:00;47.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcTimer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HydraulicScheme
+  fields:
+  - value
+  values:
+  - '8'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HydraulicScheme
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Installer1
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Installer1
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Installer2
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Installer2
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: KeyCodeforConfigMenu
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: KeyCodeforConfigMenu
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: MaintenanceDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: MaintenanceDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: MaintenanceDue
+  fields:
+  - value
+  values:
+  - 'no'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: MaxCylinderChargeTime
+  fields:
+  - value
+  values:
+  - '90'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: MaxCylinderChargeTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: MaxRoomHumidity
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: MaxRoomHumidity
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: MultiRelaySetting
+  fields:
+  - value
+  values:
+  - circulation
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: MultiRelaySetting
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: OutsideTempAvg
+  fields:
+  - value
+  values:
+  - '26.2734'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: OutsideTempAvg
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PhoneNumber1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PhoneNumber1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PhoneNumber2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PhoneNumber2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHc
+  fields:
+  - value
+  values:
+  - '6606'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: PrEnergySumHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHwc
+  fields:
+  - value
+  values:
+  - '2070'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: PrEnergySumHwc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHwcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHwcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHwcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHwcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHwc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHwc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHwcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHwcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHwcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHwcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PumpAdditionalTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PumpAdditionalTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: SolarYieldTotal
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: SolarYieldTotal
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: SystemFlowTemp
+  fields:
+  - value
+  values:
+  - '28.5'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Time
+  fields:
+  - value
+  values:
+  - '17:37:21'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Time
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: WaterPressure
+  fields:
+  - value
+  values:
+  - '1.9'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: YieldTotal
+  fields:
+  - value
+  values:
+  - '25260'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: YieldTotal
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1CoolingTemp
+  fields:
+  - value
+  values:
+  - '20'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1CoolingTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1DayTemp
+  fields:
+  - value
+  values:
+  - '22'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 01.01.2015
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 01.01.2015
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1HolidayTemp
+  fields:
+  - value
+  values:
+  - '15'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Name1
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for f115b52406020003001700 / 080303170046626800)'
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Name2
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for f115b52406020003001800 / 050303180000)'
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1NightTemp
+  fields:
+  - value
+  values:
+  - '18'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1OpMode
+  fields:
+  - value
+  values:
+  - day
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1QuickVetoEndDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1QuickVetoEndTime
+  fields:
+  - value
+  values:
+  - 00:00:00
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1RoomTemp
+  fields:
+  - value
+  values:
+  - '23.225'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Config
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Friday0
+  fields:
+  - value
+  values:
+  - 09:00;22:00;21.5
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Friday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Friday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Monday0
+  fields:
+  - value
+  values:
+  - 09:00;22:00;21.5
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Monday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Monday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Saturday0
+  fields:
+  - value
+  values:
+  - 09:00;22:00;21.5
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Saturday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Saturday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Sunday0
+  fields:
+  - value
+  values:
+  - 09:00;22:00;21.5
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Sunday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Sunday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Thursday0
+  fields:
+  - value
+  values:
+  - 09:00;22:00;21.5
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Timeframes
+  fields:
+  - value
+  values:
+  - 1;1;1;1;1;1;1
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Tuesday0
+  fields:
+  - value
+  values:
+  - 09:00;22:00;21.5
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Wednesday0
+  fields:
+  - value
+  values:
+  - 09:00;22:00;21.5
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2CoolingTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2CoolingTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2QuickVetoEndDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2QuickVetoEndTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2RoomTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z2RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Config
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Friday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Friday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Friday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Monday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Monday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Monday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Saturday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Saturday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Saturday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Sunday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Sunday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Sunday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Thursday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Timeframes
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Tuesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Wednesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3QuickVetoEndDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3QuickVetoEndTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3RoomTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z3RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Config
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Friday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Friday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Friday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Monday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Monday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Monday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Saturday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Saturday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Saturday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Sunday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Sunday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Sunday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Thursday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Timeframes
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Tuesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Wednesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: AirIntakeTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: BuildingCircuitFlow
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3108b51a0405ff323c / 02ff01)'
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: BuildingCircuitPumpSpeed
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: BuildingPumpHours
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: BuildingPumpHours
+  fields:
+  - value
+  values:
+  - '7103'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: BuildingPumpStarts
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: BuildingPumpStarts
+  fields:
+  - value
+  values:
+  - '9458'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: Clearerrorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: CompressorHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: CompressorHc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHours
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: CompressorHours
+  fields:
+  - value
+  values:
+  - '1794'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CompressorHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: CompressorHwc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHwc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHysteresisCooling
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: CompressorHysteresisHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: CompressorStarts
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: CompressorStarts
+  fields:
+  - value
+  values:
+  - '8578'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: ConsumptionThisYear1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: ConsumptionThisYear10
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: ConsumptionThisYear11
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: ConsumptionThisYear12
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: ConsumptionThisYear2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: ConsumptionThisYear3
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: ConsumptionThisYear4
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: ConsumptionThisYear5
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: ConsumptionThisYear6
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: ConsumptionThisYear7
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: ConsumptionThisYear8
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: ConsumptionThisYear9
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: ConsumptionTotal
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: CopCooling
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CopCoolingMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CopHc
+  fields:
+  - value
+  values:
+  - '3.9'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CopHcMonth
+  fields:
+  - value
+  values:
+  - '1.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CopHwc
+  fields:
+  - value
+  values:
+  - '3.8'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CopHwcMonth
+  fields:
+  - value
+  values:
+  - '4.3'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CurrentCompressorUtil
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3108b51a0405ff3225 / 02ff01)'
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: CurrentConsumedPower
+  fields:
+  - value
+  values:
+  - '0.4'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CurrentYieldPower
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - -;-;-;-;-
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: DateTime
+  fields:
+  - value
+  values:
+  - valid;17:36:28;16.08.2026;31.438
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: EEVSteps
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: EEVSteps
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: EnableTestCompressorExitTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: EnableTestCompressorIntakeTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: EnableTestCompressorSpeed
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: EnableTestCondensateTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: EnableTestEEVPosition
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: EnableTestEEVTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: EnableTestEvaporationTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: EnableTestFlowTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: EnableTestHighPress
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: EnableTestReturnTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: EnableTestWaterThroughput
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: EnableiveMonitorMain
+  fields:
+  - value
+  values:
+  - (empty for f108b503020003 / 0a7700ffffffffffffffff)
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: EnergyIntegral
+  fields:
+  - value
+  values:
+  - '500'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: Fan1Hours
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: Fan1Hours
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: Fan1Starts
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: Fan1Starts
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: Fan2Hours
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: Fan2Hours
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: Fan2Starts
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: Fan2Starts
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: FlowPressure
+  fields:
+  - value
+  values:
+  - '1.97'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: FlowTemp
+  fields:
+  - value
+  values:
+  - '19.31'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: FlowTemperature
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: FourWayValveHours
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: FourWayValveHours
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: FourWayValveSwitches
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: FourWayValveSwitches
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: FourWayValveSwitchingOperations
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: FourWayValveSwitchingOperations
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: HcBivalencePoint
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: HcModeActive
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: HeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: Hours
+  fields:
+  - value
+  values:
+  - '15575'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: HoursCool
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: HoursHc
+  fields:
+  - value
+  values:
+  - '1963'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: HoursHwc
+  fields:
+  - value
+  values:
+  - '469'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: HwcBivalencePoint
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: HwcChargeHysteresis
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: HwcMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: HwcModeActive
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: ImmersionHeaterMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: LiveMonitorAirIntakeTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: LiveMonitorCurrentCompressorUtil
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: LiveMonitorCurrentConsumedPower
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: LiveMonitorCurrentSupplyTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: LiveMonitorCurrentYieldPower
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: LiveMonitorDesiredSupplyTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: LiveMonitorMain
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: MaxFlowTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: MinFlowTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: PowerConsumptionHmu
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunDataAirInletTemp
+  fields:
+  - value
+  values:
+  - '7.70574e-42'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataBuildingCPumpPower
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3108b50905540200c509 / 050201c50900)'
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: RunDataCompressorInletTemp
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3108b509055402009808 / 0402089808)'
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: RunDataCompressorOutletTemp
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3108b50905540200a208 / 040208a208)'
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: RunDataCompressorSpeed
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3108b509055402000d0a / 0502010d0a01)'
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: RunDataEEVOutletTemp
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3108b50905540200ac08 / 040208ac08)'
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: RunDataEEVPositionAbs
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3108b50905540200280a / 040208280a)'
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: RunDataElectricPowerConsumption
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: RunDataFan1Speed
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3108b50905540200470a / 040208470a)'
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: RunDataFan2Speed
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3108b50905540200490a / 040208490a)'
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: RunDataFlowTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: RunDataHighPressure
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3108b509055402006a09 / 0502016a0900)'
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: RunDataLowPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunDataReturnTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: RunDataStatuscode
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStats4PortValveHours
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3108b50905540200c80b / 040208c80b)'
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: RunStats4PortValveSwitches
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3108b50905540200c90b / 040208c90b)'
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: RunStatsBuildingCPumpStarts
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3108b50905540200c50b / 040208c50b)'
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: RunStatsBuildingPumpHours
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3108b50905540200c40b / 040208c40b)'
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: RunStatsCompressorHc
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for f108b511021801 / 00)'
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: RunStatsCompressorHc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHours
+  fields:
+  - value
+  values:
+  - '304'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsCompressorHwc
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for f108b511021802 / 00)'
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: RunStatsCompressorHwc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHwc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorStarts
+  fields:
+  - value
+  values:
+  - '303'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsFan1Hours
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3108b50905540200d70b / 050201d70b00)'
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: RunStatsFan1Starts
+  fields:
+  - value
+  values:
+  - '1305'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsFan2Hours
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3108b50905540200d90b / 050201d90b01)'
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: RunStatsFan2Starts
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3108b50905540200da0b / 050201da0b01)'
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: RunStatsHMUHours
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3108b50905540200b80b / 040208b80b)'
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: RunStatsHcHours
+  fields:
+  - value
+  values:
+  - '-'
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: RunStatsHwcHours
+  fields:
+  - value
+  values:
+  - '-'
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: SetMode
+  fields:
+  - value
+  values:
+  - auto;19.0;-;-;1;1;1;0;0;1
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: SetMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: SourcePressure
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: SourceTempInput
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: SourceTempOutput
+  fields:
+  - value
+  values:
+  - '17.12'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: StatBuildingPumpHours
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: StatBuildingPumpStarts
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: StatCompressorHours
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: StatCompressorStarts
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: StatEEVSteps
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: StatElectricEnergySum
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatElectricEnergySumCool
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatElectricEnergySumHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatElectricEnergySumHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatEnvironmentEnergySum
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatEnvironmentEnergySumCool
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatEnvironmentEnergySumHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatEnvironmentEnergySumHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatFan1Hours
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: StatFan1Starts
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: StatFourWayValveHours
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: StatFourWayValveSwitchingOperations
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: State
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: Status01
+  fields:
+  - value
+  values:
+  - 19.0;20.0;31.438;-;46.5;off
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: Status01.pumpstate
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.temp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.temp_1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.temp_2
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: Status01.temp_3
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: Status01.temp_4
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: Status02
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: Status16
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: StatusCirPump
+  fields:
+  - value
+  values:
+  - 'on'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: SummerSwitchOffTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: SupplyTempWeighted
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: TargetFlowTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: TargetTempHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: TargetTempHwc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: TestAirIntakeTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: TestBuildingPumpPower
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: TestBuildingWaterPress
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: TestCompressorExitTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: TestCompressorInletTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: TestCompressorSpeed
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: TestCondensateTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: TestCondensateTrayHeater
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: TestCondensorInletTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: TestCondensorOutletTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: TestCylinderTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: TestDCFStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: TestEEVOutletTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: TestEEVPosition
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: TestEEVTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: TestEvaporationTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: TestFan1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: TestFan2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: TestFlowTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: TestFlowTempImmersionHeater
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: TestFourWayValve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: TestHeatingCoilCompressor
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: TestHighPress
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: TestHighPressureSwitch
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: TestImmersionHeaterSafetyCutOut
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: TestLockoutContactS20
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: TestLockoutContactS21
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: TestLowPress
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: TestMA1Output
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: TestMIInput
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: TestMO2Output
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: TestMO3Output
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: TestOutdoorTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: TestOverheatingActualValue
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: TestOverheatingTargetValue
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: TestPrioritySwitchingValve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: TestReturnTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: TestSubcoolingActualValue
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: TestSubcoolingTargetValue
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: TestSystemTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: TestTempSwitchCompressorOutlet
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: TestWaterThroughput
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: TotalEnergyUsage
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3108b51a0405ff324d / 02ff01)'
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: YieldCoolDay
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldCooling
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldCoolingMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldHc
+  fields:
+  - value
+  values:
+  - '19383'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldHcDay
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldHcMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: YieldHwc
+  fields:
+  - value
+  values:
+  - '5847'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldHwcDay
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: YieldHwcMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: YieldThisYear1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: YieldThisYear10
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: YieldThisYear11
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: YieldThisYear12
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: YieldThisYear2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: YieldThisYear3
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: YieldThisYear4
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: YieldThisYear5
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: YieldThisYear6
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: YieldThisYear7
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: YieldThisYear8
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: YieldThisYear9
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: YieldTotal
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: BypassPosition
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: ExhaustAirHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: ExhaustAirTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: MaxAirHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: MinAirHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: OutsideAirTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: SupplyAirTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: VentilationLevelDay
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: VentilationLevelNight
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldToday
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldTotal
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldYear
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Clearerrorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vr_71
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - -;-;-;-;-
+  writable: false
+  has_data: true
+- circuit: vr_71
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vr_71
+  name: Mc1Operation
+  fields:
+  - value
+  values:
+  - 2;19.0;on;5
+  writable: false
+  has_data: true
+- circuit: vr_71
+  name: Mc2Operation
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vr_71
+  name: Mc3Operation
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vr_71
+  name: SensorData1
+  fields:
+  - value
+  values:
+  - 28.50;19.88;-;-;-;-;-;50 3d
+  writable: false
+  has_data: true
+- circuit: vr_71
+  name: SensorData2
+  fields:
+  - value
+  values:
+  - -;-;-;-;0.00;8.00;80 57 05
+  writable: false
+  has_data: true
+- circuit: vr_71
+  name: SetActorState
+  fields:
+  - value
+  values:
+  - -;off;off;off;off;off;-;-;off;off;off;off;00 00
+  writable: false
+  has_data: true
+- circuit: vwz
+  name: TestHwcTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: vwz
+  name: TestOutdoorTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: vwz
+  name: TestThreeWayValve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+grab:
+- '[grab] grab continued'
+- 'f108070400 / 0ab5484d55303003080403 = 15: scan.08'
+- '3115070400 / 0ab543544c563307093704 = 172: scan.15'
+- 'f115b5090127 / 094e3530303030303030 = 31: Scan.15 Id'
+- 'f126070400 / 0ab556525f373102010503 = 8: scan.26'
+- 'f126b5090127 / 094e3100000000000000 = 31: Scan.26 Id'
+- 'f135070400 / 0ab556525f393207093904 = 8: scan.35'
+- '3135b5090127 / 094e3830303030303030 = 3: Scan.35 Id'
+- 'f176070400 / 0ab556575a303003080403 = 15: scan.76'
+- 'f176b5090127 / 00 = 179: Scan.76 Id'
+- '31f6070400 / 0ab54e4554583301290404 = 1: scan.f6'
+- '31f6b5090127 / 094e36ffffffffffffff = 3: Scan.f6 Id'
+- '31fe07fe00 = 1: Broadcast Queryexistence'
+- '1008b51009000026ffffff070004 / 0101 = 61627: hmu SetMode'
+- '1008b512020064 / 00 = 2068: hmu StatusCirPump'
+- '10feb516080024421716080726 = 10266: Broadcast Vdatetime'
+- '10feb5160301701f = 10261: Broadcast Outsidetemp'
+- '1008b5040100 / 0a03324114090807260022 = 1: hmu DateTime'
+- 1008b507010a / 03828203 = 172
+- 1008b5110100 / 09350114000008000100 = 10265
+- '1008b5110101 / 0927290022ff710000ff = 2: hmu Status01'
+- 1008b5160111 / 09010506100634060a06 = 7
+- 1026b5160111 / 090103010e0130010301 = 7
+- '1026b5230106 / 10d101420100800080008000800080503d = 8: vr_71 SensorData1'
+- '1026b5230107 / 0f008000800080008000008000805705 = 8: vr_71 SensorData2'
+- 1035b5160111 / 090105030e0330030303 = 7
+- 1076b5110101 / 09ff28701fff5e0000ff = 61577
+- 1076b5160111 / 00 = 7
+- 10feb505025c01 = 10263
+- 10feb510020601 = 2054
+- '10feb516080029411409080726 = 1: Broadcast Vdatetime'
+- '10feb51603010022 = 1: Broadcast Outsidetemp'
+- '3115b5090124 / 09003231323332343030 = 1: Scan.15 Id'
+- '3126b5090124 / 09003231323432343030 = 1: Scan.26 Id'
+- '3135b5090124 / 09003231323432313030 = 1: Scan.35 Id'
+- '3176b5090124 / 00 = 1: Scan.76 Id'
+- '31f6b5090124 / 09003231323431303830 = 1: Scan.f6 Id'
+- f108b5090124 / 09003231323431313030 = 7
+- f108b5090125 / 09313030313634323330 = 7
+- f108b5090126 / 09303031303035303030 = 7
+- f108b5090127 / 094e333c3c3c3c3c3c3c = 7
+- f108b5110100 / 09350114000008000100 = 2121
+- 'f108b5110101 / 0927290022ff710000ff = 1: hmu Status01'
+- '1008b5040100 / 0a0327421716080726701f = 10266: hmu DateTime'
+- '1008b5110101 / 092628701fff5e0000ff = 73945: hmu Status01'
+- '1026b5230106 / 10c8013e0100800080008000800080503d = 61561: vr_71 SensorData1'
+- '1026b5230107 / 0f008000800080008000008000805705 = 61565: vr_71 SensorData2'
+- '1026b5230f05ff0000000000ffff000000000000 / 0101 = 61594: vr_71 SetActorState'
+- 1008b507020900 / 02b903 = 10265
+- 1008b512020464 / 0101 = 2006
+- 1008b5120204ff / 0101 = 81
+- 1008b513020528 / 0101 = 2054
+- 'f108b503020001 / 0affffffffffffffffffff = 1: hmu Currenterror'
+- f108b503020002 / 0affffffffffffffffffff = 10269
+- f108b503020004 / 0affffffffffffffffffff = 10268
+- f108b503020005 / 00 = 10267
+- f108b509022802 / 0c02000308300100484d553030 = 7
+- f108b511021803 / 00 = 171
+- 'f115b503020001 / 0affffffffffffffffffff = 1: ctlv3 Currenterror'
+- f115b503020002 / 0affffffffffffffffffff = 10270
+- f176b503020001 / 00 = 10269
+- f176b511021801 / 00 = 171
+- f176b511021802 / 00 = 171
+- f176b511021803 / 00 = 171
+- 'f108b503020001 / 0affffffffffffffffffff = 10266: hmu Currenterror'
+- 'f108b511021801 / 00 = 171: hmu RunStatsCompressorHc'
+- 'f108b511021802 / 00 = 171: hmu RunStatsCompressorHwc'
+- 'f115b503020001 / 0affffffffffffffffffff = 10269: ctlv3 Currenterror'
+- '3126b503020001 / 0affffffffffffffffffff = 1: vr_71 Currenterror'
+- 'f108b503020003 / 0a7700ffffffffffffffff = 4157: hmu EnableiveMonitorMain'
+- '1026b5230402000226 / 020105 = 61844: vr_71 Mc1Operation'
+- 1076b512030f0001 / 0707030000801400 = 703
+- 1076b512030f0101 / 0798020000801300 = 17670
+- 1076b512030f0201 / 078a020000801300 = 2
+- 1076b512030f0202 / 07f0020000801300 = 945
+- 1076b512030f0301 / 07f0020000801300 = 42254
+- f108b5310301ffff / 00 = 7
+- f115b52403000000 / 0400004040 = 7
+- f115b52403000100 / 0400004040 = 7
+- f115b52403000200 / 0400000000 = 7
+- f115b52403000300 / 0400000000 = 7
+- f115b52403000400 / 040000a040 = 7
+- f115b52403000800 / 0400000000 = 7
+- f115b52403000900 / 040000803f = 7
+- f115b52403000a00 / 040000803f = 7
+- f115b52403000b00 / 0400000000 = 7
+- f115b52403000c00 / 0400000000 = 7
+- f115b52403000d00 / 040000803f = 7
+- f115b52403000e00 / 0400000000 = 7
+- f115b52403000f00 / 0400000000 = 7
+- f115b52403001000 / 0400000000 = 7
+- f115b52403001100 / 040000803f = 7
+- f115b52403001200 / 04ffffff7f = 7
+- f115b55503a40001 / 09000101010101010100 = 177
+- f176b5310301ffff / 00 = 7
+- 'f115b55503a40000 / 09000101010101010100 = 177: ctlv3 Z1Timer_Timeframes'
+- 'f115b55503a40002 / 09000101010101010100 = 177: ctlv3 HwcTimer_Timeframes'
+- 'f115b55503a40003 / 09000101010101010100 = 176: ctlv3 CcTimer_Timeframes'
+- '1008b51009000026ffffff070004 / 0101 = 3: hmu SetMode'
+- 1008b516081000ffff02002134 / 0b0000ff02000f35f0b7c04b = 35
+- 1008b516081002ffff0200e134 / 0b0201ff0200e13440627848 = 70
+- 1008b516081003ffff02002132 / 0b0301ff0200213258b24c4b = 70
+- 1026b5030c0700ffffffffffffffffffff / 0101 = 684
+- 1026b516081000ffff03042134 / 0b2000ff03040f3500000000 = 20
+- 1026b516081002ffff0304e134 / 0b2201ff0304e13400000000 = 41
+- 1026b516081003ffff03042132 / 0b2301ff0304213200000000 = 42
+- '1026b5230402000226 / 020105 = 8: vr_71 Mc1Operation'
+- 1026b5230b0401000000002022000000 / 0101 = 7
+- '1026b5230f05ff0000000000ffff000000000000 / 0101 = 8: vr_71 SetActorState'
+- 1035b516081000ffff03042134 / 0b1000ff03040f3500000000 = 21
+- 1035b516081002ffff0304e134 / 0b1201ff0304e13400000000 = 42
+- 1035b516081003ffff03042132 / 0b1301ff0304213200000000 = 42
+- 1035b5240a0201030015000000a041 / 00 = 6
+- 1035b52409020103012000000000 / 00 = 4
+- 1035b52409020103022000000000 / 00 = 4
+- 1035b52409020103032000000000 / 00 = 4
+- 1035b52409020103042000000000 / 00 = 4
+- 1035b52409020103052000000000 / 00 = 4
+- 1035b52409020103062000000000 / 00 = 4
+- 1035b52409020103072000000000 / 00 = 4
+- 1035b52409020103082000000000 / 00 = 4
+- 1035b5240706010a01300016 / 00 = 2
+- 1076b51009000000ffffff010000 / 0101 = 61576
+- 3015b5030c0700ffffffffffffffffffff / 0101 = 684
+- 3015b524050100004700 / 06004700000101 = 171
+- 3015b524050100009600 / 06009600000101 = 171
+- 3015b52405010000f000 / 0900f0000000ffff0100 = 171
+- 3015b52405010000f100 / 0900f1000000ffff0100 = 170
+- 3015b524050102001600 / 0902160000001d000100 = 19953
+- 3015b524050103000100 / 09030100000002000100 = 171
+- 3015b524050103000600 / 09030600000002000100 = 171
+- 3015b5240602000000f100 / 060300f100ffff = 512
+- 3015b52406020002001600 / 06030216000000 = 19955
+- 3015b52406020003001b00 / 0601031b000000 = 20850
+- 3015b52406060009010400 / 0701090400070900 = 171
+- 3015b5240606000a013000 / 05010a300016 = 342
+- 3015b5240a06010a01070000008c42 / 02000a = 4108
+- 3115b52406020000004800 / 06010048000200 = 88218
+- 3115b52406020001000600 / 050101060000 = 72513
+- '3115b52406020002001100 / 080302110000009841 = 3: ctlv3 Hc1MinCoolingTempDesired'
+- '3115b52406020003000200 / 08020302000000a041 = 2: ctlv3 Z1CoolingTemp'
+- '3115b5240902010000db001a011b / 020000 = 2: ctlv2 ManualCoolingEndDate'
+- 3115b52406060001010100 / 050101010000 = 6615
+- 3115b52406060001020100 / 050101010000 = 6638
+- 3115b52406060001030100 / 050101010000 = 6636
+- 3115b52406060001040100 / 050101010000 = 6637
+- 3115b52406060001050100 / 050101010000 = 6638
+- 3115b52406060001060100 / 050101010000 = 6625
+- 3115b52406060001070100 / 050101010000 = 6638
+- 3115b52406060001080100 / 050101010000 = 6637
+- 3115b52406060002011500 / 080102150000009841 = 32887
+- 3115b52406060002020100 / 050102010000 = 6631
+- 3115b52406060002030100 / 050102010000 = 6623
+- 3115b52406060002040100 / 050102010000 = 6648
+- 3115b52406060002050100 / 050102010000 = 6627
+- 3115b52406060002060100 / 050102010000 = 6648
+- 3115b52406060002070100 / 050102010000 = 6645
+- 3115b52406060002080100 / 050102010000 = 6636
+- f108b509055402000008 / 06020100080000 = 1985
+- f108b50905540200040b / 060201040b6000 = 1982
+- f108b50905540200050b / 060201050ba400 = 1985
+- f108b509055402000e0b / 0602010e0b0000 = 1983
+- f108b509055402000f0b / 0602010f0b3006 = 1985
+- f108b509055402001408 / 06020114080000 = 1985
+- f108b50905540200180b / 060201180bc401 = 11276
+- f108b509055402001c0c / 0802011c0cfb0704f8 = 171
+- f108b509055402001d0c / 0502011d0c2b = 170
+- f108b509055402001e0c / 0602011e0cd007 = 170
+- f108b50905540200200c / 050201200c00 = 170
+- f108b50905540200290a / 050201290a00 = 1043
+- f108b509055402003608 / 0602013608a501 = 1983
+- f108b50905540200530c / 050201530c02 = 7
+- f108b509055402005a0a / 0702015a0ab70100 = 1982
+- f108b509055402005f0a / 0702015f0ab80100 = 1983
+- f108b509055402006009 / 050201600900 = 1985
+- f108b50905540200640a / 070201640ad0f9aa = 1984
+- f108b509055402006e0a / 0702016e0ad0f9aa = 3416
+- f108b50905540200960a / 070201960a460100 = 5126
+- f108b50905540200ba0b / 0e0201ba0b7700ffffffffffffffff = 5126
+- f108b50905540200bb0b / 0e0201bb0bffffffffffffffffffff = 1985
+- f108b50905540200cd0a / 070201cd0a570300 = 1983
+- f108b50905540200d307 / 050241d30701 = 171
+- f108b50905540200d707 / 050201d70700 = 1023
+- f108b50905540200f00a / 060201f00a1301 = 1984
+- f108b50905540200f207 / 080201f2075a050000 = 340
+- f108b50905540200f307 / 080201f307a2010000 = 170
+- f108b50905540200f407 / 080201f40700000000 = 171
+- f108b50905540200fa0a / 060201fa0a1301 = 1985
+- f108b50905540200fd07 / 060201fd070000 = 1985
+- f108b516081000ffff49050000 / 0b1000ff4905103500000000 = 1902
+- f108b51a0405000c00 / 020001 = 172
+- f108b51a0405000c4d / 020001 = 172
+- f108b51a0405000c50 / 020001 = 172
+- f108b51a0405000c51 / 020001 = 172
+- f108b51a0405000c52 / 020001 = 172
+- f108b51a0405000c53 / 020001 = 172
+- f108b51a0405000c54 / 020001 = 172
+- f108b51a0405000ca1 / 020001 = 172
+- f108b51a0405ff3203 / 0aff010590014001700310 = 171
+- f108b51a0405ff3215 / 02ff01 = 170
+- 'f108b51a0405ff3220 / 0aff083e38010000000000 = 1: hmu FlowTemp'
+- '[grab stop] grab stopped'
+labeled_telegrams:
+- msgid: '0704'
+  master: f1
+  slave: 08
+  sub: '00'
+  resp: 0ab5484d55303003080403
+  count: '15'
+  label: scan.08
+- msgid: '0704'
+  master: '31'
+  slave: '15'
+  sub: '00'
+  resp: 0ab543544c563307093704
+  count: '172'
+  label: scan.15
+- msgid: b509
+  master: f1
+  slave: '15'
+  sub: '0127'
+  resp: 094e3530303030303030
+  count: '31'
+  label: Scan.15 Id
+- msgid: '0704'
+  master: f1
+  slave: '26'
+  sub: '00'
+  resp: 0ab556525f373102010503
+  count: '8'
+  label: scan.26
+- msgid: b509
+  master: f1
+  slave: '26'
+  sub: '0127'
+  resp: 094e3100000000000000
+  count: '31'
+  label: Scan.26 Id
+- msgid: '0704'
+  master: f1
+  slave: '35'
+  sub: '00'
+  resp: 0ab556525f393207093904
+  count: '8'
+  label: scan.35
+- msgid: b509
+  master: '31'
+  slave: '35'
+  sub: '0127'
+  resp: 094e3830303030303030
+  count: '3'
+  label: Scan.35 Id
+- msgid: '0704'
+  master: f1
+  slave: '76'
+  sub: '00'
+  resp: 0ab556575a303003080403
+  count: '15'
+  label: scan.76
+- msgid: b509
+  master: f1
+  slave: '76'
+  sub: '0127'
+  resp: '00'
+  count: '179'
+  label: Scan.76 Id
+- msgid: '0704'
+  master: '31'
+  slave: f6
+  sub: '00'
+  resp: 0ab54e4554583301290404
+  count: '1'
+  label: scan.f6
+- msgid: b509
+  master: '31'
+  slave: f6
+  sub: '0127'
+  resp: 094e36ffffffffffffff
+  count: '3'
+  label: Scan.f6 Id
+- msgid: 07fe
+  master: '31'
+  slave: fe
+  sub: '00'
+  resp: null
+  count: '1'
+  label: Broadcast Queryexistence
+- msgid: b510
+  master: '10'
+  slave: 08
+  sub: 09000026ffffff070004
+  resp: '0101'
+  count: '61627'
+  label: hmu SetMode
+- msgid: b512
+  master: '10'
+  slave: 08
+  sub: '020064'
+  resp: '00'
+  count: '2068'
+  label: hmu StatusCirPump
+- msgid: b516
+  master: '10'
+  slave: fe
+  sub: 080024421716080726
+  resp: null
+  count: '10266'
+  label: Broadcast Vdatetime
+- msgid: b516
+  master: '10'
+  slave: fe
+  sub: 0301701f
+  resp: null
+  count: '10261'
+  label: Broadcast Outsidetemp
+- msgid: b504
+  master: '10'
+  slave: 08
+  sub: '0100'
+  resp: 0a03324114090807260022
+  count: '1'
+  label: hmu DateTime
+- msgid: b511
+  master: '10'
+  slave: 08
+  sub: '0101'
+  resp: 0927290022ff710000ff
+  count: '2'
+  label: hmu Status01
+- msgid: b523
+  master: '10'
+  slave: '26'
+  sub: '0106'
+  resp: 10d101420100800080008000800080503d
+  count: '8'
+  label: vr_71 SensorData1
+- msgid: b523
+  master: '10'
+  slave: '26'
+  sub: '0107'
+  resp: 0f008000800080008000008000805705
+  count: '8'
+  label: vr_71 SensorData2
+- msgid: b516
+  master: '10'
+  slave: fe
+  sub: 080029411409080726
+  resp: null
+  count: '1'
+  label: Broadcast Vdatetime
+- msgid: b516
+  master: '10'
+  slave: fe
+  sub: '03010022'
+  resp: null
+  count: '1'
+  label: Broadcast Outsidetemp
+- msgid: b509
+  master: '31'
+  slave: '15'
+  sub: '0124'
+  resp: 09003231323332343030
+  count: '1'
+  label: Scan.15 Id
+- msgid: b509
+  master: '31'
+  slave: '26'
+  sub: '0124'
+  resp: 09003231323432343030
+  count: '1'
+  label: Scan.26 Id
+- msgid: b509
+  master: '31'
+  slave: '35'
+  sub: '0124'
+  resp: 09003231323432313030
+  count: '1'
+  label: Scan.35 Id
+- msgid: b509
+  master: '31'
+  slave: '76'
+  sub: '0124'
+  resp: '00'
+  count: '1'
+  label: Scan.76 Id
+- msgid: b509
+  master: '31'
+  slave: f6
+  sub: '0124'
+  resp: 09003231323431303830
+  count: '1'
+  label: Scan.f6 Id
+- msgid: b511
+  master: f1
+  slave: 08
+  sub: '0101'
+  resp: 0927290022ff710000ff
+  count: '1'
+  label: hmu Status01
+- msgid: b504
+  master: '10'
+  slave: 08
+  sub: '0100'
+  resp: 0a0327421716080726701f
+  count: '10266'
+  label: hmu DateTime
+- msgid: b511
+  master: '10'
+  slave: 08
+  sub: '0101'
+  resp: 092628701fff5e0000ff
+  count: '73945'
+  label: hmu Status01
+- msgid: b523
+  master: '10'
+  slave: '26'
+  sub: '0106'
+  resp: 10c8013e0100800080008000800080503d
+  count: '61561'
+  label: vr_71 SensorData1
+- msgid: b523
+  master: '10'
+  slave: '26'
+  sub: '0107'
+  resp: 0f008000800080008000008000805705
+  count: '61565'
+  label: vr_71 SensorData2
+- msgid: b523
+  master: '10'
+  slave: '26'
+  sub: 0f05ff0000000000ffff000000000000
+  resp: '0101'
+  count: '61594'
+  label: vr_71 SetActorState
+- msgid: b503
+  master: f1
+  slave: 08
+  sub: '020001'
+  resp: 0affffffffffffffffffff
+  count: '1'
+  label: hmu Currenterror
+- msgid: b503
+  master: f1
+  slave: '15'
+  sub: '020001'
+  resp: 0affffffffffffffffffff
+  count: '1'
+  label: ctlv3 Currenterror
+- msgid: b503
+  master: f1
+  slave: 08
+  sub: '020001'
+  resp: 0affffffffffffffffffff
+  count: '10266'
+  label: hmu Currenterror
+- msgid: b511
+  master: f1
+  slave: 08
+  sub: 021801
+  resp: '00'
+  count: '171'
+  label: hmu RunStatsCompressorHc
+- msgid: b511
+  master: f1
+  slave: 08
+  sub: 021802
+  resp: '00'
+  count: '171'
+  label: hmu RunStatsCompressorHwc
+- msgid: b503
+  master: f1
+  slave: '15'
+  sub: '020001'
+  resp: 0affffffffffffffffffff
+  count: '10269'
+  label: ctlv3 Currenterror
+- msgid: b503
+  master: '31'
+  slave: '26'
+  sub: '020001'
+  resp: 0affffffffffffffffffff
+  count: '1'
+  label: vr_71 Currenterror
+- msgid: b503
+  master: f1
+  slave: 08
+  sub: '020003'
+  resp: 0a7700ffffffffffffffff
+  count: '4157'
+  label: hmu EnableiveMonitorMain
+- msgid: b523
+  master: '10'
+  slave: '26'
+  sub: '0402000226'
+  resp: '020105'
+  count: '61844'
+  label: vr_71 Mc1Operation
+- msgid: b555
+  master: f1
+  slave: '15'
+  sub: 03a40000
+  resp: 09000101010101010100
+  count: '177'
+  label: ctlv3 Z1Timer_Timeframes
+- msgid: b555
+  master: f1
+  slave: '15'
+  sub: 03a40002
+  resp: 09000101010101010100
+  count: '177'
+  label: ctlv3 HwcTimer_Timeframes
+- msgid: b555
+  master: f1
+  slave: '15'
+  sub: 03a40003
+  resp: 09000101010101010100
+  count: '176'
+  label: ctlv3 CcTimer_Timeframes
+- msgid: b510
+  master: '10'
+  slave: 08
+  sub: 09000026ffffff070004
+  resp: '0101'
+  count: '3'
+  label: hmu SetMode
+- msgid: b523
+  master: '10'
+  slave: '26'
+  sub: '0402000226'
+  resp: '020105'
+  count: '8'
+  label: vr_71 Mc1Operation
+- msgid: b523
+  master: '10'
+  slave: '26'
+  sub: 0f05ff0000000000ffff000000000000
+  resp: '0101'
+  count: '8'
+  label: vr_71 SetActorState
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020002001100'
+  resp: 080302110000009841
+  count: '3'
+  label: ctlv3 Hc1MinCoolingTempDesired
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020003000200'
+  resp: 08020302000000a041
+  count: '2'
+  label: ctlv3 Z1CoolingTemp
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 0902010000db001a011b
+  resp: '020000'
+  count: '2'
+  label: ctlv2 ManualCoolingEndDate
+- msgid: b51a
+  master: f1
+  slave: 08
+  sub: 0405ff3220
+  resp: 0aff083e38010000000000
+  count: '1'
+  label: hmu FlowTemp
+unknown_telegrams:
+- msgid: b507
+  master: '10'
+  slave: 08
+  sub: 010a
+  resp: 03828203
+  count: '172'
+  label: null
+- msgid: b511
+  master: '10'
+  slave: 08
+  sub: '0100'
+  resp: 09350114000008000100
+  count: '10265'
+  label: null
+- msgid: b516
+  master: '10'
+  slave: 08
+  sub: '0111'
+  resp: 09010506100634060a06
+  count: '7'
+  label: null
+- msgid: b516
+  master: '10'
+  slave: '26'
+  sub: '0111'
+  resp: 090103010e0130010301
+  count: '7'
+  label: null
+- msgid: b516
+  master: '10'
+  slave: '35'
+  sub: '0111'
+  resp: 090105030e0330030303
+  count: '7'
+  label: null
+- msgid: b511
+  master: '10'
+  slave: '76'
+  sub: '0101'
+  resp: 09ff28701fff5e0000ff
+  count: '61577'
+  label: null
+- msgid: b516
+  master: '10'
+  slave: '76'
+  sub: '0111'
+  resp: '00'
+  count: '7'
+  label: null
+- msgid: b505
+  master: '10'
+  slave: fe
+  sub: 025c01
+  resp: null
+  count: '10263'
+  label: null
+- msgid: b510
+  master: '10'
+  slave: fe
+  sub: '020601'
+  resp: null
+  count: '2054'
+  label: null
+- msgid: b509
+  master: f1
+  slave: 08
+  sub: '0124'
+  resp: 09003231323431313030
+  count: '7'
+  label: null
+- msgid: b509
+  master: f1
+  slave: 08
+  sub: '0125'
+  resp: 09313030313634323330
+  count: '7'
+  label: null
+- msgid: b509
+  master: f1
+  slave: 08
+  sub: '0126'
+  resp: 09303031303035303030
+  count: '7'
+  label: null
+- msgid: b509
+  master: f1
+  slave: 08
+  sub: '0127'
+  resp: 094e333c3c3c3c3c3c3c
+  count: '7'
+  label: null
+- msgid: b511
+  master: f1
+  slave: 08
+  sub: '0100'
+  resp: 09350114000008000100
+  count: '2121'
+  label: null
+- msgid: b507
+  master: '10'
+  slave: 08
+  sub: 020900
+  resp: 02b903
+  count: '10265'
+  label: null
+- msgid: b512
+  master: '10'
+  slave: 08
+  sub: '020464'
+  resp: '0101'
+  count: '2006'
+  label: null
+- msgid: b512
+  master: '10'
+  slave: 08
+  sub: 0204ff
+  resp: '0101'
+  count: '81'
+  label: null
+- msgid: b513
+  master: '10'
+  slave: 08
+  sub: 020528
+  resp: '0101'
+  count: '2054'
+  label: null
+- msgid: b503
+  master: f1
+  slave: 08
+  sub: '020002'
+  resp: 0affffffffffffffffffff
+  count: '10269'
+  label: null
+- msgid: b503
+  master: f1
+  slave: 08
+  sub: '020004'
+  resp: 0affffffffffffffffffff
+  count: '10268'
+  label: null
+- msgid: b503
+  master: f1
+  slave: 08
+  sub: '020005'
+  resp: '00'
+  count: '10267'
+  label: null
+- msgid: b509
+  master: f1
+  slave: 08
+  sub: 022802
+  resp: 0c02000308300100484d553030
+  count: '7'
+  label: null
+- msgid: b511
+  master: f1
+  slave: 08
+  sub: 021803
+  resp: '00'
+  count: '171'
+  label: null
+- msgid: b503
+  master: f1
+  slave: '15'
+  sub: '020002'
+  resp: 0affffffffffffffffffff
+  count: '10270'
+  label: null
+- msgid: b503
+  master: f1
+  slave: '76'
+  sub: '020001'
+  resp: '00'
+  count: '10269'
+  label: null
+- msgid: b511
+  master: f1
+  slave: '76'
+  sub: 021801
+  resp: '00'
+  count: '171'
+  label: null
+- msgid: b511
+  master: f1
+  slave: '76'
+  sub: 021802
+  resp: '00'
+  count: '171'
+  label: null
+- msgid: b511
+  master: f1
+  slave: '76'
+  sub: 021803
+  resp: '00'
+  count: '171'
+  label: null
+- msgid: b512
+  master: '10'
+  slave: '76'
+  sub: 030f0001
+  resp: 0707030000801400
+  count: '703'
+  label: null
+- msgid: b512
+  master: '10'
+  slave: '76'
+  sub: 030f0101
+  resp: 0798020000801300
+  count: '17670'
+  label: null
+- msgid: b512
+  master: '10'
+  slave: '76'
+  sub: 030f0201
+  resp: 078a020000801300
+  count: '2'
+  label: null
+- msgid: b512
+  master: '10'
+  slave: '76'
+  sub: 030f0202
+  resp: 07f0020000801300
+  count: '945'
+  label: null
+- msgid: b512
+  master: '10'
+  slave: '76'
+  sub: 030f0301
+  resp: 07f0020000801300
+  count: '42254'
+  label: null
+- msgid: b531
+  master: f1
+  slave: 08
+  sub: 0301ffff
+  resp: '00'
+  count: '7'
+  label: null
+- msgid: b524
+  master: f1
+  slave: '15'
+  sub: '03000000'
+  resp: '0400004040'
+  count: '7'
+  label: null
+- msgid: b524
+  master: f1
+  slave: '15'
+  sub: '03000100'
+  resp: '0400004040'
+  count: '7'
+  label: null
+- msgid: b524
+  master: f1
+  slave: '15'
+  sub: '03000200'
+  resp: '0400000000'
+  count: '7'
+  label: null
+- msgid: b524
+  master: f1
+  slave: '15'
+  sub: '03000300'
+  resp: '0400000000'
+  count: '7'
+  label: null
+- msgid: b524
+  master: f1
+  slave: '15'
+  sub: '03000400'
+  resp: 040000a040
+  count: '7'
+  label: null
+- msgid: b524
+  master: f1
+  slave: '15'
+  sub: 03000800
+  resp: '0400000000'
+  count: '7'
+  label: null
+- msgid: b524
+  master: f1
+  slave: '15'
+  sub: 03000900
+  resp: 040000803f
+  count: '7'
+  label: null
+- msgid: b524
+  master: f1
+  slave: '15'
+  sub: 03000a00
+  resp: 040000803f
+  count: '7'
+  label: null
+- msgid: b524
+  master: f1
+  slave: '15'
+  sub: 03000b00
+  resp: '0400000000'
+  count: '7'
+  label: null
+- msgid: b524
+  master: f1
+  slave: '15'
+  sub: 03000c00
+  resp: '0400000000'
+  count: '7'
+  label: null
+- msgid: b524
+  master: f1
+  slave: '15'
+  sub: 03000d00
+  resp: 040000803f
+  count: '7'
+  label: null
+- msgid: b524
+  master: f1
+  slave: '15'
+  sub: 03000e00
+  resp: '0400000000'
+  count: '7'
+  label: null
+- msgid: b524
+  master: f1
+  slave: '15'
+  sub: 03000f00
+  resp: '0400000000'
+  count: '7'
+  label: null
+- msgid: b524
+  master: f1
+  slave: '15'
+  sub: '03001000'
+  resp: '0400000000'
+  count: '7'
+  label: null
+- msgid: b524
+  master: f1
+  slave: '15'
+  sub: '03001100'
+  resp: 040000803f
+  count: '7'
+  label: null
+- msgid: b524
+  master: f1
+  slave: '15'
+  sub: '03001200'
+  resp: 04ffffff7f
+  count: '7'
+  label: null
+- msgid: b555
+  master: f1
+  slave: '15'
+  sub: 03a40001
+  resp: 09000101010101010100
+  count: '177'
+  label: null
+- msgid: b531
+  master: f1
+  slave: '76'
+  sub: 0301ffff
+  resp: '00'
+  count: '7'
+  label: null
+- msgid: b516
+  master: '10'
+  slave: 08
+  sub: 081000ffff02002134
+  resp: 0b0000ff02000f35f0b7c04b
+  count: '35'
+  label: null
+- msgid: b516
+  master: '10'
+  slave: 08
+  sub: 081002ffff0200e134
+  resp: 0b0201ff0200e13440627848
+  count: '70'
+  label: null
+- msgid: b516
+  master: '10'
+  slave: 08
+  sub: 081003ffff02002132
+  resp: 0b0301ff0200213258b24c4b
+  count: '70'
+  label: null
+- msgid: b503
+  master: '10'
+  slave: '26'
+  sub: 0c0700ffffffffffffffffffff
+  resp: '0101'
+  count: '684'
+  label: null
+- msgid: b516
+  master: '10'
+  slave: '26'
+  sub: 081000ffff03042134
+  resp: 0b2000ff03040f3500000000
+  count: '20'
+  label: null
+- msgid: b516
+  master: '10'
+  slave: '26'
+  sub: 081002ffff0304e134
+  resp: 0b2201ff0304e13400000000
+  count: '41'
+  label: null
+- msgid: b516
+  master: '10'
+  slave: '26'
+  sub: 081003ffff03042132
+  resp: 0b2301ff0304213200000000
+  count: '42'
+  label: null
+- msgid: b523
+  master: '10'
+  slave: '26'
+  sub: 0b0401000000002022000000
+  resp: '0101'
+  count: '7'
+  label: null
+- msgid: b516
+  master: '10'
+  slave: '35'
+  sub: 081000ffff03042134
+  resp: 0b1000ff03040f3500000000
+  count: '21'
+  label: null
+- msgid: b516
+  master: '10'
+  slave: '35'
+  sub: 081002ffff0304e134
+  resp: 0b1201ff0304e13400000000
+  count: '42'
+  label: null
+- msgid: b516
+  master: '10'
+  slave: '35'
+  sub: 081003ffff03042132
+  resp: 0b1301ff0304213200000000
+  count: '42'
+  label: null
+- msgid: b524
+  master: '10'
+  slave: '35'
+  sub: 0a0201030015000000a041
+  resp: '00'
+  count: '6'
+  label: null
+- msgid: b524
+  master: '10'
+  slave: '35'
+  sub: 09020103012000000000
+  resp: '00'
+  count: '4'
+  label: null
+- msgid: b524
+  master: '10'
+  slave: '35'
+  sub: 09020103022000000000
+  resp: '00'
+  count: '4'
+  label: null
+- msgid: b524
+  master: '10'
+  slave: '35'
+  sub: 09020103032000000000
+  resp: '00'
+  count: '4'
+  label: null
+- msgid: b524
+  master: '10'
+  slave: '35'
+  sub: 09020103042000000000
+  resp: '00'
+  count: '4'
+  label: null
+- msgid: b524
+  master: '10'
+  slave: '35'
+  sub: 09020103052000000000
+  resp: '00'
+  count: '4'
+  label: null
+- msgid: b524
+  master: '10'
+  slave: '35'
+  sub: 09020103062000000000
+  resp: '00'
+  count: '4'
+  label: null
+- msgid: b524
+  master: '10'
+  slave: '35'
+  sub: 09020103072000000000
+  resp: '00'
+  count: '4'
+  label: null
+- msgid: b524
+  master: '10'
+  slave: '35'
+  sub: 09020103082000000000
+  resp: '00'
+  count: '4'
+  label: null
+- msgid: b524
+  master: '10'
+  slave: '35'
+  sub: 0706010a01300016
+  resp: '00'
+  count: '2'
+  label: null
+- msgid: b510
+  master: '10'
+  slave: '76'
+  sub: 09000000ffffff010000
+  resp: '0101'
+  count: '61576'
+  label: null
+- msgid: b503
+  master: '30'
+  slave: '15'
+  sub: 0c0700ffffffffffffffffffff
+  resp: '0101'
+  count: '684'
+  label: null
+- msgid: b524
+  master: '30'
+  slave: '15'
+  sub: '050100004700'
+  resp: '06004700000101'
+  count: '171'
+  label: null
+- msgid: b524
+  master: '30'
+  slave: '15'
+  sub: 050100009600
+  resp: 06009600000101
+  count: '171'
+  label: null
+- msgid: b524
+  master: '30'
+  slave: '15'
+  sub: 05010000f000
+  resp: 0900f0000000ffff0100
+  count: '171'
+  label: null
+- msgid: b524
+  master: '30'
+  slave: '15'
+  sub: 05010000f100
+  resp: 0900f1000000ffff0100
+  count: '170'
+  label: null
+- msgid: b524
+  master: '30'
+  slave: '15'
+  sub: '050102001600'
+  resp: 0902160000001d000100
+  count: '19953'
+  label: null
+- msgid: b524
+  master: '30'
+  slave: '15'
+  sub: '050103000100'
+  resp: 09030100000002000100
+  count: '171'
+  label: null
+- msgid: b524
+  master: '30'
+  slave: '15'
+  sub: '050103000600'
+  resp: 09030600000002000100
+  count: '171'
+  label: null
+- msgid: b524
+  master: '30'
+  slave: '15'
+  sub: 0602000000f100
+  resp: 060300f100ffff
+  count: '512'
+  label: null
+- msgid: b524
+  master: '30'
+  slave: '15'
+  sub: '06020002001600'
+  resp: '06030216000000'
+  count: '19955'
+  label: null
+- msgid: b524
+  master: '30'
+  slave: '15'
+  sub: 06020003001b00
+  resp: 0601031b000000
+  count: '20850'
+  label: null
+- msgid: b524
+  master: '30'
+  slave: '15'
+  sub: 06060009010400
+  resp: 0701090400070900
+  count: '171'
+  label: null
+- msgid: b524
+  master: '30'
+  slave: '15'
+  sub: 0606000a013000
+  resp: 05010a300016
+  count: '342'
+  label: null
+- msgid: b524
+  master: '30'
+  slave: '15'
+  sub: 0a06010a01070000008c42
+  resp: 02000a
+  count: '4108'
+  label: null
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020000004800
+  resp: 06010048000200
+  count: '88218'
+  label: null
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020001000600'
+  resp: '050101060000'
+  count: '72513'
+  label: null
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06060001010100'
+  resp: '050101010000'
+  count: '6615'
+  label: null
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06060001020100'
+  resp: '050101010000'
+  count: '6638'
+  label: null
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06060001030100'
+  resp: '050101010000'
+  count: '6636'
+  label: null
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06060001040100'
+  resp: '050101010000'
+  count: '6637'
+  label: null
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06060001050100'
+  resp: '050101010000'
+  count: '6638'
+  label: null
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06060001060100'
+  resp: '050101010000'
+  count: '6625'
+  label: null
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06060001070100'
+  resp: '050101010000'
+  count: '6638'
+  label: null
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06060001080100
+  resp: '050101010000'
+  count: '6637'
+  label: null
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06060002011500'
+  resp: 080102150000009841
+  count: '32887'
+  label: null
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06060002020100'
+  resp: '050102010000'
+  count: '6631'
+  label: null
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06060002030100'
+  resp: '050102010000'
+  count: '6623'
+  label: null
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06060002040100'
+  resp: '050102010000'
+  count: '6648'
+  label: null
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06060002050100'
+  resp: '050102010000'
+  count: '6627'
+  label: null
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06060002060100'
+  resp: '050102010000'
+  count: '6648'
+  label: null
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06060002070100'
+  resp: '050102010000'
+  count: '6645'
+  label: null
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06060002080100
+  resp: '050102010000'
+  count: '6636'
+  label: null
+- msgid: b509
+  master: f1
+  slave: 08
+  sub: 055402000008
+  resp: 06020100080000
+  count: '1985'
+  label: null
+- msgid: b509
+  master: f1
+  slave: 08
+  sub: 05540200040b
+  resp: 060201040b6000
+  count: '1982'
+  label: null
+- msgid: b509
+  master: f1
+  slave: 08
+  sub: 05540200050b
+  resp: 060201050ba400
+  count: '1985'
+  label: null
+- msgid: b509
+  master: f1
+  slave: 08
+  sub: 055402000e0b
+  resp: 0602010e0b0000
+  count: '1983'
+  label: null
+- msgid: b509
+  master: f1
+  slave: 08
+  sub: 055402000f0b
+  resp: 0602010f0b3006
+  count: '1985'
+  label: null
+- msgid: b509
+  master: f1
+  slave: 08
+  sub: 055402001408
+  resp: 06020114080000
+  count: '1985'
+  label: null
+- msgid: b509
+  master: f1
+  slave: 08
+  sub: 05540200180b
+  resp: 060201180bc401
+  count: '11276'
+  label: null
+- msgid: b509
+  master: f1
+  slave: 08
+  sub: 055402001c0c
+  resp: 0802011c0cfb0704f8
+  count: '171'
+  label: null
+- msgid: b509
+  master: f1
+  slave: 08
+  sub: 055402001d0c
+  resp: 0502011d0c2b
+  count: '170'
+  label: null
+- msgid: b509
+  master: f1
+  slave: 08
+  sub: 055402001e0c
+  resp: 0602011e0cd007
+  count: '170'
+  label: null
+- msgid: b509
+  master: f1
+  slave: 08
+  sub: 05540200200c
+  resp: 050201200c00
+  count: '170'
+  label: null
+- msgid: b509
+  master: f1
+  slave: 08
+  sub: 05540200290a
+  resp: 050201290a00
+  count: '1043'
+  label: null
+- msgid: b509
+  master: f1
+  slave: 08
+  sub: 055402003608
+  resp: 0602013608a501
+  count: '1983'
+  label: null
+- msgid: b509
+  master: f1
+  slave: 08
+  sub: 05540200530c
+  resp: 050201530c02
+  count: '7'
+  label: null
+- msgid: b509
+  master: f1
+  slave: 08
+  sub: 055402005a0a
+  resp: 0702015a0ab70100
+  count: '1982'
+  label: null
+- msgid: b509
+  master: f1
+  slave: 08
+  sub: 055402005f0a
+  resp: 0702015f0ab80100
+  count: '1983'
+  label: null
+- msgid: b509
+  master: f1
+  slave: 08
+  sub: 055402006009
+  resp: 050201600900
+  count: '1985'
+  label: null
+- msgid: b509
+  master: f1
+  slave: 08
+  sub: 05540200640a
+  resp: 070201640ad0f9aa
+  count: '1984'
+  label: null
+- msgid: b509
+  master: f1
+  slave: 08
+  sub: 055402006e0a
+  resp: 0702016e0ad0f9aa
+  count: '3416'
+  label: null
+- msgid: b509
+  master: f1
+  slave: 08
+  sub: 05540200960a
+  resp: 070201960a460100
+  count: '5126'
+  label: null
+- msgid: b509
+  master: f1
+  slave: 08
+  sub: 05540200ba0b
+  resp: 0e0201ba0b7700ffffffffffffffff
+  count: '5126'
+  label: null
+- msgid: b509
+  master: f1
+  slave: 08
+  sub: 05540200bb0b
+  resp: 0e0201bb0bffffffffffffffffffff
+  count: '1985'
+  label: null
+- msgid: b509
+  master: f1
+  slave: 08
+  sub: 05540200cd0a
+  resp: 070201cd0a570300
+  count: '1983'
+  label: null
+- msgid: b509
+  master: f1
+  slave: 08
+  sub: 05540200d307
+  resp: 050241d30701
+  count: '171'
+  label: null
+- msgid: b509
+  master: f1
+  slave: 08
+  sub: 05540200d707
+  resp: 050201d70700
+  count: '1023'
+  label: null
+- msgid: b509
+  master: f1
+  slave: 08
+  sub: 05540200f00a
+  resp: 060201f00a1301
+  count: '1984'
+  label: null
+- msgid: b509
+  master: f1
+  slave: 08
+  sub: 05540200f207
+  resp: 080201f2075a050000
+  count: '340'
+  label: null
+- msgid: b509
+  master: f1
+  slave: 08
+  sub: 05540200f307
+  resp: 080201f307a2010000
+  count: '170'
+  label: null
+- msgid: b509
+  master: f1
+  slave: 08
+  sub: 05540200f407
+  resp: 080201f40700000000
+  count: '171'
+  label: null
+- msgid: b509
+  master: f1
+  slave: 08
+  sub: 05540200fa0a
+  resp: 060201fa0a1301
+  count: '1985'
+  label: null
+- msgid: b509
+  master: f1
+  slave: 08
+  sub: 05540200fd07
+  resp: 060201fd070000
+  count: '1985'
+  label: null
+- msgid: b516
+  master: f1
+  slave: 08
+  sub: 081000ffff49050000
+  resp: 0b1000ff4905103500000000
+  count: '1902'
+  label: null
+- msgid: b51a
+  master: f1
+  slave: 08
+  sub: 0405000c00
+  resp: '020001'
+  count: '172'
+  label: null
+- msgid: b51a
+  master: f1
+  slave: 08
+  sub: 0405000c4d
+  resp: '020001'
+  count: '172'
+  label: null
+- msgid: b51a
+  master: f1
+  slave: 08
+  sub: 0405000c50
+  resp: '020001'
+  count: '172'
+  label: null
+- msgid: b51a
+  master: f1
+  slave: 08
+  sub: 0405000c51
+  resp: '020001'
+  count: '172'
+  label: null
+- msgid: b51a
+  master: f1
+  slave: 08
+  sub: 0405000c52
+  resp: '020001'
+  count: '172'
+  label: null
+- msgid: b51a
+  master: f1
+  slave: 08
+  sub: 0405000c53
+  resp: '020001'
+  count: '172'
+  label: null
+- msgid: b51a
+  master: f1
+  slave: 08
+  sub: 0405000c54
+  resp: '020001'
+  count: '172'
+  label: null
+- msgid: b51a
+  master: f1
+  slave: 08
+  sub: 0405000ca1
+  resp: '020001'
+  count: '172'
+  label: null
+- msgid: b51a
+  master: f1
+  slave: 08
+  sub: 0405ff3203
+  resp: 0aff010590014001700310
+  count: '171'
+  label: null
+- msgid: b51a
+  master: f1
+  slave: 08
+  sub: 0405ff3215
+  resp: 02ff01
+  count: '170'
+  label: null
+after_registers:
+- circuit: Broadcast
+  name: Datetime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Error
+  fields:
+  - value
+  values:
+  - 'ERR: no data stored'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: Broadcast
+  name: FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: Broadcast
+  name: HwcStatus
+  fields:
+  - value
+  values:
+  - 'ERR: no data stored'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: Broadcast
+  name: Outsidetemp
+  fields:
+  - value
+  values:
+  - '31.438'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: Broadcast
+  name: Vdatetime
+  fields:
+  - value
+  values:
+  - 17:42:24;16.08.2026
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: Broadcast
+  name: WaterPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: AdaptHeatCurve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: CcTimer_Config
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: CcTimer_Timeframes
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: ContinuousHeating
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: CylinderChargeHyst
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: CylinderChargeOffset
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Date
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: DisplayedOutsideTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: FrostOverRideTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1AutoOffMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1CircuitType
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1CoolingEnabled
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1CoolingFlowTempMin
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1DewPointMonitoring
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1DewPointOffset
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1ExcessTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1HeatCurve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MixerMovement
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1PumpStatus
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1RoomTempModulation
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1Status
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1SummerTempLimit
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2AutoOffMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2CircuitType
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2ExcessTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2HeatCurve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MixerMovement
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2PumpStatus
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2Status
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2SummerTempLimit
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3AutoOffMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3CircuitType
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3ExcessTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3HeatCurve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MixerMovement
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3PumpStatus
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3Status
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3SummerTempLimit
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HcStorageTempBottom
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: ctlv2
+  name: HcStorageTempTop
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: ctlv2
+  name: HwcFlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcLockTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcMaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcOpMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcParallelLoading
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcSFMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcSfMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcStorageTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcStorageTempBottom
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcStorageTempTop
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HydraulicScheme
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: ManualCoolingEndDate
+  fields:
+  - value
+  values:
+  - 26.01.2027
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: ManualCoolingStartDate
+  fields:
+  - value
+  values:
+  - 10.08.2026
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: MaxCylinderChargeTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: MaxRoomHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: MultiRelaySetting
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: OutsideTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: OutsideTempAvg
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySum
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHcLastMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHcThisMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHwcLastMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHwcThisMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: SystemFlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: WaterPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingManualTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingOpMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingSetbackTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1DayTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1HolidayTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1NightTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1OpMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoDuration
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoEndDate
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoEndTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1RoomTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1SFMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z2RoomTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: z1RoomHumidity
+  fields:
+  - value
+  values:
+  - '70'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: BuildingCircuitFlow
+  fields:
+  - value
+  values:
+  - 'ERR: invalid position in decode'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: BuildingCircuitPumpSpeed
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: CompressorHc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: CompressorHwc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHwc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CopCooling
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CopCoolingMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CopHc
+  fields:
+  - value
+  values:
+  - '3.9'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CopHcMonth
+  fields:
+  - value
+  values:
+  - '1.0'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CopHwc
+  fields:
+  - value
+  values:
+  - '3.8'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CopHwcMonth
+  fields:
+  - value
+  values:
+  - '4.3'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CurrentCompressorUtil
+  fields:
+  - value
+  values:
+  - 'ERR: invalid position in decode'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CurrentConsumedPower
+  fields:
+  - value
+  values:
+  - '0.4'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CurrentYieldPower
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - -;-;-;-;-
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: DateTime
+  fields:
+  - value
+  values:
+  - valid;17:42:27;16.08.2026;31.438
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: FlowTemp
+  fields:
+  - value
+  values:
+  - '19.31'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: FlowTemperature
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: HoursCool
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: PowerConsumptionHmu
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunDataAirInletTemp
+  fields:
+  - value
+  values:
+  - '7.92995e-42'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataBuildingCPumpPower
+  fields:
+  - value
+  values:
+  - 'ERR: invalid position in decode'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataCompressorInletTemp
+  fields:
+  - value
+  values:
+  - 'ERR: invalid position in decode'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataCompressorOutletTemp
+  fields:
+  - value
+  values:
+  - 'ERR: invalid position in decode'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataCompressorSpeed
+  fields:
+  - value
+  values:
+  - 'ERR: invalid position in decode'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataEEVOutletTemp
+  fields:
+  - value
+  values:
+  - 'ERR: invalid position in decode'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataEEVPositionAbs
+  fields:
+  - value
+  values:
+  - 'ERR: invalid position in decode'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataFan1Speed
+  fields:
+  - value
+  values:
+  - 'ERR: invalid position in decode'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataFan2Speed
+  fields:
+  - value
+  values:
+  - 'ERR: invalid position in decode'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataHighPressure
+  fields:
+  - value
+  values:
+  - 'ERR: invalid position in decode'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataLowPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunDataStatuscode
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStats4PortValveHours
+  fields:
+  - value
+  values:
+  - 'ERR: invalid position in decode'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStats4PortValveSwitches
+  fields:
+  - value
+  values:
+  - 'ERR: invalid position in decode'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsBuildingCPumpStarts
+  fields:
+  - value
+  values:
+  - 'ERR: invalid position in decode'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsBuildingPumpHours
+  fields:
+  - value
+  values:
+  - 'ERR: invalid position in decode'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHc
+  fields:
+  - value
+  values:
+  - 'ERR: invalid position in decode'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunStatsCompressorHc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHours
+  fields:
+  - value
+  values:
+  - '304'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHwc
+  fields:
+  - value
+  values:
+  - 'ERR: invalid position in decode'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunStatsCompressorHwc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHwc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorStarts
+  fields:
+  - value
+  values:
+  - '309'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsFan1Hours
+  fields:
+  - value
+  values:
+  - 'ERR: invalid position in decode'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsFan1Starts
+  fields:
+  - value
+  values:
+  - '10801'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsFan2Hours
+  fields:
+  - value
+  values:
+  - 'ERR: invalid position in decode'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsFan2Starts
+  fields:
+  - value
+  values:
+  - 'ERR: invalid position in decode'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsHMUHours
+  fields:
+  - value
+  values:
+  - 'ERR: invalid position in decode'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsHcHours
+  fields:
+  - value
+  values:
+  - '-'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsHwcHours
+  fields:
+  - value
+  values:
+  - '-'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: SourceTempInput
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: SourceTempOutput
+  fields:
+  - value
+  values:
+  - '17.12'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatElectricEnergySum
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatElectricEnergySumCool
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatElectricEnergySumHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatElectricEnergySumHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatEnvironmentEnergySum
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatEnvironmentEnergySumCool
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatEnvironmentEnergySumHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatEnvironmentEnergySumHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01
+  fields:
+  - value
+  values:
+  - 19.0;20.0;31.438;-;47.0;off
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.pumpstate
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.temp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.temp_1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.temp_2
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: Status01.temp_3
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: Status01.temp_4
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: StatusCirPump
+  fields:
+  - value
+  values:
+  - 'on'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: SupplyTempWeighted
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: TotalEnergyUsage
+  fields:
+  - value
+  values:
+  - 'ERR: invalid position in decode'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldCoolDay
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldCooling
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldCoolingMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldHc
+  fields:
+  - value
+  values:
+  - '19383'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldHcDay
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldHwc
+  fields:
+  - value
+  values:
+  - '5883'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: BypassPosition
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: ExhaustAirHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: ExhaustAirTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: MaxAirHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: MinAirHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: OutsideAirTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: SupplyAirTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: VentilationLevelDay
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: VentilationLevelNight
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldToday
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldTotal
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldYear
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Clearerrorhistory
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - -;-;-;-;-
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - 'ERR: end of input reached'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Mc1Operation
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Mc2Operation
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Mc3Operation
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: SensorData1
+  fields:
+  - value
+  values:
+  - 28.50;19.94;-;-;-;-;-;50 3d
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: SensorData2
+  fields:
+  - value
+  values:
+  - -;-;-;-;0.00;8.00;80 57 05
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: SetActorState
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vwz
+  name: TestHwcTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: vwz
+  name: TestOutdoorTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: vwz
+  name: TestThreeWayValve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+raw_find_lines_after:
+- Broadcast Datetime = no data stored
+- ''

--- a/tests/test_entity_factory.py
+++ b/tests/test_entity_factory.py
@@ -728,6 +728,31 @@ class TestStatEnergyRegisters:
         assert "hmu.StatElectricEnergySumCool.value" not in by_key
         assert "hmu.StatEnvironmentEnergySumCool.value" not in by_key
 
+    # flexoTHERM v1.3.3 dump (issue #50): daily cooling yield + runtime are
+    # live (YieldCoolDay=0.0, HoursCool=0), while cumulative cooling totals
+    # return "element not found" and must stay hidden.
+    def test_flexotherm_133_cooling_daily_yield_entities(self) -> None:
+        graph = DiscoveryService.build_device_graph(
+            load_find_lines("community/flexotherm_133_cooling_discovery.yaml")
+        )
+        by_key = {e.key: e for e in EntityFactoryService().generate(graph)}
+        yield_day = by_key.get("hmu.YieldCoolDay.value")
+        assert yield_day is not None, "daily cooling yield must be an entity"
+        assert yield_day.meta.device_class == "energy"
+        assert yield_day.meta.unit == "kWh"
+        runtime = by_key.get("hmu.HoursCool.value")
+        assert runtime is not None, "cooling runtime must be an entity"
+        assert runtime.meta.device_class == "duration"
+        for reg in (
+            "hmu.StatElectricEnergySumCool.value",
+            "hmu.StatEnvironmentEnergySumCool.value",
+            "hmu.YieldCooling.value",
+            "hmu.YieldCoolingMonth.value",
+            "hmu.CopCooling.value",
+            "hmu.CopCoolingMonth.value",
+        ):
+            assert reg not in by_key, f"element-not-found register must stay hidden: {reg}"
+
     # flexoCOMPACT (air/water aroTHERM with active cooling) reports cooling
     # energy live on both hmu and ctlv2; both get hmu energy metadata (issue #50).
     def test_flexocompact_cooling_energy_entities(self) -> None:

--- a/tests/test_fake_ebusd.py
+++ b/tests/test_fake_ebusd.py
@@ -50,6 +50,7 @@ async def test_arotherm_fixture_loads() -> None:
         ("community/arotherm_plus_hwc_run_discovery.yaml", 50),
         ("community/arotherm_plus_ctlv2_cooling_discovery.yaml", 50),
         ("community/geniaset_bass3_discovery.yaml", 50),
+        ("community/flexotherm_133_cooling_discovery.yaml", 50),
     ],
 )
 async def test_all_fixtures_load(fixture: str, min_registers: int) -> None:


### PR DESCRIPTION
## Summary

Bumps to v1.4.2. Adds a community discovery-dump fixture from issue #50 (flexoTHERM v1.3.3 dump) and regression tests confirming the flexoTHERM exposes daily cooling yield (`hmu.YieldCoolDay`, kWh) and cooling runtime (`hmu.HoursCool`, h), while cumulative cooling totals that return `ERR: element not found` stay hidden. No production code change required.

## Changes

- `tests/fixtures/community/flexotherm_133_cooling_discovery.yaml`: new fixture
- `tests/test_fake_ebusd.py`: register the new fixture
- `tests/test_entity_factory.py`: regression test for cooling daily-yield entities
- `CHANGELOG.md`, `manifest.json`: v1.4.2