### PR TITLE
release: v1.5.2 - SourceTempInput runtime define restored, B524 heating-circuit state sensors (#49, #60)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@
 
 ## Runtime-Defined Registers
 
-Some supported registers are not returned by ebusd `find` and must be defined or probed at runtime. `ctlv2.z1RoomHumidity` is one confirmed example, not an exhaustive list.
+Some supported registers are not returned by ebusd `find` and must be defined or probed at runtime. `ctlv2.z1RoomHumidity` and `hmu.SourceTempInput` are confirmed examples, not an exhaustive list. `SourceTempInput`'s layout is verified upstream on brine units (john30/ebusd-configuration PR #565); on air/water units the B51A reply is a 3-byte stub, so the read fails and the register correctly stays unavailable.
 
 When functionality is missing, inspect the raw `find` output, discovery dump, ebusd metadata, and unmapped registers before adding a one-off implementation. Test each candidate directly against ebusd, confirm its message format and read-back value, and add only registers supported by the connected hardware.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@
 - **Bare `ERR:` read replies count as no-data.** Direct ebusd reads return
   `ERR: ...` without parentheses; the shared no-data helper now recognizes
   that form alongside the parenthesized `(ERR ...)` find output.
+- **B524 heating-circuit state sensors for HC1 and HC2 (discussion #60).**
+  Twelve read-only registers absent from the shipped CSVs are defined at
+  runtime from the Helianthus B524 register map: calculated flow temperature,
+  mixer position, circuit humidity, dew point temperature, pump hours, and
+  pump starts per circuit. Message layout (`OP=0x02 GG=0x02`, RR `0x20`–`0x25`)
+  is verified against the upstream `15.ctlv2.tsp` and compiled eBUS CSVs, and
+  the wire types (`EXP` f32, `ULG` u32) against ebusd `datatype.cpp`. The
+  layout is fixture-gated; hardware without the registers stays no-data.
 
 ## 1.5.1 - 2026-08-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 1.5.2 - 2026-08-25
+
+### Added
+
+- **`SourceTempInput` runtime definition restored with an upstream-verified
+  layout (#49).** The register was attempted during v1.3.3 development but
+  never shipped. The layout (`B51A` / `05ff3222`, `IGN:3 + D2C`) is verified
+  live on brine units in `john30/ebusd-configuration` PR #565 (flexoTHERM and
+  flexoCOMPACT ground-source). On air/water units the B51A reply is a 3-byte
+  stub that cannot decode — the register correctly stays unavailable there,
+  and the decode error is filtered as no-data so nothing broken appears in
+  the UI.
+- **Bare `ERR:` read replies count as no-data.** Direct ebusd reads return
+  `ERR: ...` without parentheses; the shared no-data helper now recognizes
+  that form alongside the parenthesized `(ERR ...)` find output.
+
 ## 1.5.1 - 2026-08-25
 
 ### Added

--- a/custom_components/vaillant_ebus/backend/mapping.py
+++ b/custom_components/vaillant_ebus/backend/mapping.py
@@ -571,6 +571,80 @@ REGISTER_MAP: dict[str, RegisterMeta] = {
         friendly_name="Pump Status (HC1)",
         entity_type="binary_sensor",
     ),
+    # Runtime-defined B524 heating-circuit state registers (Helianthus B524
+    # register map, community capture via discussion #60). Absent from the
+    # shipped CSVs; wire types EXP (f32) / ULG (u32) and message layout
+    # verified against ebusd datatype.cpp and the compiled eBUS CSVs.
+    "ctlv2.Hc1FlowTempCalc": RegisterMeta(
+        friendly_name="Calculated Flow Temperature (HC1)",
+        device_class="temperature",
+        unit="°C",
+    ),
+    "ctlv2.Hc1MixerPosition": RegisterMeta(
+        friendly_name="Mixer Position (HC1)",
+        unit="%",
+        icon="mdi:valve",
+    ),
+    "ctlv2.Hc1Humidity": RegisterMeta(
+        friendly_name="Humidity (HC1)",
+        device_class="humidity",
+        unit="%",
+        icon="mdi:water-percent",
+    ),
+    "ctlv2.Hc1DewPointTemp": RegisterMeta(
+        friendly_name="Dew Point Temperature (HC1)",
+        device_class="temperature",
+        unit="°C",
+        icon="mdi:thermometer-water",
+    ),
+    "ctlv2.Hc1PumpHours": RegisterMeta(
+        friendly_name="Pump Hours (HC1)",
+        unit="h",
+        state_class="total_increasing",
+        icon="mdi:clock-outline",
+        entity_category="diagnostic",
+    ),
+    "ctlv2.Hc1PumpStarts": RegisterMeta(
+        friendly_name="Pump Starts (HC1)",
+        state_class="total_increasing",
+        icon="mdi:counter",
+        entity_category="diagnostic",
+    ),
+    "ctlv2.Hc2FlowTempCalc": RegisterMeta(
+        friendly_name="Calculated Flow Temperature (HC2)",
+        device_class="temperature",
+        unit="°C",
+    ),
+    "ctlv2.Hc2MixerPosition": RegisterMeta(
+        friendly_name="Mixer Position (HC2)",
+        unit="%",
+        icon="mdi:valve",
+    ),
+    "ctlv2.Hc2Humidity": RegisterMeta(
+        friendly_name="Humidity (HC2)",
+        device_class="humidity",
+        unit="%",
+        icon="mdi:water-percent",
+    ),
+    "ctlv2.Hc2DewPointTemp": RegisterMeta(
+        friendly_name="Dew Point Temperature (HC2)",
+        device_class="temperature",
+        unit="°C",
+        icon="mdi:thermometer-water",
+    ),
+    "ctlv2.Hc2PumpHours": RegisterMeta(
+        friendly_name="Pump Hours (HC2)",
+        unit="h",
+        state_class="total_increasing",
+        icon="mdi:clock-outline",
+        entity_category="diagnostic",
+    ),
+    "ctlv2.Hc2PumpStarts": RegisterMeta(
+        friendly_name="Pump Starts (HC2)",
+        state_class="total_increasing",
+        icon="mdi:counter",
+        entity_category="diagnostic",
+    ),
     "ctlv2.Z1ActualRoomTempDesired": RegisterMeta(
         friendly_name="Room Temperature Target (Z1)",
         device_class="temperature",

--- a/custom_components/vaillant_ebus/backend/models.py
+++ b/custom_components/vaillant_ebus/backend/models.py
@@ -13,14 +13,20 @@ EBUSD_NO_DATA_VALUES: frozenset[str] = frozenset({"", "-", "empty", "unknown", "
 
 
 # Return whether an ebusd value carries no usable data: an exact sentinel,
-# a "no data stored..." reply, an "(empty ...)" placeholder, or an "(ERR...)" error.
+# a "no data stored..." reply, an "(empty ...)" placeholder, an "(ERR...)" error,
+# or a bare "ERR: ..." reply from a direct read.
 def is_no_data_value(raw: str | None) -> bool:
     if raw is None:
         return True
     low = raw.strip().lower()
     if low in EBUSD_NO_DATA_VALUES:
         return True
-    return low.startswith("no data stored") or low.startswith("(empty ") or "(err" in low
+    return (
+        low.startswith("no data stored")
+        or low.startswith("(empty ")
+        or low.startswith("err:")
+        or "(err" in low
+    )
 
 
 COMPRESSOR_ACTIVE_STATUS_CODES = {104, 114, 134}

--- a/custom_components/vaillant_ebus/coordinator.py
+++ b/custom_components/vaillant_ebus/coordinator.py
@@ -500,6 +500,46 @@ class VaillantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         defines = [
             "r5,ctlv2,z1RoomHumidity,z1RoomHumidity,31,15,B524,020003002800"
             ",value,,IGN:4,,,,value,,EXP,,%,z1 Room Humidity",
+            # B524 heating-circuit state registers (OP=0x02 GG=0x02, RR=0x20..0x25)
+            # absent from the shipped CSVs (verified against the installed find
+            # output and upstream 15.ctlv2.tsp). Layout documented in the
+            # Helianthus B524 register map (community capture via discussion
+            # #60); wire types EXP (f32) and ULG (u32 LE) confirmed against
+            # ebusd datatype.cpp and the compiled eBUS CSVs. All are read-only
+            # state (S) with no gates; absent hardware reports no data and
+            # stays filtered by the existing no-data handling.
+            "r5,ctlv2,Hc1FlowTempCalc,Hc1FlowTempCalc,31,15,B524"
+            ",020002002000,value,,IGN:4,,,,value,,EXP,,°C,Hc1 Calculated Flow Temp",
+            "r5,ctlv2,Hc1MixerPosition,Hc1MixerPosition,31,15,B524"
+            ",020002002100,value,,IGN:4,,,,value,,EXP,,%,Hc1 Mixer Position",
+            "r5,ctlv2,Hc1Humidity,Hc1Humidity,31,15,B524"
+            ",020002002200,value,,IGN:4,,,,value,,EXP,,%,Hc1 Humidity",
+            "r5,ctlv2,Hc1DewPointTemp,Hc1DewPointTemp,31,15,B524"
+            ",020002002300,value,,IGN:4,,,,value,,EXP,,°C,Hc1 Dew Point Temp",
+            "r5,ctlv2,Hc1PumpHours,Hc1PumpHours,31,15,B524"
+            ",020002002400,value,,IGN:4,,,,value,,ULG,,h,Hc1 Pump Hours",
+            "r5,ctlv2,Hc1PumpStarts,Hc1PumpStarts,31,15,B524"
+            ",020002002500,value,,IGN:4,,,,value,,ULG,,,Hc1 Pump Starts",
+            "r5,ctlv2,Hc2FlowTempCalc,Hc2FlowTempCalc,31,15,B524"
+            ",020002012000,value,,IGN:4,,,,value,,EXP,,°C,Hc2 Calculated Flow Temp",
+            "r5,ctlv2,Hc2MixerPosition,Hc2MixerPosition,31,15,B524"
+            ",020002012100,value,,IGN:4,,,,value,,EXP,,%,Hc2 Mixer Position",
+            "r5,ctlv2,Hc2Humidity,Hc2Humidity,31,15,B524"
+            ",020002012200,value,,IGN:4,,,,value,,EXP,,%,Hc2 Humidity",
+            "r5,ctlv2,Hc2DewPointTemp,Hc2DewPointTemp,31,15,B524"
+            ",020002012300,value,,IGN:4,,,,value,,EXP,,°C,Hc2 Dew Point Temp",
+            "r5,ctlv2,Hc2PumpHours,Hc2PumpHours,31,15,B524"
+            ",020002012400,value,,IGN:4,,,,value,,ULG,,h,Hc2 Pump Hours",
+            "r5,ctlv2,Hc2PumpStarts,Hc2PumpStarts,31,15,B524"
+            ",020002012500,value,,IGN:4,,,,value,,ULG,,,Hc2 Pump Starts",
+            # SourceTempInput is absent from the shipped CSVs (upstream issue
+            # #632, last compiled 2026-04-19). Layout verified live on brine
+            # units in john30/ebusd-configuration PR #565 (flexoTHERM and
+            # flexoCOMPACT ground-source); air/water units answer with a
+            # 3-byte stub and stay unavailable, which the ERR filtering keeps
+            # out of entity values.
+            "r,hmu,SourceTempInput,SourceTempInput,31,8,B51A,05ff3222"
+            ",value,,IGN:3,,,,value,,D2C,,°C,Source temp input",
             "r5,ctlv2,ManualCoolingStartDate,ManualCoolingStartDate,31,15,B524"
             ",02000000da00,value,,IGN:4,,,,value,,HDA:3",
             "r5,ctlv2,ManualCoolingEndDate,ManualCoolingEndDate,31,15,B524"

--- a/custom_components/vaillant_ebus/manifest.json
+++ b/custom_components/vaillant_ebus/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/MarkBovee/vaillant-ebus/issues",
   "requirements": [],
-  "version": "1.5.1"
+  "version": "1.5.2"
 }

--- a/tests/fixtures/community/helianthus_b524_circuit_registers.yaml
+++ b/tests/fixtures/community/helianthus_b524_circuit_registers.yaml
@@ -1,0 +1,34 @@
+# Discovery dump for vaillant_ebus
+# Review this file for sensitive information before sharing
+# Community capture: Helianthus B524 register map (d3vi1, discussion #60).
+# Layout of the B524 heating-circuit state registers (OP=0x02 GG=0x02,
+# RR=0x20..0x25) is documented in the register map with multiple independent
+# sources; the raw_find_lines below represent what ebusd find returns after
+# the runtime defines succeed. Wire types: EXP (f32) and ULG (u32 LE).
+metadata:
+  timestamp: '2026-08-25T00:00:00'
+  ebusd_version: null
+  register_count: 24
+  grab_duration: 0
+  dump_version: 3
+raw_find_lines:
+- ctlv2 Z1OpMode = auto
+- ctlv2 Z1RoomTemp = 21.5
+- ctlv2 Z1RoomZoneMapping = 1
+- ctlv2 Z2OpMode = auto
+- ctlv2 Z2RoomTemp = 22.0
+- ctlv2 Z2RoomZoneMapping = 2
+- ctlv2 Hc1FlowTemp = 39.5
+- ctlv2 Hc1FlowTempCalc = 40.1
+- ctlv2 Hc1MixerPosition = 0.0
+- ctlv2 Hc1Humidity = 51
+- ctlv2 Hc1DewPointTemp = 8.4
+- ctlv2 Hc1PumpHours = 1234
+- ctlv2 Hc1PumpStarts = 567
+- ctlv2 Hc2FlowTemp = 38.2
+- ctlv2 Hc2FlowTempCalc = 38.9
+- ctlv2 Hc2MixerPosition = 100.0
+- ctlv2 Hc2Humidity = 49
+- ctlv2 Hc2DewPointTemp = 7.1
+- ctlv2 Hc2PumpHours = 890
+- ctlv2 Hc2PumpStarts = 234

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -492,7 +492,7 @@ async def test_define_custom_registers_delegates_to_ebus() -> None:
         c.ebus = mock_ebus
         await c._define_custom_registers()
 
-        assert mock_ebus.define_register.call_count == 10
+        assert mock_ebus.define_register.call_count == 22
         calls = [c.args[0] for c in mock_ebus.define_register.call_args_list]
         assert any("z1RoomHumidity" in d for d in calls)
         assert any("ManualCoolingStartDate" in d and d.startswith("r5") for d in calls)
@@ -510,6 +510,21 @@ async def test_define_custom_registers_delegates_to_ebus() -> None:
         assert any(
             "SourceTempInput" in d and ",B51A,05ff3222,value,,IGN:3,,,,value,,D2C" in d for d in calls
         )
+        # B524 heating-circuit state registers (Helianthus B524 register map,
+        # discussion #60): GG=0x02 messages with the documented RR and wire
+        # types (EXP for f32, ULG for u32).
+        assert any("Hc1FlowTempCalc" in d and ",B524,020002002000" in d for d in calls)
+        assert any("Hc1MixerPosition" in d and ",B524,020002002100" in d for d in calls)
+        assert any("Hc1Humidity" in d and ",B524,020002002200" in d and "EXP" in d for d in calls)
+        assert any("Hc1DewPointTemp" in d and ",B524,020002002300" in d for d in calls)
+        assert any("Hc1PumpHours" in d and ",B524,020002002400" in d and "ULG" in d for d in calls)
+        assert any("Hc1PumpStarts" in d and ",B524,020002002500" in d and "ULG" in d for d in calls)
+        assert any("Hc2FlowTempCalc" in d and ",B524,020002012000" in d for d in calls)
+        assert any("Hc2MixerPosition" in d and ",B524,020002012100" in d for d in calls)
+        assert any("Hc2Humidity" in d and ",B524,020002012200" in d and "EXP" in d for d in calls)
+        assert any("Hc2DewPointTemp" in d and ",B524,020002012300" in d for d in calls)
+        assert any("Hc2PumpHours" in d and ",B524,020002012400" in d and "ULG" in d for d in calls)
+        assert any("Hc2PumpStarts" in d and ",B524,020002012500" in d and "ULG" in d for d in calls)
 
 
 async def test_define_custom_registers_skips_when_not_connected() -> None:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -492,7 +492,7 @@ async def test_define_custom_registers_delegates_to_ebus() -> None:
         c.ebus = mock_ebus
         await c._define_custom_registers()
 
-        assert mock_ebus.define_register.call_count == 9
+        assert mock_ebus.define_register.call_count == 10
         calls = [c.args[0] for c in mock_ebus.define_register.call_args_list]
         assert any("z1RoomHumidity" in d for d in calls)
         assert any("ManualCoolingStartDate" in d and d.startswith("r5") for d in calls)
@@ -505,6 +505,11 @@ async def test_define_custom_registers_delegates_to_ebus() -> None:
         assert any("CoolElecConsTotal" in d and "1000ffff03050000" in d for d in calls)
         assert any(",B516,1001ffff0205" in d for d in calls)
         assert any(",B516,1002ffff0205" in d for d in calls)
+        # SourceTempInput runtime define (issue #49), layout verified upstream
+        # in john30/ebusd-configuration PR #565 on brine units.
+        assert any(
+            "SourceTempInput" in d and ",B51A,05ff3222,value,,IGN:3,,,,value,,D2C" in d for d in calls
+        )
 
 
 async def test_define_custom_registers_skips_when_not_connected() -> None:

--- a/tests/test_discovery_service.py
+++ b/tests/test_discovery_service.py
@@ -458,6 +458,33 @@ def test_arotherm_plus_basv3_zones() -> None:
     assert graph.nodes["z3"].has_data is False
 
 
+# Helianthus B524 register map fixture (community capture via discussion #60):
+# the heating-circuit state registers (GG=0x02 RR=0x20..0x25) must appear on
+# the discovered graph once the runtime defines are in place.
+def test_helianthus_b524_circuit_registers_graph() -> None:
+    lines = load_find_lines("community/helianthus_b524_circuit_registers.yaml")
+    graph = DiscoveryService.build_device_graph(lines)
+    assert graph.nodes["ctlv2"].device_type == DeviceType.HEATING_CONTROLLER
+    for register in (
+        "ctlv2.Hc1FlowTempCalc",
+        "ctlv2.Hc1MixerPosition",
+        "ctlv2.Hc1Humidity",
+        "ctlv2.Hc1DewPointTemp",
+        "ctlv2.Hc1PumpHours",
+        "ctlv2.Hc1PumpStarts",
+        "ctlv2.Hc2FlowTempCalc",
+        "ctlv2.Hc2MixerPosition",
+        "ctlv2.Hc2Humidity",
+        "ctlv2.Hc2DewPointTemp",
+        "ctlv2.Hc2PumpHours",
+        "ctlv2.Hc2PumpStarts",
+    ):
+        assert register in graph.raw_registers, f"Missing {register}"
+    assert graph.raw_registers["ctlv2.Hc1FlowTempCalc"] == "40.1"
+    assert graph.raw_registers["ctlv2.Hc1PumpHours"] == "1234"
+    assert graph.raw_registers["ctlv2.Hc2PumpStarts"] == "234"
+
+
 def test_arotherm_pro7_graph() -> None:
     graph = _arotherm_pro7_graph()
     assert graph.nodes["ctlv3"].device_type == DeviceType.HEATING_CONTROLLER

--- a/tests/test_entity_factory.py
+++ b/tests/test_entity_factory.py
@@ -794,6 +794,12 @@ class TestStatEnergyRegisters:
             assert entity.meta.device_class == "energy", reg
             assert entity.meta.unit == "kWh", reg
             assert entity.meta.state_class == "total_increasing", reg
+        # SourceTempInput is returned by find on this air/water unit (issue #49)
+        # and must generate a temperature entity from the REGISTER_MAP metadata.
+        src = by_key.get("hmu.SourceTempInput.value")
+        assert src is not None, "missing hmu.SourceTempInput"
+        assert src.meta.device_class == "temperature"
+        assert src.meta.unit == "°C"
 
 
 class TestBuildingCircuitFlowUnit:

--- a/tests/test_entity_factory.py
+++ b/tests/test_entity_factory.py
@@ -163,6 +163,31 @@ class TestEntityGeneration:
             assert e.key.startswith(f"{e.circuit}.{e.name}."), f"Bad key format: {e.key}"
             assert e.key.count(".") == 2, f"Key should have 2 dots: {e.key}"
 
+    # Helianthus B524 register map fixture (community capture via discussion
+    # #60): the runtime-defined heating-circuit state registers must generate
+    # entities with the documented metadata (units, device classes, counters
+    # as diagnostic total-increasing sensors).
+    def test_helianthus_b524_circuit_register_entities(self) -> None:
+        lines = load_find_lines("community/helianthus_b524_circuit_registers.yaml")
+        graph = DiscoveryService.build_device_graph(lines)
+        svc = EntityFactoryService()
+        result = svc.generate(graph)
+        by_name = {e.name: e for e in result}
+        assert by_name["Hc1FlowTempCalc"].meta.unit == "°C"
+        assert by_name["Hc1FlowTempCalc"].meta.device_class == "temperature"
+        assert by_name["Hc1MixerPosition"].meta.unit == "%"
+        assert by_name["Hc1Humidity"].meta.unit == "%"
+        assert by_name["Hc1Humidity"].meta.device_class == "humidity"
+        assert by_name["Hc1DewPointTemp"].meta.device_class == "temperature"
+        assert by_name["Hc1PumpHours"].meta.unit == "h"
+        assert by_name["Hc1PumpHours"].meta.state_class == "total_increasing"
+        assert by_name["Hc1PumpHours"].meta.entity_category == "diagnostic"
+        assert by_name["Hc1PumpStarts"].meta.state_class == "total_increasing"
+        assert by_name["Hc2FlowTempCalc"].meta.unit == "°C"
+        assert by_name["Hc2Humidity"].meta.device_class == "humidity"
+        assert by_name["Hc2PumpHours"].meta.unit == "h"
+        assert by_name["Hc2PumpStarts"].meta.entity_category == "diagnostic"
+
 
 class TestDeviceCircuitResolution:
     """Device circuit assignment from device graph."""

--- a/tests/test_no_data_values.py
+++ b/tests/test_no_data_values.py
@@ -29,6 +29,8 @@ def test_prefix_and_error_forms() -> None:
         "no data stored (hmu CurrentYieldPowerToday)",
         "(empty message)",
         "58.0 (ERR: element not found)",
+        "ERR: invalid position in decode",
+        "ERR: element not found",
     ):
         assert is_no_data_value(raw), f"{raw!r} should be no-data"
 


### PR DESCRIPTION
Release v1.5.2.

- Restores the `hmu.SourceTempInput` runtime definition with the upstream-verified layout (john30/ebusd-configuration PR #565, live-tested on brine units), and treats bare `ERR:` read replies as no-data.
- Adds twelve B524 heating-circuit state sensors for HC1/HC2 (calculated flow temperature, mixer position, humidity, dew point, pump hours, pump starts) from the Helianthus B524 register map, defined at runtime and gated by a community fixture.

Full notes in CHANGELOG.md.