### PR TITLE
release: v1.4.4 - b516 cooling-energy registers (#50)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## 1.4.4 - 2026-08-24
+
+### Added
+
+- **Cooling-energy registers via runtime-defined b516 statistics (#50).** The
+  b516 energy-statistics API on the HMU supports a cooling usage code
+  (`Z=5`, upstream `john30/ebusd-configuration` issue #490), but the shipped
+  HW5103 CSV definitions omit the family (upstream issue #600), so heat pumps
+  report `ERR: element not found` for every cooling total. Four registers are
+  now injected at startup via the existing runtime-definition mechanism and
+  verified live against ebusd:
+
+  - `hmu.CoolEnvYieldTotal` — environmental yield used for cooling, lifetime
+    (Wh, total increasing)
+  - `hmu.CoolEnvYieldDay` — environmental yield for cooling today (Wh)
+  - `hmu.CoolEnvYieldMonth` — environmental yield for cooling this month (Wh)
+  - `hmu.CoolElecConsTotal` — electric consumption used for cooling, lifetime
+    (Wh, total increasing)
+
+  Unlike the compressor-based counters (`YieldCoolDay`, `HoursCool`), these
+  measure the thermal energy exchanged with the building regardless of
+  compressor operation, so they also cover passive brine cooling. The day and
+  month variants carry a date payload that is re-encoded from the current
+  date on every (re)connect; the encoding helper (`b516_date_bytes`) is unit
+  tested against known dates including the live-verified 2026-08-24 case.
+
 ## 1.4.3 - 2026-08-24
 
 ### Fixed

--- a/custom_components/vaillant_ebus/backend/mapping.py
+++ b/custom_components/vaillant_ebus/backend/mapping.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from datetime import datetime
+
 from .models import RegisterMeta
 
 # Multi-field registers: register key -> field names in semicolon order of the
@@ -259,6 +261,34 @@ REGISTER_MAP: dict[str, RegisterMeta] = {
         friendly_name="Yield Cooling Today",
         device_class="energy",
         unit="kWh",
+    ),
+    # Runtime-defined b516 cooling-energy registers (issue #50). The bus
+    # reports Wh; the unit stays Wh because ebusd returns the raw EXP value.
+    "hmu.CoolEnvYieldTotal": RegisterMeta(
+        friendly_name="Cooling Energy Total",
+        device_class="energy",
+        unit="Wh",
+        state_class="total_increasing",
+        icon="mdi:snowflake",
+    ),
+    "hmu.CoolEnvYieldDay": RegisterMeta(
+        friendly_name="Cooling Energy Today",
+        device_class="energy",
+        unit="Wh",
+        icon="mdi:snowflake",
+    ),
+    "hmu.CoolEnvYieldMonth": RegisterMeta(
+        friendly_name="Cooling Energy Month",
+        device_class="energy",
+        unit="Wh",
+        icon="mdi:snowflake",
+    ),
+    "hmu.CoolElecConsTotal": RegisterMeta(
+        friendly_name="Cooling Electricity Total",
+        device_class="energy",
+        unit="Wh",
+        state_class="total_increasing",
+        icon="mdi:snowflake",
     ),
     "hmu.YieldCooling": RegisterMeta(
         friendly_name="Yield Cooling",
@@ -1489,6 +1519,22 @@ REGISTER_MAP: dict[str, RegisterMeta] = {
         entity_category="diagnostic",
     ),
 }
+
+
+# Encode the W/V/QQ date bytes of the b516 energy-statistics API (upstream
+# john30/ebusd-configuration issue #490). W is a month nibble that restarts at
+# 0 for the last five months of the year, V a day nibble, and QQ counts
+# half-years since 2000 plus one from August onwards. Verified live against a
+# B516-capable HMU.
+def b516_date_bytes(now: datetime) -> str:
+    qq = (now.year - 2000) * 2
+    if now.month >= 8:
+        qq += 1
+        w = (now.month - 8) * 2
+    else:
+        w = now.month * 2
+    v = now.day - 16 if now.day > 15 else now.day
+    return f"{(w << 4) | v:02x}{qq:02x}"
 
 
 # Look up RegisterMeta by circuit.name, return empty meta if unknown

--- a/custom_components/vaillant_ebus/coordinator.py
+++ b/custom_components/vaillant_ebus/coordinator.py
@@ -21,7 +21,7 @@ from .backend.analysis_service import AnalysisResult, AnalysisService
 from .backend.discovery_service import HIDDEN_DEVICE_KEYWORDS, DiscoveryService
 from .backend.ebus_service import EbusService
 from .backend.entity_factory import EntityDescription, EntityFactoryService
-from .backend.mapping import REGISTER_MAP, split_multi_field
+from .backend.mapping import REGISTER_MAP, b516_date_bytes, split_multi_field
 from .backend.models import (
     CIRCUIT_NAMES,
     COMPRESSOR_STATUS_LABELS,
@@ -482,6 +482,15 @@ class VaillantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # Definitions may target hardware not present on this bus. ebusd
         # reports those as unavailable; fallback/entity filtering handles that.
         # Keep only definitions verified by upstream or community evidence here.
+        #
+        # The b516 cooling-energy registers (Z=5 usage code, upstream issue
+        # #490) are absent from the shipped HW5103 CSV (upstream issue #600).
+        # They report environmental yield / electric consumption for cooling
+        # regardless of compressor operation, so they also cover passive
+        # brine cooling. Verified live against ebusd; values are Wh. Day and
+        # Month variants carry a date payload that must be refreshed on each
+        # (re)connect.
+        date_bytes = b516_date_bytes(datetime.now())
         defines = [
             "r5,ctlv2,z1RoomHumidity,z1RoomHumidity,31,15,B524,020003002800"
             ",value,,IGN:4,,,,value,,EXP,,%,z1 Room Humidity",
@@ -493,6 +502,18 @@ class VaillantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             ",02010000da00,value,m,HDA:3",
             "w,ctlv2,ManualCoolingEndDate,ManualCoolingEndDate,31,15,B524"
             ",02010000db00,value,m,HDA:3",
+            "r,hmu,CoolEnvYieldTotal,CoolEnvYieldTotal,31,08,B516"
+            ",1000ffff02050000,value,,IGN:7,,,,value,,EXP,,Wh"
+            ",hmu Cooling Env Yield Total",
+            "r,hmu,CoolElecConsTotal,CoolElecConsTotal,31,08,B516"
+            ",1000ffff03050000,value,,IGN:7,,,,value,,EXP,,Wh"
+            ",hmu Cooling Electric Consumption",
+            f"r,hmu,CoolEnvYieldDay,CoolEnvYieldDay,31,08,B516"
+            f",1001ffff0205{date_bytes},value,,IGN:7,,,,value,,EXP,,Wh"
+            f",hmu Cooling Env Yield Today",
+            f"r,hmu,CoolEnvYieldMonth,CoolEnvYieldMonth,31,08,B516"
+            f",1002ffff0205{date_bytes},value,,IGN:7,,,,value,,EXP,,Wh"
+            f",hmu Cooling Env Yield This Month",
         ]
         defined = 0
         unavailable = 0

--- a/custom_components/vaillant_ebus/manifest.json
+++ b/custom_components/vaillant_ebus/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/MarkBovee/vaillant-ebus/issues",
   "requirements": [],
-  "version": "1.4.3"
+  "version": "1.4.4"
 }

--- a/tests/test_b516_registers.py
+++ b/tests/test_b516_registers.py
@@ -1,0 +1,96 @@
+"""Tests for the runtime-defined b516 cooling-energy registers (issue #50)."""
+
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import sys
+from datetime import datetime
+from pathlib import Path
+
+BACKEND_PATH = Path(__file__).parents[1] / "custom_components/vaillant_ebus/backend"
+COMPONENT_PATH = BACKEND_PATH.parent
+
+for name in ("vaillant_ebus", "vaillant_ebus.backend"):
+    pkg = importlib.util.module_from_spec(importlib.machinery.ModuleSpec(name, None))
+    pkg.__path__ = [str(COMPONENT_PATH)] if name == "vaillant_ebus" else [str(BACKEND_PATH)]
+    sys.modules[name] = pkg
+
+MODELS_SPEC = importlib.util.spec_from_file_location("vaillant_ebus.backend.models", BACKEND_PATH / "models.py")
+assert MODELS_SPEC and MODELS_SPEC.loader
+MODELS = importlib.util.module_from_spec(MODELS_SPEC)
+sys.modules["vaillant_ebus.backend.models"] = MODELS
+MODELS_SPEC.loader.exec_module(MODELS)
+
+MAPPING_SPEC = importlib.util.spec_from_file_location(
+    "vaillant_ebus.backend.mapping", BACKEND_PATH / "mapping.py"
+)
+assert MAPPING_SPEC and MAPPING_SPEC.loader
+MAPPING = importlib.util.module_from_spec(MAPPING_SPEC)
+sys.modules["vaillant_ebus.backend.mapping"] = MAPPING
+MAPPING_SPEC.loader.exec_module(MAPPING)
+
+ENTITY_SPEC = importlib.util.spec_from_file_location(
+    "vaillant_ebus.backend.entity_factory", BACKEND_PATH / "entity_factory.py"
+)
+assert ENTITY_SPEC and ENTITY_SPEC.loader
+ENTITY = importlib.util.module_from_spec(ENTITY_SPEC)
+sys.modules["vaillant_ebus.backend.entity_factory"] = ENTITY
+ENTITY_SPEC.loader.exec_module(ENTITY)
+
+DISCOVERY_SPEC = importlib.util.spec_from_file_location(
+    "vaillant_ebus.backend.discovery_service", BACKEND_PATH / "discovery_service.py"
+)
+assert DISCOVERY_SPEC and DISCOVERY_SPEC.loader
+DISCOVERY = importlib.util.module_from_spec(DISCOVERY_SPEC)
+sys.modules["vaillant_ebus.backend.discovery_service"] = DISCOVERY
+DISCOVERY_SPEC.loader.exec_module(DISCOVERY)
+
+b516_date_bytes = MAPPING.b516_date_bytes
+DiscoveryService = DISCOVERY.DiscoveryService
+EntityFactoryService = ENTITY.EntityFactoryService
+
+
+# The encoding was verified live on 2026-08-24: the HMU accepted payload
+# suffix 0835 and returned a plausible August cooling yield.
+def test_b516_date_bytes_known_dates() -> None:
+    assert b516_date_bytes(datetime(2026, 8, 24)) == "0835"
+    assert b516_date_bytes(datetime(2026, 3, 5)) == "6534"
+    assert b516_date_bytes(datetime(2026, 12, 31)) == "8f35"
+    assert b516_date_bytes(datetime(2025, 1, 1)) == "2132"
+
+
+def test_b516_date_bytes_month_boundaries() -> None:
+    assert b516_date_bytes(datetime(2026, 7, 31)) == "ef34"
+    assert b516_date_bytes(datetime(2026, 8, 1)) == "0135"
+
+
+def test_b516_cooling_register_entities() -> None:
+    lines = [
+        "hmu CoolEnvYieldTotal = 1206000",
+        "hmu CoolEnvYieldDay = 8000",
+        "hmu CoolEnvYieldMonth = 139818",
+        "hmu CoolElecConsTotal = 153000",
+    ]
+    graph = DiscoveryService.build_device_graph(lines)
+    entities = EntityFactoryService().generate(graph)
+    by_key = {e.key: e for e in entities}
+
+    expected_names = {
+        "hmu.CoolEnvYieldTotal.value": "Cooling Energy Total",
+        "hmu.CoolEnvYieldDay.value": "Cooling Energy Today",
+        "hmu.CoolEnvYieldMonth.value": "Cooling Energy Month",
+        "hmu.CoolElecConsTotal.value": "Cooling Electricity Total",
+    }
+    for key, friendly in expected_names.items():
+        entity = by_key.get(key)
+        assert entity is not None, f"{key} must be an entity"
+        assert entity.meta.friendly_name == friendly
+        assert entity.entity_type == "sensor"
+        assert entity.meta.device_class == "energy"
+        assert entity.meta.unit == "Wh"
+
+    assert by_key["hmu.CoolEnvYieldTotal.value"].meta.state_class == "total_increasing"
+    assert by_key["hmu.CoolElecConsTotal.value"].meta.state_class == "total_increasing"
+    # Daily/monthly yields reset, so they must not be marked total_increasing.
+    assert by_key["hmu.CoolEnvYieldDay.value"].meta.state_class != "total_increasing"

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -500,13 +500,19 @@ async def test_define_custom_registers_delegates_to_ebus() -> None:
         c.ebus = mock_ebus
         await c._define_custom_registers()
 
-        assert mock_ebus.define_register.call_count == 5
+        assert mock_ebus.define_register.call_count == 9
         calls = [c.args[0] for c in mock_ebus.define_register.call_args_list]
         assert any("z1RoomHumidity" in d for d in calls)
         assert any("ManualCoolingStartDate" in d and d.startswith("r5") for d in calls)
         assert any("ManualCoolingEndDate" in d and d.startswith("r5") for d in calls)
         assert any("ManualCoolingStartDate" in d and d.startswith("w") for d in calls)
         assert any("ManualCoolingEndDate" in d and d.startswith("w") for d in calls)
+        # b516 cooling-energy registers (issue #50), including the date-coded
+        # day/month variants.
+        assert any("CoolEnvYieldTotal" in d and "1000ffff02050000" in d for d in calls)
+        assert any("CoolElecConsTotal" in d and "1000ffff03050000" in d for d in calls)
+        assert any(",B516,1001ffff0205" in d for d in calls)
+        assert any(",B516,1002ffff0205" in d for d in calls)
 
 
 async def test_define_custom_registers_skips_when_not_connected() -> None:


### PR DESCRIPTION
## Summary

Adds runtime-defined `hmu` cooling-energy registers via the b516 energy-statistics API, closing the gap behind the app's passive-cooling value reported in #50.

## Background

Issue #50 established that the compressor-based cooling counters (`YieldCoolDay`, `HoursCool`) stay at zero during passive brine cooling, so the myVaillant app's cooling energy could not be reproduced from any known register.

Upstream research found the missing piece:

- The b516 energy-statistics API has an explicit **cooling usage code** (`Z=5`, upstream issue #490), reporting both environmental yield and electric consumption per period (all/day/month) with a date-encoded payload.
- The shipped HW5103 CSV definitions omit this family entirely (upstream issue #600), which is why every cooling total returns `ERR: element not found` on affected hardware.
- Unlike the compressor counters, b516 environmental yield measures thermal energy exchanged with the building — independent of compressor operation — so it also covers **passive brine cooling**.

## Registers added

All injected at startup via the existing runtime-definition mechanism and live-verified against ebusd:

| Register | Payload | Verified value |
|---|---|---|
| `hmu.CoolEnvYieldTotal` | `1000ffff02050000` | 1 206 kWh lifetime |
| `hmu.CoolElecConsTotal` | `1000ffff03050000` | 153 kWh lifetime |
| `hmu.CoolEnvYieldDay` | `1001ffff0205<WVQQ>` | date encoding confirmed |
| `hmu.CoolEnvYieldMonth` | `1002ffff0205<WVQQ>` | 139.8 kWh (August) |

Cross-check: lifetime COP cooling = 1206/153 ≈ 7.9, matching the unit's reported `CopCooling` of 7.8.

The day/month date payload is re-encoded from the current date on every (re)connect; the encoding helper is unit tested against known dates including the live-verified case.

## Validation

- `ruff check .`: clean
- `pytest -q`: 354 passed (3 new tests)
- `compileall`: clean
- Deployed to live HA server: entities created, `cooling_energy_month` reads 139818 Wh matching the direct ebusd read