### PR TITLE
fix(tools): align SSH env names with .env convention

### DIFF
--- a/tools/compare_dumps.py
+++ b/tools/compare_dumps.py
@@ -14,7 +14,7 @@ except ImportError:
     import yaml
 
 
-def ssh(cmd: str, passwd: str) -> str:
+def ssh(cmd: str, passwd: str, user: str, host: str) -> str:
     r = subprocess.run(
         [
             "sshpass",
@@ -25,7 +25,7 @@ def ssh(cmd: str, passwd: str) -> str:
             "StrictHostKeyChecking=no",
             "-o",
             "UserKnownHostsFile=/dev/null",
-            "markbovee@192.168.1.135",
+            f"{user}@{host}",
             cmd,
         ],
         capture_output=True,
@@ -38,9 +38,9 @@ def ssh(cmd: str, passwd: str) -> str:
     return r.stdout.strip()
 
 
-def list_dumps(passwd: str) -> list[tuple[str, str]]:
+def list_dumps(passwd: str, user: str, host: str) -> list[tuple[str, str]]:
     """Return sorted [(timestamp, path), ...] from HA."""
-    out = ssh("ls -1 /config/vaillant_ebus/discovery_dump_*.yaml 2>/dev/null", passwd)
+    out = ssh("ls -1 /config/vaillant_ebus/discovery_dump_*.yaml 2>/dev/null", passwd, user, host)
     if not out:
         print("No dumps found on HA", file=sys.stderr)
         sys.exit(1)
@@ -54,10 +54,10 @@ def list_dumps(passwd: str) -> list[tuple[str, str]]:
     return sorted(result, key=lambda x: x[0])
 
 
-def fetch_dump(path: str, passwd: str) -> dict:
+def fetch_dump(path: str, passwd: str, user: str, host: str) -> dict:
     with tempfile.NamedTemporaryFile(suffix=".yaml", delete=False) as f:
         local = f.name
-    data = ssh(f"cat {path}", passwd)
+    data = ssh(f"cat {path}", passwd, user, host)
     with open(local, "w") as f:
         f.write(data)
     with open(local) as f:
@@ -71,21 +71,28 @@ def main() -> None:
     parser.add_argument("--env", default="/mnt/work/Projects/Personal/vaillant-ebus/.env")
     args = parser.parse_args()
 
-    # Read password
-    passwd = None
+    # Read connection settings from .env
+    env: dict[str, str] = {}
     with open(args.env) as f:
         for line in f:
-            if line.startswith("HA_SSH_PASSWORD="):
-                passwd = line.strip().split("=", 1)[1]
-                break
-            if line.startswith("SSH_PASSWORD="):
-                passwd = line.strip().split("=", 1)[1]
-                break
-    if not passwd:
-        print("SSH_PASSWORD not found in .env", file=sys.stderr)
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            key, _, value = line.partition("=")
+            env[key] = value
+    passwd = env.get("HA_SSH_PASSWORD")
+    user = env.get("HA_SSH_USER")
+    host = env.get("HA_HOST")
+    missing = [
+        name
+        for name, val in (("HA_SSH_PASSWORD", passwd), ("HA_SSH_USER", user), ("HA_HOST", host))
+        if not val
+    ]
+    if missing:
+        print(f"Missing {', '.join(missing)} in {args.env}", file=sys.stderr)
         sys.exit(1)
 
-    dumps = list_dumps(passwd)
+    dumps = list_dumps(passwd, user, host)
     if len(dumps) < 2:
         print(f"Need at least 2 dumps, found {len(dumps)}", file=sys.stderr)
         sys.exit(1)
@@ -96,8 +103,8 @@ def main() -> None:
     print(f"After:  {after_ts}  ({after_path})", file=sys.stderr)
     print(file=sys.stderr)
 
-    b = fetch_dump(before_path, passwd)
-    a = fetch_dump(after_path, passwd)
+    b = fetch_dump(before_path, passwd, user, host)
+    a = fetch_dump(after_path, passwd, user, host)
 
     bm = {}
     for r in b["registers"]:


### PR DESCRIPTION
## Summary

`tools/compare_dumps.py` hardcoded `markbovee@192.168.1.135` and fell back to a nonexistent `SSH_PASSWORD=` env name. It now reads `HA_SSH_USER`, `HA_HOST`, and `HA_SSH_PASSWORD` from `.env`, matching the convention used by the deploy tooling and the Home Assistant skill docs, and exits with a clear message when any of them is missing.