### PR TITLE
release: v1.4.3 - DHW sub-device collision fix (#50, #79)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 1.4.3 - 2026-08-24
+
+### Fixed
+
+- **DHW sub-device collision hid live hot-water registers (#50, #79).** When two
+  source circuits mapped to the same logical device name — for example
+  `ctlv3/dhw` with live registers and `hmu/dhw` without any data — the later,
+  data-less sub-device overwrote the live node during discovery. The affected
+  registers (`HwcStorageTemp`, `HwcTempDesired`, `HwcOpMode`) were silently
+  dropped from the device graph, so no DHW sensor entities were generated and
+  `water_heater` stayed without a current temperature. Sub-devices sharing a
+  logical name are now merged instead of overwritten. Verified against three
+  community fixtures: flexoTHERM (issue #50), GeniaSet BASS3 (issue #79), and
+  aroTHERM Plus two-zone (no regression).
+- **Corrected the cooling-context note for the flexoTHERM v1.3.3 dump (#50).**
+  The dump was captured during an active passive (brine) cooling cycle — flow
+  temperature around 19 °C at 31 °C outside, `releaseCooling` enabled — while
+  the compressor never ran (`RunDataStatuscode = 0`). The compressor-based
+  counters (`YieldCoolDay`, `HoursCool`) therefore stay at zero by design and
+  cannot represent passive-cooling energy; regression test comments now record
+  this context.
+
 ## 1.4.2 - 2026-08-21
 
 ### Fixed

--- a/custom_components/vaillant_ebus/backend/discovery_service.py
+++ b/custom_components/vaillant_ebus/backend/discovery_service.py
@@ -193,6 +193,22 @@ class DiscoveryService:
             if not regs:
                 continue
             assigned_regs.update(regs)
+            existing = nodes.get(sub_name)
+            if existing is not None:
+                # Two source circuits can map to one logical device name (for
+                # example ctlv3/dhw and hmu/dhw both become "dhw"). Merge their
+                # registers so a live variant is not silently dropped by the
+                # later, data-less one.
+                merged = list(existing.registers)
+                merged.extend(rk for rk in regs if rk not in set(existing.registers))
+                nodes[sub_name] = DeviceNode(
+                    circuit=sub_name,
+                    device_type=existing.device_type,
+                    registers=merged,
+                    has_data=existing.has_data
+                    or any(raw_registers.get(rk) is not None for rk in regs),
+                )
+                continue
             nodes[sub_name] = DeviceNode(
                 circuit=sub_name,
                 device_type=d_type,

--- a/custom_components/vaillant_ebus/manifest.json
+++ b/custom_components/vaillant_ebus/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/MarkBovee/vaillant-ebus/issues",
   "requirements": [],
-  "version": "1.4.2"
+  "version": "1.4.3"
 }

--- a/tests/test_entity_factory.py
+++ b/tests/test_entity_factory.py
@@ -728,9 +728,11 @@ class TestStatEnergyRegisters:
         assert "hmu.StatElectricEnergySumCool.value" not in by_key
         assert "hmu.StatEnvironmentEnergySumCool.value" not in by_key
 
-    # flexoTHERM v1.3.3 dump (issue #50): daily cooling yield + runtime are
-    # live (YieldCoolDay=0.0, HoursCool=0), while cumulative cooling totals
-    # return "element not found" and must stay hidden.
+    # flexoTHERM v1.3.3 dump (issue #50), captured during an active passive
+    # (brine) cooling cycle: flow temp ~19 °C at 31 °C outside, releaseCooling=1,
+    # but RunDataStatuscode=0 — the compressor never runs, so the compressor-based
+    # counters stay at 0 (YieldCoolDay=0.0, HoursCool=0) and cumulative cooling
+    # totals return "element not found" and must stay hidden.
     def test_flexotherm_133_cooling_daily_yield_entities(self) -> None:
         graph = DiscoveryService.build_device_graph(
             load_find_lines("community/flexotherm_133_cooling_discovery.yaml")
@@ -752,6 +754,27 @@ class TestStatEnergyRegisters:
             "hmu.CopCoolingMonth.value",
         ):
             assert reg not in by_key, f"element-not-found register must stay hidden: {reg}"
+
+    # flexoTHERM v1.3.3 dump (issue #50): ctlv3/dhw (live Hwc registers) and
+    # hmu/dhw (all no-data) both map to the logical "dhw" device name. The
+    # later one used to overwrite the live node, hiding the DHW sensors and
+    # leaving water_heater without a current temperature.
+    def test_flexotherm_dhw_sub_device_merge_keeps_live_registers(self) -> None:
+        graph = DiscoveryService.build_device_graph(
+            load_find_lines("community/flexotherm_133_cooling_discovery.yaml")
+        )
+        dhw = graph.nodes.get("dhw")
+        assert dhw is not None
+        assert dhw.has_data, "dhw node must keep the live variant's data"
+        assert "ctlv3.HwcStorageTemp" in dhw.registers
+        by_key = {e.key: e for e in EntityFactoryService().generate(graph)}
+        for reg in (
+            "ctlv3.HwcStorageTemp.value",
+            "ctlv3.HwcTempDesired.value",
+            "ctlv3.HwcOpMode.value",
+        ):
+            entity = by_key.get(reg)
+            assert entity is not None, f"live DHW register must be an entity: {reg}"
 
     # flexoCOMPACT (air/water aroTHERM with active cooling) reports cooling
     # energy live on both hmu and ctlv2; both get hmu energy metadata (issue #50).

--- a/tests/test_geniaset_bass3.py
+++ b/tests/test_geniaset_bass3.py
@@ -39,6 +39,22 @@ DISCOVERY = importlib.util.module_from_spec(DISCOVERY_SPEC)
 sys.modules["vaillant_ebus.backend.discovery_service"] = DISCOVERY
 DISCOVERY_SPEC.loader.exec_module(DISCOVERY)
 
+MAPPING_SPEC = importlib.util.spec_from_file_location(
+    "vaillant_ebus.backend.mapping", BACKEND_PATH / "mapping.py"
+)
+assert MAPPING_SPEC and MAPPING_SPEC.loader
+MAPPING = importlib.util.module_from_spec(MAPPING_SPEC)
+sys.modules["vaillant_ebus.backend.mapping"] = MAPPING
+MAPPING_SPEC.loader.exec_module(MAPPING)
+
+ENTITY_SPEC = importlib.util.spec_from_file_location(
+    "vaillant_ebus.backend.entity_factory", BACKEND_PATH / "entity_factory.py"
+)
+assert ENTITY_SPEC and ENTITY_SPEC.loader
+ENTITY = importlib.util.module_from_spec(ENTITY_SPEC)
+sys.modules["vaillant_ebus.backend.entity_factory"] = ENTITY
+ENTITY_SPEC.loader.exec_module(ENTITY)
+
 DiscoveryService = DISCOVERY.DiscoveryService
 DeviceType = DISCOVERY.DeviceType
 
@@ -57,3 +73,21 @@ def test_geniaset_bass3_dhw_registers_discovered() -> None:
     graph = DiscoveryService.build_device_graph(GENIASET_LINES)
     for key in ("bass.HwcOpMode", "bass.HwcStorageTemp", "bass.HwcTempDesired"):
         assert key in graph.raw_registers, f"missing {key}"
+
+
+# bass/dhw (live Hwc registers) and hmu/dhw (no data) both map to the logical
+# "dhw" device name; the merge must keep the live bass registers as entities
+# so water_heater gets a current temperature (GitHub issue #79).
+def test_geniaset_bass3_dhw_entities_survive_sub_device_merge() -> None:
+    graph = DiscoveryService.build_device_graph(GENIASET_LINES)
+    dhw = graph.nodes["dhw"]
+    assert dhw.has_data is True
+    assert "bass.HwcStorageTemp" in dhw.registers
+
+    by_key = {e.key: e for e in ENTITY.EntityFactoryService().generate(graph)}
+    for reg in (
+        "bass.HwcStorageTemp.value",
+        "bass.HwcTempDesired.value",
+        "bass.HwcOpMode.value",
+    ):
+        assert reg in by_key, f"live DHW register must be an entity: {reg}"


### PR DESCRIPTION
## Summary

Fixes a discovery bug where two source circuits mapping to the same logical device name silently dropped live DHW registers.

## Problem

Sub-device nodes are stored under their bare logical name (`dhw`, `z1`, ...). When two circuits produced the same sub-device — for example `ctlv3/dhw` with live registers and `hmu/dhw` without any data — the later, data-less node overwrote the live one. The affected registers (`HwcStorageTemp`, `HwcTempDesired`, `HwcOpMode`) were marked assigned but their node was gone, so no DHW sensor entities were generated and `water_heater` had no current temperature.

Verified against community fixtures:

- **flexoTHERM** (issue #50): `ctlv3.HwcStorageTemp = 46.5` live but no entity before the fix
- **GeniaSet BASS3** (issue #79): `bass.HwcStorageTemp = 43` live but no entity — likely the root cause of the open "water_heater stays unknown" point
- **aroTHERM Plus two-zone**: unchanged, no regression

Also corrects the cooling-context note for the flexoTHERM v1.3.3 dump: it was captured during an active passive (brine) cooling cycle (flow ~19 °C at 31 °C outside, `releaseCooling=1`) while the compressor never ran, so compressor-based counters stay at zero by design.

## Changes

- `discovery_service.py`: merge sub-devices sharing a logical name instead of overwriting
- Regression tests in `test_entity_factory.py` and `test_geniaset_bass3.py`
- Corrected fixture test comments
- Version bump to 1.4.3 + changelog

## Validation

- `ruff check .`: clean
- `pytest -q`: 351 passed
- `compileall`: clean
- Deployed to live HA server: v1.4.3 active, 208 sensors, water_heater populated (31.5 °C), logs clean, coordinator polling normally