### PR TITLE
release: v1.5.3 - daily electric counters for cooling/heating/DHW, additional electric registers (#50), v32 boiler fixes (#83)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## 1.5.3 - 2026-08-27
+
+### Added
+
+- **Daily electric consumption for cooling, heating, and DHW (#50).** The b516
+  statistics API now also defines daily electric counters (`CoolElecConsDay`,
+  `HcElecConsDay`, `HwcElecConsDay`) alongside the existing lifetime totals,
+  so the daily `Consumed Electrical Energy Cooling` value shown in the
+  myPyllant app has a matching sensor. Lifetime electric totals for heating
+  (`HcElecConsTotal`) and DHW (`HwcElecConsTotal`) are added as well, using
+  the same live-verified layout (upstream issue john30/ebusd-configuration
+  #490; X=0 total / X=1 day, Y=3 electric, Z=3 heating / Z=4 hot water /
+  Z=5 cooling).
+- **Additional electric registers from the standard `find` output (#50).**
+  `hmu.ConsumptionTotal` (kWh), `hmu.RunDataElectricPowerConsumption` (W),
+  `hmu.LiveMonitorCurrentConsumedPower` (kW), and the `hmu.StatSolarEnergySum*`
+  family (kWh) now get proper metadata. These supplement the runtime-defined
+  b516 counters and stay opt-in: entities appear only when the discovery graph
+  carries the register with data.
+
+### Fixed
+
+- **v32 gas boiler (ecoTEC plus via VR32) register handling (#83).** Registers
+  from the bai CSV now get proper metadata (temperatures in °C, hour counters
+  as `duration` with `total_increasing`, pump power in W, water pressure in
+  bar), multi-field values are split (`ReturnTemp` no longer shows
+  `55.31;64650;ok`, `Status01`/`Status02` become individual sensors), and
+  sensor-fault values (`;circuit`, `;cutoff`) are treated as no data instead
+  of exposing bogus readings like `HwcTemp = 116.06;circuit`. Ventilation-only
+  registers (e.g. `BypassPosition`, `ExhaustAirHumidity`) stay absent on
+  boiler setups, guarded by a new community fixture test.
+
 ## 1.5.2 - 2026-08-25
 
 ### Added

--- a/custom_components/vaillant_ebus/backend/entity_factory.py
+++ b/custom_components/vaillant_ebus/backend/entity_factory.py
@@ -290,6 +290,9 @@ class EntityFactoryService:
                 if field_names:
                     field_values = split_multi_field(rk, raw)
                     for field_name in field_names:
+                        if field_name == "value":
+                            # Single-field mappings reuse the base entity.
+                            continue
                         field_raw = field_values.get(field_name)
                         field_meta = get_meta(circuit, name, field_name)
                         field_override = overrides.get(f"{rk}.{field_name}") or {}

--- a/custom_components/vaillant_ebus/backend/mapping.py
+++ b/custom_components/vaillant_ebus/backend/mapping.py
@@ -15,6 +15,18 @@ MULTI_FIELD_FIELDS: dict[str, list[str]] = {
     "hmu.CompressorHwc": ["runtime", "cycles"],
     "hmu.RunStatsCompressorHc": ["runtime", "cycles"],
     "hmu.RunStatsCompressorHwc": ["runtime", "cycles"],
+    # v32 gas boiler (ecoTEC plus via VR32, bai.308523.inc + hcmode.inc).
+    # Status01/Status02 share the hmu Status01 layout (hcmode.inc B511).
+    # Single-field sensor registers expose only the first field; the trailing
+    # fields are tempmirror/status values (see _templates.tsp models).
+    "v32.Status01": ["temp", "temp_1", "temp_2", "temp_3", "temp_4", "pumpstate"],
+    "v32.Status02": ["hwcmode", "temp0", "temp1", "temp0_1", "temp1_1"],
+    "v32.FlowTemp": ["value"],
+    "v32.ReturnTemp": ["value"],
+    "v32.StorageTemp": ["value"],
+    "v32.WaterPressure": ["value"],
+    "v32.HwcTemp": ["value"],
+    "v32.OutdoorstempSensor": ["value"],
 }
 
 
@@ -289,6 +301,78 @@ REGISTER_MAP: dict[str, RegisterMeta] = {
         unit="Wh",
         state_class="total_increasing",
         icon="mdi:snowflake",
+    ),
+    "hmu.CoolElecConsDay": RegisterMeta(
+        friendly_name="Cooling Electricity Today",
+        device_class="energy",
+        unit="Wh",
+        icon="mdi:snowflake",
+    ),
+    "hmu.HcElecConsTotal": RegisterMeta(
+        friendly_name="Heating Electricity Total",
+        device_class="energy",
+        unit="Wh",
+        state_class="total_increasing",
+        icon="mdi:radiator",
+    ),
+    "hmu.HcElecConsDay": RegisterMeta(
+        friendly_name="Heating Electricity Today",
+        device_class="energy",
+        unit="Wh",
+        icon="mdi:radiator",
+    ),
+    "hmu.HwcElecConsTotal": RegisterMeta(
+        friendly_name="DHW Electricity Total",
+        device_class="energy",
+        unit="Wh",
+        state_class="total_increasing",
+        icon="mdi:water-boiler",
+    ),
+    "hmu.HwcElecConsDay": RegisterMeta(
+        friendly_name="DHW Electricity Today",
+        device_class="energy",
+        unit="Wh",
+        icon="mdi:water-boiler",
+    ),
+    # CSV/find-based electric registers that supplement the runtime-defined
+    # b516 counters above (issue #50). Units follow the upstream 08.hmu.tsp
+    # definitions: energy is UIN kWh, RunDataElectricPowerConsumption is EXP W,
+    # LiveMonitorCurrentConsumedPower is UIN kW with a divisor of 10, and the
+    # StatSolar* sums are EXP kWh. All are opt-in: entities only appear when
+    # the discovery graph carries them with data.
+    "hmu.ConsumptionTotal": RegisterMeta(
+        friendly_name="Electrical Energy Consumption",
+        device_class="energy",
+        unit="kWh",
+        state_class="total_increasing",
+    ),
+    "hmu.RunDataElectricPowerConsumption": RegisterMeta(
+        friendly_name="Electric Power Consumption",
+        device_class="power",
+        unit="W",
+    ),
+    "hmu.LiveMonitorCurrentConsumedPower": RegisterMeta(
+        friendly_name="Live Power Consumption",
+        device_class="power",
+        unit="kW",
+    ),
+    "hmu.StatSolarEnergySum": RegisterMeta(
+        friendly_name="Solar Energy Sum",
+        device_class="energy",
+        unit="kWh",
+        state_class="total_increasing",
+    ),
+    "hmu.StatSolarEnergySumHc": RegisterMeta(
+        friendly_name="Solar Energy Sum (Heating)",
+        device_class="energy",
+        unit="kWh",
+        state_class="total_increasing",
+    ),
+    "hmu.StatSolarEnergySumHwc": RegisterMeta(
+        friendly_name="Solar Energy Sum (DHW)",
+        device_class="energy",
+        unit="kWh",
+        state_class="total_increasing",
     ),
     "hmu.YieldCooling": RegisterMeta(
         friendly_name="Yield Cooling",
@@ -1545,6 +1629,132 @@ REGISTER_MAP: dict[str, RegisterMeta] = {
         friendly_name="Max Air Humidity",
         icon="mdi:water-percent",
         unit="%",
+        entity_category="diagnostic",
+    ),
+    # v32 gas boiler (ecoTEC plus via VR32 board, bai.308523.inc) — from the
+    # community discovery dump in issue #83. Layouts follow the upstream
+    # tempsensor/tempmirrorsensor/presssensor models.
+    "v32.ReturnTemp": RegisterMeta(
+        friendly_name="Return Temperature",
+        device_class="temperature",
+        unit="°C",
+    ),
+    "v32.StorageTemp": RegisterMeta(
+        friendly_name="Storage Temperature",
+        device_class="temperature",
+        unit="°C",
+    ),
+    "v32.StorageTempDesired": RegisterMeta(
+        friendly_name="Storage Temperature Desired",
+        device_class="temperature",
+        unit="°C",
+    ),
+    "v32.FlowTempDesired": RegisterMeta(
+        friendly_name="Flow Temperature Desired",
+        device_class="temperature",
+        unit="°C",
+    ),
+    "v32.FlowTempMax": RegisterMeta(
+        friendly_name="Maximum Flow Temperature",
+        device_class="temperature",
+        unit="°C",
+    ),
+    "v32.ReturnTempMax": RegisterMeta(
+        friendly_name="Maximum Return Temperature",
+        device_class="temperature",
+        unit="°C",
+    ),
+    "v32.FanHours": RegisterMeta(
+        friendly_name="Fan Hours",
+        device_class="duration",
+        unit="h",
+        state_class="total_increasing",
+    ),
+    "v32.HcHours": RegisterMeta(
+        friendly_name="Heating Hours",
+        device_class="duration",
+        unit="h",
+        state_class="total_increasing",
+    ),
+    "v32.HwcHours": RegisterMeta(
+        friendly_name="Hot Water Hours",
+        device_class="duration",
+        unit="h",
+        state_class="total_increasing",
+    ),
+    "v32.PumpHours": RegisterMeta(
+        friendly_name="Pump Hours",
+        device_class="duration",
+        unit="h",
+        state_class="total_increasing",
+    ),
+    "v32.StorageLoadPumpHours": RegisterMeta(
+        friendly_name="Storage Load Pump Hours",
+        device_class="duration",
+        unit="h",
+        state_class="total_increasing",
+    ),
+    "v32.HoursTillService": RegisterMeta(
+        friendly_name="Hours Until Service",
+        device_class="duration",
+        unit="h",
+    ),
+    "v32.PumpPower": RegisterMeta(
+        friendly_name="Pump Power",
+        device_class="power",
+        unit="W",
+    ),
+    # Faulty-sensor registers: the physical sensors are absent on this system
+    # (sensor status "circuit"/"cutoff"), so they stay disabled by default and
+    # the fault values are filtered as no-data.
+    "v32.HwcTemp": RegisterMeta(
+        friendly_name="Hot Water Temperature",
+        device_class="temperature",
+        unit="°C",
+        enabled=False,
+    ),
+    "v32.OutdoorstempSensor": RegisterMeta(
+        friendly_name="Outside Temperature Sensor",
+        device_class="temperature",
+        unit="°C",
+        enabled=False,
+    ),
+    "v32.Maintenancedata_HwcTempMax": RegisterMeta(
+        friendly_name="Max Hot Water Temperature (Maintenance)",
+        device_class="temperature",
+        unit="°C",
+        entity_category="diagnostic",
+        enabled=False,
+    ),
+    # v32.Status02 fields (hcmode.inc B511). Names follow the CSV comment
+    # ("Betriebsart/Maximaltemperatur/ReglerCurrentTEMP/..."); the reporter was
+    # asked to confirm their meaning live (issue #83).
+    "v32.Status02.hwcmode": RegisterMeta(
+        friendly_name="Operating Mode",
+        entity_category="diagnostic",
+    ),
+    "v32.Status02.temp0": RegisterMeta(
+        friendly_name="Max Temperature",
+        device_class="temperature",
+        unit="°C",
+        entity_category="diagnostic",
+    ),
+    "v32.Status02.temp1": RegisterMeta(
+        friendly_name="Current Temperature",
+        device_class="temperature",
+        unit="°C",
+        entity_category="diagnostic",
+    ),
+    "v32.Status02.temp0_1": RegisterMeta(
+        friendly_name="Max Temperature 2",
+        device_class="temperature",
+        unit="°C",
+        entity_category="diagnostic",
+    ),
+    "v32.Status02.temp1_1": RegisterMeta(
+        friendly_name="Current Temperature 2",
+        device_class="temperature",
+        unit="°C",
         entity_category="diagnostic",
     ),
     "vr_71.SetActorState": RegisterMeta(

--- a/custom_components/vaillant_ebus/backend/models.py
+++ b/custom_components/vaillant_ebus/backend/models.py
@@ -11,15 +11,23 @@ from enum import Enum
 # "none" is deliberately excluded: RoomZoneMapping legitimately reports it.
 EBUSD_NO_DATA_VALUES: frozenset[str] = frozenset({"", "-", "empty", "unknown", "unavailable"})
 
+# Sensor fault statuses from the Vaillant sensor enum (Values_sensor in the
+# upstream ebusd configuration: ok=0, circuit=85, cutoff=170). Registers whose
+# trailing sensor-status field reports a fault (e.g. "116.06;circuit",
+# "-60.44;cutoff") carry no usable measurement: the sensor is not present.
+SENSOR_FAULT_STATUSES: frozenset[str] = frozenset({"circuit", "cutoff"})
+
 
 # Return whether an ebusd value carries no usable data: an exact sentinel,
 # a "no data stored..." reply, an "(empty ...)" placeholder, an "(ERR...)" error,
-# or a bare "ERR: ..." reply from a direct read.
+# a bare "ERR: ..." reply from a direct read, or a sensor-fault status.
 def is_no_data_value(raw: str | None) -> bool:
     if raw is None:
         return True
     low = raw.strip().lower()
     if low in EBUSD_NO_DATA_VALUES:
+        return True
+    if low.endswith((";circuit", ";cutoff")) or low in SENSOR_FAULT_STATUSES:
         return True
     return (
         low.startswith("no data stored")

--- a/custom_components/vaillant_ebus/coordinator.py
+++ b/custom_components/vaillant_ebus/coordinator.py
@@ -560,6 +560,31 @@ class VaillantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             f"r,hmu,CoolEnvYieldMonth,CoolEnvYieldMonth,31,08,B516"
             f",1002ffff0205{date_bytes},value,,IGN:7,,,,value,,EXP,,Wh"
             f",hmu Cooling Env Yield This Month",
+            # Daily electric consumption for cooling (issue #50 follow-up: the
+            # integration only exposed the lifetime electric total, while the
+            # myPyllant app shows a daily "Consumed Electrical Energy Cooling"
+            # value). Same b516 API with the electric usage code (Y=3) and the
+            # daily X=1 selector, so the layout matches the verified cooling
+            # family; date payload refreshes per connect like CoolEnvYieldDay.
+            f"r,hmu,CoolElecConsDay,CoolElecConsDay,31,08,B516"
+            f",1001ffff0305{date_bytes},value,,IGN:7,,,,value,,EXP,,Wh"
+            f",hmu Cooling Electric Consumption Today",
+            # Lifetime and daily electric consumption for the heating (Z=3) and
+            # hot-water (Z=4) domains, same b516 statistics API (upstream issue
+            # #490). Conservative extension of the live-verified cooling layout
+            # (Y=3 electric); absent hardware reports no data and stays hidden.
+            "r,hmu,HcElecConsTotal,HcElecConsTotal,31,08,B516"
+            ",1000ffff03030000,value,,IGN:7,,,,value,,EXP,,Wh"
+            ",hmu Heating Electric Consumption",
+            f"r,hmu,HcElecConsDay,HcElecConsDay,31,08,B516"
+            f",1001ffff0303{date_bytes},value,,IGN:7,,,,value,,EXP,,Wh"
+            f",hmu Heating Electric Consumption Today",
+            "r,hmu,HwcElecConsTotal,HwcElecConsTotal,31,08,B516"
+            ",1000ffff03040000,value,,IGN:7,,,,value,,EXP,,Wh"
+            ",hmu DHW Electric Consumption",
+            f"r,hmu,HwcElecConsDay,HwcElecConsDay,31,08,B516"
+            f",1001ffff0304{date_bytes},value,,IGN:7,,,,value,,EXP,,Wh"
+            f",hmu DHW Electric Consumption Today",
         ]
         defined = 0
         unavailable = 0
@@ -744,12 +769,12 @@ class VaillantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             try:
                 value = await self.ebus.read_register(circuit, name)
                 was_new = key not in self.registers
-                if value and (value.startswith(("or:", "ERR:", "no data stored")) or "read [-" in value):
+                if value and (is_no_data_value(value) or value.startswith("or:") or "read [-" in value):
                     value = None
                 if value is None:
                     cache = await self._async_load_cache()
                     cached = cache.get(f"{circuit}.{name}.value")
-                    if cached is not None:
+                    if cached is not None and not is_no_data_value(cached):
                         value = cached
                 if value is not None:
                     read_with_data += 1

--- a/custom_components/vaillant_ebus/manifest.json
+++ b/custom_components/vaillant_ebus/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/MarkBovee/vaillant-ebus/issues",
   "requirements": [],
-  "version": "1.5.2"
+  "version": "1.5.3"
 }

--- a/tests/fixtures/community/v32_boiler_discovery.yaml
+++ b/tests/fixtures/community/v32_boiler_discovery.yaml
@@ -1,0 +1,16375 @@
+# Discovery dump for vaillant_ebus
+# Review this file for sensitive information before sharing
+metadata:
+  timestamp: '2026-08-22T11:16:00.849212'
+  ebusd_version: null
+  register_count: 818
+  grab_duration: 20
+  dump_version: 3
+raw_find_lines:
+- Broadcast Datetime = no data stored
+- Broadcast Error = no data stored
+- Broadcast HwcStatus = no data stored
+- Broadcast Id = no data stored
+- Broadcast IdAnswer = no data stored
+- Broadcast IdQuery = no data stored
+- Broadcast Load = no data stored
+- Broadcast Outsidetemp = 28.582
+- Broadcast Queryexistence =  (empty for 31fe07fe00 / )
+- Broadcast Signoflife = no data stored
+- Broadcast Vdatetime = 11:15:15;22.08.2026
+- Broadcast Vdatetime = no data stored
+- ctlv2 AdaptHeatCurve = no
+- ctlv2 AdaptHeatCurve = no data stored
+- ctlv2 CcTimer_Config = 00 03 0a 00 00 00 ff ff 00
+- ctlv2 CcTimer_Friday0 = 06:00;22:00
+- ctlv2 CcTimer_Friday1 = 00:00;00:00
+- ctlv2 CcTimer_Friday2 = 00:00;00:00
+- ctlv2 CcTimer_Friday = no data stored
+- ctlv2 CcTimer_Monday0 = 06:00;22:00
+- ctlv2 CcTimer_Monday1 = 00:00;00:00
+- ctlv2 CcTimer_Monday2 = 00:00;00:00
+- ctlv2 CcTimer_Monday = no data stored
+- ctlv2 CcTimer_Saturday0 = 07:30;23:30
+- ctlv2 CcTimer_Saturday1 = 00:00;00:00
+- ctlv2 CcTimer_Saturday2 = 00:00;00:00
+- ctlv2 CcTimer_Saturday = no data stored
+- ctlv2 CcTimer_Sunday0 = 07:30;22:00
+- ctlv2 CcTimer_Sunday1 = 00:00;00:00
+- ctlv2 CcTimer_Sunday2 = 00:00;00:00
+- ctlv2 CcTimer_Sunday = no data stored
+- ctlv2 CcTimer_Thursday0 = 06:00;22:00
+- ctlv2 CcTimer_Thursday1 = 00:00;00:00
+- ctlv2 CcTimer_Thursday2 = 00:00;00:00
+- ctlv2 CcTimer_Thursday = no data stored
+- ctlv2 CcTimer_Timeframes = 1;1;1;1;1;1;1
+- ctlv2 CcTimer_Tuesday0 = 06:00;22:00
+- ctlv2 CcTimer_Tuesday1 = 00:00;00:00
+- ctlv2 CcTimer_Tuesday2 = 00:00;00:00
+- ctlv2 CcTimer_Tuesday = no data stored
+- ctlv2 CcTimer_Wednesday0 = 06:00;22:00
+- ctlv2 CcTimer_Wednesday1 = 00:00;00:00
+- ctlv2 CcTimer_Wednesday2 = 00:00;00:00
+- ctlv2 CcTimer_Wednesday = no data stored
+- ctlv2 Clearerrorhistory = no data stored
+- ctlv2 ContinuousHeating = -26
+- ctlv2 ContinuousHeating = no data stored
+- ctlv2 Currenterror = -;-;-;-;-
+- ctlv2 CylinderChargeHyst = 3
+- ctlv2 CylinderChargeHyst = no data stored
+- ctlv2 CylinderChargeOffset = 25
+- ctlv2 CylinderChargeOffset = no data stored
+- ctlv2 Date = 22.08.2026
+- ctlv2 Date = no data stored
+- ctlv2 DisplayedOutsideTemp = 28.5352
+- ctlv2 Errorhistory = no data stored
+- ctlv2 FrostOverRideTime = 4
+- ctlv2 FrostOverRideTime = no data stored
+- ctlv2 Hc1ActualFlowTempDesired = 0.0
+- ctlv2 Hc1AutoOffMode = night
+- ctlv2 Hc1AutoOffMode = no data stored
+- ctlv2 Hc1CircuitType = mixer
+- ctlv2 Hc1ExcessTemp = 0.0
+- ctlv2 Hc1ExcessTemp = no data stored
+- ctlv2 Hc1FlowTemp = 30.1875
+- ctlv2 Hc1HeatCurve = 1.7
+- ctlv2 Hc1HeatCurve = no data stored
+- ctlv2 Hc1HeatCurveAdaption = 0.0
+- ctlv2 Hc1MaxFlowTempDesired = 65
+- ctlv2 Hc1MaxFlowTempDesired = no data stored
+- ctlv2 Hc1MinCoolingTempDesired = 13
+- ctlv2 Hc1MinCoolingTempDesired = no data stored
+- ctlv2 Hc1MinFlowTempDesired = 48
+- ctlv2 Hc1MinFlowTempDesired = no data stored
+- ctlv2 Hc1MixerMovement = -100
+- ctlv2 Hc1PumpStatus = 0
+- ctlv2 Hc1PumpStatus = no data stored
+- ctlv2 Hc1RoomTempSwitchOn = thermostat
+- ctlv2 Hc1RoomTempSwitchOn = no data stored
+- ctlv2 Hc1Status = 0
+- ctlv2 Hc1Status = no data stored
+- ctlv2 Hc1SummerTempLimit = 40
+- ctlv2 Hc1SummerTempLimit = no data stored
+- ctlv2 Hc2ActualFlowTempDesired = 0.0
+- ctlv2 Hc2AutoOffMode = night
+- ctlv2 Hc2AutoOffMode = no data stored
+- ctlv2 Hc2CircuitType = mixer
+- ctlv2 Hc2ExcessTemp = 0.0
+- ctlv2 Hc2ExcessTemp = no data stored
+- ctlv2 Hc2FlowTemp = 24.875
+- ctlv2 Hc2HeatCurve = 1.7
+- ctlv2 Hc2HeatCurve = no data stored
+- ctlv2 Hc2HeatCurveAdaption = 0.0
+- ctlv2 Hc2MaxFlowTempDesired = 65
+- ctlv2 Hc2MaxFlowTempDesired = no data stored
+- ctlv2 Hc2MinCoolingTempDesired = 20
+- ctlv2 Hc2MinCoolingTempDesired = no data stored
+- ctlv2 Hc2MinFlowTempDesired = 48
+- ctlv2 Hc2MinFlowTempDesired = no data stored
+- ctlv2 Hc2MixerMovement = -100
+- ctlv2 Hc2PumpStatus = 0
+- ctlv2 Hc2PumpStatus = no data stored
+- ctlv2 Hc2RoomTempSwitchOn = thermostat
+- ctlv2 Hc2RoomTempSwitchOn = no data stored
+- ctlv2 Hc2Status = 0
+- ctlv2 Hc2Status = no data stored
+- ctlv2 Hc2SummerTempLimit = 40
+- ctlv2 Hc2SummerTempLimit = no data stored
+- ctlv2 Hc3ActualFlowTempDesired = 0.0
+- ctlv2 Hc3AutoOffMode = eco
+- ctlv2 Hc3AutoOffMode = no data stored
+- ctlv2 Hc3CircuitType = inactive
+- ctlv2 Hc3ExcessTemp = 0.0
+- ctlv2 Hc3ExcessTemp = no data stored
+- ctlv2 Hc3FlowTemp =  (empty for 3115b52406020002020800 / 0800020800ffffff7f)
+- ctlv2 Hc3HeatCurve = 1.2
+- ctlv2 Hc3HeatCurve = no data stored
+- ctlv2 Hc3HeatCurveAdaption = 0.0
+- ctlv2 Hc3MaxFlowTempDesired = 90
+- ctlv2 Hc3MaxFlowTempDesired = no data stored
+- ctlv2 Hc3MinCoolingTempDesired = 20
+- ctlv2 Hc3MinCoolingTempDesired = no data stored
+- ctlv2 Hc3MinFlowTempDesired = 15
+- ctlv2 Hc3MinFlowTempDesired = no data stored
+- ctlv2 Hc3MixerMovement = 0.0
+- ctlv2 Hc3PumpStatus = 0
+- ctlv2 Hc3PumpStatus = no data stored
+- ctlv2 Hc3RoomTempSwitchOn = off
+- ctlv2 Hc3RoomTempSwitchOn = no data stored
+- ctlv2 Hc3Status = 0
+- ctlv2 Hc3Status = no data stored
+- ctlv2 Hc3SummerTempLimit = 21
+- ctlv2 Hc3SummerTempLimit = no data stored
+- ctlv2 HcStorageTempBottom =  (empty for 3115b5240602000000a000 / 080000a000ffffff7f)
+- ctlv2 HcStorageTempTop =  (empty for 3115b52406020000009f00 / 0800009f00ffffff7f)
+- ctlv2 HwcBankHolidayEndPeriod = no data stored
+- ctlv2 HwcBankHolidayEndPeriod = no data stored
+- ctlv2 HwcBankHolidayStartPeriod = no data stored
+- ctlv2 HwcBankHolidayStartPeriod = no data stored
+- ctlv2 HwcFlowTemp = 0.0
+- ctlv2 HwcHolidayEndPeriod = 01.01.2015
+- ctlv2 HwcHolidayEndPeriod = no data stored
+- ctlv2 HwcHolidayStartPeriod = 01.01.2015
+- ctlv2 HwcHolidayStartPeriod = no data stored
+- ctlv2 HwcLockTime = 60
+- ctlv2 HwcLockTime = no data stored
+- ctlv2 HwcMaxFlowTempDesired = 75
+- ctlv2 HwcMaxFlowTempDesired = no data stored
+- ctlv2 HwcOpMode = day
+- ctlv2 HwcOpMode = no data stored
+- ctlv2 HwcParallelLoading = off
+- ctlv2 HwcParallelLoading = no data stored
+- ctlv2 HwcSFMode = auto
+- ctlv2 HwcSFMode = no data stored
+- ctlv2 HwcStorageTemp = 62
+- ctlv2 HwcStorageTempBottom =  (empty for 3115b52406020000009e00 / 0800009e00ffffff7f)
+- ctlv2 HwcStorageTempTop =  (empty for 3115b52406020000009d00 / 0800009d00ffffff7f)
+- ctlv2 HwcTempDesired = 46
+- ctlv2 HwcTempDesired = no data stored
+- ctlv2 HwcTimer_Config = 00 03 0a 0a 01 01 23 46 00
+- ctlv2 HwcTimer_Friday0 = 05:30;22:00;46.0
+- ctlv2 HwcTimer_Friday1 = 00:00;00:00;-
+- ctlv2 HwcTimer_Friday2 = 00:00;00:00;-
+- ctlv2 HwcTimer_Friday = no data stored
+- ctlv2 HwcTimer_Monday0 = 05:30;22:00;46.0
+- ctlv2 HwcTimer_Monday1 = 00:00;00:00;-
+- ctlv2 HwcTimer_Monday2 = 00:00;00:00;-
+- ctlv2 HwcTimer_Monday = no data stored
+- ctlv2 HwcTimer_Saturday0 = no data stored
+- ctlv2 HwcTimer_Saturday1 = no data stored
+- ctlv2 HwcTimer_Saturday2 = no data stored
+- ctlv2 HwcTimer_Saturday = no data stored
+- ctlv2 HwcTimer_Sunday0 = no data stored
+- ctlv2 HwcTimer_Sunday1 = no data stored
+- ctlv2 HwcTimer_Sunday2 = no data stored
+- ctlv2 HwcTimer_Sunday = no data stored
+- ctlv2 HwcTimer_Thursday0 = no data stored
+- ctlv2 HwcTimer_Thursday1 = no data stored
+- ctlv2 HwcTimer_Thursday2 = no data stored
+- ctlv2 HwcTimer_Thursday = no data stored
+- ctlv2 HwcTimer_Timeframes = no data stored
+- ctlv2 HwcTimer_Tuesday0 = no data stored
+- ctlv2 HwcTimer_Tuesday1 = no data stored
+- ctlv2 HwcTimer_Tuesday2 = no data stored
+- ctlv2 HwcTimer_Tuesday = no data stored
+- ctlv2 HwcTimer_Wednesday0 = no data stored
+- ctlv2 HwcTimer_Wednesday1 = no data stored
+- ctlv2 HwcTimer_Wednesday2 = no data stored
+- ctlv2 HwcTimer_Wednesday = no data stored
+- ctlv2 HydraulicScheme = 12
+- ctlv2 HydraulicScheme = no data stored
+- ctlv2 Installer1 = no data stored
+- ctlv2 Installer1 = no data stored
+- ctlv2 Installer2 = no data stored
+- ctlv2 Installer2 = no data stored
+- ctlv2 KeyCodeforConfigMenu = no data stored
+- ctlv2 KeyCodeforConfigMenu = no data stored
+- ctlv2 MaintenanceDate = no data stored
+- ctlv2 MaintenanceDate = no data stored
+- ctlv2 MaintenanceDue = no data stored
+- ctlv2 ManualCoolingEndDate = 01.01.2019
+- ctlv2 ManualCoolingEndDate = no data stored
+- ctlv2 ManualCoolingStartDate = 01.01.2019
+- ctlv2 ManualCoolingStartDate = no data stored
+- ctlv2 MaxCylinderChargeTime = 60
+- ctlv2 MaxCylinderChargeTime = no data stored
+- ctlv2 MaxRoomHumidity = 40
+- ctlv2 MaxRoomHumidity = no data stored
+- ctlv2 MultiRelaySetting = circulation
+- ctlv2 MultiRelaySetting = no data stored
+- ctlv2 OutsideTempAvg = 26.2656
+- ctlv2 OutsideTempAvg = no data stored
+- ctlv2 PhoneNumber1 = no data stored
+- ctlv2 PhoneNumber1 = no data stored
+- ctlv2 PhoneNumber2 = no data stored
+- ctlv2 PhoneNumber2 = no data stored
+- 'ctlv2 PrEnergySum =  (ERR: invalid position for 3115b52406020000005c00 / 00)'
+- ctlv2 PrEnergySum = no data stored
+- ctlv2 PrEnergySumHc = 6220
+- ctlv2 PrEnergySumHc = no data stored
+- ctlv2 PrEnergySumHcLastMonth = 13
+- ctlv2 PrEnergySumHcLastMonth = no data stored
+- ctlv2 PrEnergySumHcThisMonth = 9
+- ctlv2 PrEnergySumHcThisMonth = no data stored
+- ctlv2 PrEnergySumHwc = 2596
+- ctlv2 PrEnergySumHwc = no data stored
+- ctlv2 PrEnergySumHwcLastMonth = 24
+- ctlv2 PrEnergySumHwcLastMonth = no data stored
+- ctlv2 PrEnergySumHwcThisMonth = 24
+- ctlv2 PrEnergySumHwcThisMonth = no data stored
+- ctlv2 PrFuelSum = no data stored
+- ctlv2 PrFuelSum = no data stored
+- ctlv2 PrFuelSumHc = no data stored
+- ctlv2 PrFuelSumHc = no data stored
+- ctlv2 PrFuelSumHcLastMonth = no data stored
+- ctlv2 PrFuelSumHcLastMonth = no data stored
+- ctlv2 PrFuelSumHcThisMonth = no data stored
+- ctlv2 PrFuelSumHcThisMonth = no data stored
+- ctlv2 PrFuelSumHwc = no data stored
+- ctlv2 PrFuelSumHwc = no data stored
+- ctlv2 PrFuelSumHwcLastMonth = no data stored
+- ctlv2 PrFuelSumHwcLastMonth = no data stored
+- ctlv2 PrFuelSumHwcThisMonth = no data stored
+- ctlv2 PrFuelSumHwcThisMonth = no data stored
+- ctlv2 PumpAdditionalTime = no data stored
+- ctlv2 PumpAdditionalTime = no data stored
+- ctlv2 SolarYieldTotal = no data stored
+- ctlv2 SolarYieldTotal = no data stored
+- ctlv2 SystemFlowTemp = 32.25
+- ctlv2 Time = no data stored
+- ctlv2 Time = no data stored
+- ctlv2 WaterPressure = 1.6
+- ctlv2 YieldTotal = 14845
+- ctlv2 YieldTotal = no data stored
+- ctlv2 Z1ActualRoomTempDesired = 5
+- ctlv2 Z1ActualRoomTempDesired = no data stored
+- ctlv2 Z1BankHolidayEndPeriod = no data stored
+- ctlv2 Z1BankHolidayEndPeriod = no data stored
+- ctlv2 Z1BankHolidayStartPeriod = no data stored
+- ctlv2 Z1BankHolidayStartPeriod = no data stored
+- ctlv2 Z1CoolingTemp = 24
+- ctlv2 Z1CoolingTemp = no data stored
+- ctlv2 Z1DayTemp = 18
+- ctlv2 Z1DayTemp = no data stored
+- ctlv2 Z1HolidayEndPeriod = 01.01.2015
+- ctlv2 Z1HolidayEndPeriod = no data stored
+- ctlv2 Z1HolidayStartPeriod = 01.01.2015
+- ctlv2 Z1HolidayStartPeriod = no data stored
+- ctlv2 Z1HolidayTemp = 15
+- ctlv2 Z1HolidayTemp = no data stored
+- ctlv2 Z1Name1 = no data stored
+- ctlv2 Z1Name1 = no data stored
+- ctlv2 Z1Name2 = no data stored
+- ctlv2 Z1Name2 = no data stored
+- ctlv2 Z1NightTemp = 18.5
+- ctlv2 Z1NightTemp = no data stored
+- ctlv2 Z1OpMode = off
+- ctlv2 Z1OpMode = no data stored
+- ctlv2 Z1QuickVetoDuration = 3
+- ctlv2 Z1QuickVetoDuration = no data stored
+- ctlv2 Z1QuickVetoEndDate = 01.01.2019
+- ctlv2 Z1QuickVetoEndTime = 00:00:00
+- ctlv2 Z1QuickVetoTemp = 10
+- ctlv2 Z1QuickVetoTemp = no data stored
+- ctlv2 z1RoomHumidity = 57
+- ctlv2 Z1RoomTemp = 27.85
+- ctlv2 Z1RoomZoneMapping = no data stored
+- ctlv2 Z1RoomZoneMapping = no data stored
+- ctlv2 Z1SFMode = auto
+- ctlv2 Z1SFMode = no data stored
+- ctlv2 Z1Shortname = no data stored
+- ctlv2 Z1Shortname = no data stored
+- ctlv2 Z1Timer_Config = no data stored
+- ctlv2 Z1Timer_Friday0 = no data stored
+- ctlv2 Z1Timer_Friday1 = no data stored
+- ctlv2 Z1Timer_Friday2 = no data stored
+- ctlv2 Z1Timer_Friday = no data stored
+- ctlv2 Z1Timer_Monday0 = no data stored
+- ctlv2 Z1Timer_Monday1 = no data stored
+- ctlv2 Z1Timer_Monday2 = no data stored
+- ctlv2 Z1Timer_Monday = no data stored
+- ctlv2 Z1Timer_Saturday0 = no data stored
+- ctlv2 Z1Timer_Saturday1 = no data stored
+- ctlv2 Z1Timer_Saturday2 = no data stored
+- ctlv2 Z1Timer_Saturday = no data stored
+- ctlv2 Z1Timer_Sunday0 = no data stored
+- ctlv2 Z1Timer_Sunday1 = no data stored
+- ctlv2 Z1Timer_Sunday2 = no data stored
+- ctlv2 Z1Timer_Sunday = no data stored
+- ctlv2 Z1Timer_Thursday0 = no data stored
+- ctlv2 Z1Timer_Thursday1 = no data stored
+- ctlv2 Z1Timer_Thursday2 = no data stored
+- ctlv2 Z1Timer_Thursday = no data stored
+- ctlv2 Z1Timer_Timeframes = no data stored
+- ctlv2 Z1Timer_Tuesday0 = no data stored
+- ctlv2 Z1Timer_Tuesday1 = no data stored
+- ctlv2 Z1Timer_Tuesday2 = no data stored
+- ctlv2 Z1Timer_Tuesday = no data stored
+- ctlv2 Z1Timer_Wednesday0 = no data stored
+- ctlv2 Z1Timer_Wednesday1 = no data stored
+- ctlv2 Z1Timer_Wednesday2 = no data stored
+- ctlv2 Z1Timer_Wednesday = no data stored
+- ctlv2 Z1ValveStatus = no data stored
+- ctlv2 Z1ValveStatus = no data stored
+- ctlv2 Z2ActualRoomTempDesired = 5
+- ctlv2 Z2ActualRoomTempDesired = no data stored
+- ctlv2 Z2BankHolidayEndPeriod = no data stored
+- ctlv2 Z2BankHolidayEndPeriod = no data stored
+- ctlv2 Z2BankHolidayStartPeriod = no data stored
+- ctlv2 Z2BankHolidayStartPeriod = no data stored
+- ctlv2 Z2CoolingTemp = no data stored
+- ctlv2 Z2CoolingTemp = no data stored
+- ctlv2 Z2DayTemp = 18.5
+- ctlv2 Z2DayTemp = no data stored
+- ctlv2 Z2HolidayEndPeriod = no data stored
+- ctlv2 Z2HolidayEndPeriod = no data stored
+- ctlv2 Z2HolidayStartPeriod = no data stored
+- ctlv2 Z2HolidayStartPeriod = no data stored
+- ctlv2 Z2HolidayTemp = no data stored
+- ctlv2 Z2HolidayTemp = no data stored
+- ctlv2 Z2Name1 = no data stored
+- ctlv2 Z2Name1 = no data stored
+- ctlv2 Z2Name2 = no data stored
+- ctlv2 Z2Name2 = no data stored
+- ctlv2 Z2NightTemp = no data stored
+- ctlv2 Z2NightTemp = no data stored
+- ctlv2 Z2OpMode = off
+- ctlv2 Z2OpMode = no data stored
+- ctlv2 Z2QuickVetoDuration = no data stored
+- ctlv2 Z2QuickVetoDuration = no data stored
+- ctlv2 Z2QuickVetoEndDate = no data stored
+- ctlv2 Z2QuickVetoEndTime = no data stored
+- ctlv2 Z2QuickVetoTemp = no data stored
+- ctlv2 Z2QuickVetoTemp = no data stored
+- ctlv2 Z2RoomTemp = 27.2875
+- ctlv2 Z2RoomZoneMapping = no data stored
+- ctlv2 Z2RoomZoneMapping = no data stored
+- ctlv2 Z2SFMode = no data stored
+- ctlv2 Z2SFMode = no data stored
+- ctlv2 Z2Shortname = no data stored
+- ctlv2 Z2Shortname = no data stored
+- ctlv2 Z2Timer_Config = no data stored
+- ctlv2 Z2Timer_Friday0 = no data stored
+- ctlv2 Z2Timer_Friday1 = no data stored
+- ctlv2 Z2Timer_Friday2 = no data stored
+- ctlv2 Z2Timer_Friday = no data stored
+- ctlv2 Z2Timer_Monday0 = no data stored
+- ctlv2 Z2Timer_Monday1 = no data stored
+- ctlv2 Z2Timer_Monday2 = no data stored
+- ctlv2 Z2Timer_Monday = no data stored
+- ctlv2 Z2Timer_Saturday0 = no data stored
+- ctlv2 Z2Timer_Saturday1 = no data stored
+- ctlv2 Z2Timer_Saturday2 = no data stored
+- ctlv2 Z2Timer_Saturday = no data stored
+- ctlv2 Z2Timer_Sunday0 = no data stored
+- ctlv2 Z2Timer_Sunday1 = no data stored
+- ctlv2 Z2Timer_Sunday2 = no data stored
+- ctlv2 Z2Timer_Sunday = no data stored
+- ctlv2 Z2Timer_Thursday0 = no data stored
+- ctlv2 Z2Timer_Thursday1 = no data stored
+- ctlv2 Z2Timer_Thursday2 = no data stored
+- ctlv2 Z2Timer_Thursday = no data stored
+- ctlv2 Z2Timer_Timeframes = no data stored
+- ctlv2 Z2Timer_Tuesday0 = no data stored
+- ctlv2 Z2Timer_Tuesday1 = no data stored
+- ctlv2 Z2Timer_Tuesday2 = no data stored
+- ctlv2 Z2Timer_Tuesday = no data stored
+- ctlv2 Z2Timer_Wednesday0 = no data stored
+- ctlv2 Z2Timer_Wednesday1 = no data stored
+- ctlv2 Z2Timer_Wednesday2 = no data stored
+- ctlv2 Z2Timer_Wednesday = no data stored
+- ctlv2 Z2ValveStatus = no data stored
+- ctlv2 Z2ValveStatus = no data stored
+- ctlv2 Z3ActualRoomTempDesired = no data stored
+- ctlv2 Z3ActualRoomTempDesired = no data stored
+- ctlv2 Z3BankHolidayEndPeriod = no data stored
+- ctlv2 Z3BankHolidayEndPeriod = no data stored
+- ctlv2 Z3BankHolidayStartPeriod = no data stored
+- ctlv2 Z3BankHolidayStartPeriod = no data stored
+- ctlv2 Z3DayTemp = no data stored
+- ctlv2 Z3DayTemp = no data stored
+- ctlv2 Z3HolidayEndPeriod = no data stored
+- ctlv2 Z3HolidayEndPeriod = no data stored
+- ctlv2 Z3HolidayStartPeriod = no data stored
+- ctlv2 Z3HolidayStartPeriod = no data stored
+- ctlv2 Z3HolidayTemp = no data stored
+- ctlv2 Z3HolidayTemp = no data stored
+- ctlv2 Z3Name1 = no data stored
+- ctlv2 Z3Name1 = no data stored
+- ctlv2 Z3Name2 = no data stored
+- ctlv2 Z3Name2 = no data stored
+- ctlv2 Z3NightTemp = no data stored
+- ctlv2 Z3NightTemp = no data stored
+- ctlv2 Z3OpMode = no data stored
+- ctlv2 Z3OpMode = no data stored
+- ctlv2 Z3QuickVetoDuration = no data stored
+- ctlv2 Z3QuickVetoDuration = no data stored
+- ctlv2 Z3QuickVetoEndDate = no data stored
+- ctlv2 Z3QuickVetoEndTime = no data stored
+- ctlv2 Z3QuickVetoTemp = no data stored
+- ctlv2 Z3QuickVetoTemp = no data stored
+- ctlv2 Z3RoomTemp = no data stored
+- ctlv2 Z3RoomZoneMapping = no data stored
+- ctlv2 Z3RoomZoneMapping = no data stored
+- ctlv2 Z3SFMode = no data stored
+- ctlv2 Z3SFMode = no data stored
+- ctlv2 Z3Shortname = no data stored
+- ctlv2 Z3Shortname = no data stored
+- ctlv2 Z3Timer_Config = no data stored
+- ctlv2 Z3Timer_Friday0 = no data stored
+- ctlv2 Z3Timer_Friday1 = no data stored
+- ctlv2 Z3Timer_Friday2 = no data stored
+- ctlv2 Z3Timer_Friday = no data stored
+- ctlv2 Z3Timer_Monday0 = no data stored
+- ctlv2 Z3Timer_Monday1 = no data stored
+- ctlv2 Z3Timer_Monday2 = no data stored
+- ctlv2 Z3Timer_Monday = no data stored
+- ctlv2 Z3Timer_Saturday0 = no data stored
+- ctlv2 Z3Timer_Saturday1 = no data stored
+- ctlv2 Z3Timer_Saturday2 = no data stored
+- ctlv2 Z3Timer_Saturday = no data stored
+- ctlv2 Z3Timer_Sunday0 = no data stored
+- ctlv2 Z3Timer_Sunday1 = no data stored
+- ctlv2 Z3Timer_Sunday2 = no data stored
+- ctlv2 Z3Timer_Sunday = no data stored
+- ctlv2 Z3Timer_Thursday0 = no data stored
+- ctlv2 Z3Timer_Thursday1 = no data stored
+- ctlv2 Z3Timer_Thursday2 = no data stored
+- ctlv2 Z3Timer_Thursday = no data stored
+- ctlv2 Z3Timer_Timeframes = no data stored
+- ctlv2 Z3Timer_Tuesday0 = no data stored
+- ctlv2 Z3Timer_Tuesday1 = no data stored
+- ctlv2 Z3Timer_Tuesday2 = no data stored
+- ctlv2 Z3Timer_Tuesday = no data stored
+- ctlv2 Z3Timer_Wednesday0 = no data stored
+- ctlv2 Z3Timer_Wednesday1 = no data stored
+- ctlv2 Z3Timer_Wednesday2 = no data stored
+- ctlv2 Z3Timer_Wednesday = no data stored
+- ctlv2 Z3ValveStatus = no data stored
+- ctlv2 Z3ValveStatus = no data stored
+- General Valuerange = no data stored
+- hmu BuildingCircuitFlow = 0
+- hmu Clearerrorhistory = no data stored
+- hmu CompressorBlocktime = no data stored
+- hmu CompressorHc = no data stored (message not available due to condition)
+- hmu CompressorHwc = no data stored (message not available due to condition)
+- hmu CopCooling = 1.0
+- hmu CopCoolingMonth = 1.0
+- hmu CopHc = 2.6
+- hmu CopHcMonth = 1.0
+- hmu CopHwc = 2.7
+- hmu CopHwcMonth = 3.7
+- hmu CurrentCompressorUtil = 0.00
+- hmu CurrentConsumedPower = 0.0
+- hmu Currenterror = -;-;-;-;-
+- hmu CurrentYieldPower = 0.0
+- hmu DateTime = nosignal;-:-:-;-.-.-;-
+- hmu EnergyIntegral = -178
+- hmu Errorhistory = no data stored
+- hmu FlowPressure = no data stored (message not available due to condition)
+- hmu FlowTemp = 48.12
+- 'hmu PowerConsumptionHmu =  (ERR: invalid position for 3108b5160114 / 00)'
+- hmu RunDataAirInletTemp = 25.4612
+- hmu RunDataBuildingCPumpPower = 0.0
+- hmu RunDataCompressorInletTemp = 30.9524
+- hmu RunDataCompressorOutletTemp = 50.7246
+- hmu RunDataCompressorSpeed = 0.0
+- hmu RunDataEEVOutletTemp = 28.0747
+- hmu RunDataEEVPositionAbs = 155
+- hmu RunDataFan1Speed = 0.0
+- hmu RunDataFan2Speed = 0.0
+- hmu RunDataHighPressure = 14.739
+- hmu RunDataStatuscode = standby
+- hmu RunStats4PortValveHours = 0
+- hmu RunStats4PortValveSwitches = 14
+- hmu RunStatsBuildingCPumpStarts = 4092
+- hmu RunStatsBuildingPumpHours = 4810
+- hmu RunStatsCompressorHours = 2546
+- hmu RunStatsCompressorStarts = 6521
+- hmu RunStatsFan1Hours = 3040
+- hmu RunStatsFan1Starts = 9955
+- hmu RunStatsFan2Hours = 3040
+- hmu RunStatsFan2Starts = 9955
+- hmu RunStatsHcHours = 2416
+- hmu RunStatsHMUHours = 26642
+- hmu RunStatsHwcHours = 1135
+- hmu SetMode = auto;0.0;-;-;1;1;1;0;0;0
+- hmu SetMode = no data stored
+- hmu Status01 = 48.0;46.0;-;-;-;off
+- hmu Status02 = no data stored
+- 'hmu Status16 =  (ERR: invalid position for 3108b5040116 / 00)'
+- 'hmu Status =  (ERR: invalid position for 3108b5110103 / 00)'
+- hmu StatusCirPump = on
+- hmu SupplyTempWeighted = 20.00
+- hmu TotalEnergyUsage = 8556
+- hmu YieldCoolDay = 0.0
+- hmu YieldCooling = 0.0
+- hmu YieldCoolingMonth = 0.0
+- hmu YieldHc = 10137
+- hmu YieldHcDay = 0.0
+- hmu YieldHcMonth = 2.3
+- hmu YieldHwc = 4709
+- hmu YieldHwcDay = 1.1
+- hmu YieldHwcMonth = 69.3
+- Memory Eeprom = no data stored
+- Memory Eeprom = no data stored
+- Memory Ram = no data stored
+- Memory Ram = no data stored
+- Scan Id = no data stored
+- scan.08  = Vaillant;HMU00;0522;5103
+- scan.15  = Vaillant;CTLV2;0514;1104
+- Scan.15 Id = 21;22;51;0020260913;0953;045677;N9
+- scan.18  = Vaillant;V32;0106;6004
+- Scan.18 Id = 21;22;41;0010022017;0001;005945;N9
+- scan.26  = Vaillant;VR_71;0100;5904
+- Scan.26 Id = 21;22;42;0020184847;0082;020249;N7
+- scan.35  = Vaillant;VR_92;0514;1204
+- Scan.35 Id = 21;22;18;0020260925;0953;009293;N2
+- scan.76  = Vaillant;VWZIO;0901;5103
+- Scan.76 Id = 21;23;03;0010034193;1610;005152;N2
+- scan.f6  = Vaillant;NETX3;0129;0404
+- Scan.f6 Id = 21;22;45;0020292012;0933;083357;N0
+- v32 AccessoriesOne = no data stored
+- v32 AccessoriesOne = no data stored
+- v32 AccessoriesTwo = no data stored
+- v32 AccessoriesTwo = no data stored
+- v32 ACRoomthermostat = no data stored
+- v32 APCComStatus = no data stored (message not available due to condition)
+- v32 APCLegioProtection = no data stored (message not available due to condition)
+- v32 APCLegioProtection = no data stored (message not available due to condition)
+- v32 AverageIgnitiontime = no data stored
+- v32 BlockTimeHcMax = no data stored
+- v32 BlockTimeHcMax = no data stored
+- v32 BoilerType = no data stored
+- v32 ChangesDSN = no data stored
+- v32 CirPump = no data stored
+- v32 Clearerrorhistory = no data stored
+- v32 CounterStartattempts1 = no data stored
+- v32 CounterStartattempts2 = 2
+- v32 CounterStartAttempts3 = no data stored
+- v32 CounterStartAttempts4 = no data stored
+- v32 Currenterror = -;-;-;-;-
+- v32 DateTime = nosignal;-:-:-;-.-.-;-
+- v32 DcfState = no data stored
+- v32 DCFTimeDate = no data stored
+- v32 DCRoomthermostat = no data stored
+- v32 DeactivationsIFC = no data stored
+- v32 DeactivationsTemplimiter = 0
+- v32 DeltaFlowReturnMax = no data stored
+- v32 DisplayMode = no data stored
+- v32 DSN = no data stored
+- v32 DSNOffset = no data stored
+- v32 DSNOffset = no data stored
+- v32 DSNStart = no data stored
+- v32 EBusHeatcontrol = no data stored
+- v32 EbusSourceOn = no data stored
+- v32 EbusVoltage = no data stored
+- v32 Errorhistory = no data stored
+- v32 Expertlevel_ReturnTemp = no data stored
+- v32 ExternalFaultmessage = no data stored
+- 'v32 ExternalFlowTempDesired =  (ERR: invalid position for 3118b509030d2500 / 00)'
+- v32 ExternalHwcSwitch = no data stored
+- v32 ExternGasvalve = no data stored
+- 'v32 ExtFlowTempDesiredMin =  (ERR: invalid position for 3118b509030d6e04 / 00)'
+- v32 ExtStorageModulCon = no data stored
+- v32 ExtWP = no data stored
+- v32 FanHours = 96
+- v32 FanMaxSpeedOperation = no data stored
+- v32 FanMinSpeedOperation = no data stored
+- v32 FanPWMSum = no data stored
+- v32 FanPWMTest = no data stored
+- v32 FanSpeed = no data stored
+- v32 FanSpeedOffsetMax = no data stored
+- v32 FanSpeedOffsetMax = no data stored
+- v32 FanSpeedOffsetMin = no data stored
+- v32 FanSpeedOffsetMin = no data stored
+- v32 FanStarts = 444
+- v32 Flame = no data stored
+- v32 FlameSensingASIC = no data stored
+- v32 FloorHeatingContact = no data stored
+- v32 FlowsetHcMax = no data stored
+- v32 FlowsetHcMax = no data stored
+- v32 FlowsetHwcMax = no data stored
+- v32 FlowsetHwcMax = no data stored
+- v32 FlowSetPotmeter = no data stored
+- v32 FlowTemp = 47.06;ok
+- v32 FlowTempDesired = 0.00
+- v32 FlowTempMax = 85.81
+- v32 Fluegasvalve = no data stored
+- v32 FluegasvalveOpen = no data stored
+- v32 Gasvalve3UC = no data stored
+- v32 Gasvalve = no data stored
+- v32 GasvalveASICFeedback = no data stored
+- v32 GasvalveUC = no data stored
+- v32 GasvalveUCFeedback = no data stored
+- v32 HcHours = 47
+- v32 HcPumpMode = post_run
+- v32 HcPumpMode = no data stored
+- v32 HcPumpStarts = 2288
+- v32 HcStarts = 0
+- v32 HcUnderHundredStarts = 0
+- v32 HeatingSwitch = no data stored
+- v32 HoursTillService = 2
+- v32 HoursTillService = no data stored
+- v32 HwcDemand = no data stored
+- v32 HwcHours = 41
+- v32 HwcImpellorSwitch = no data stored
+- v32 HwcPostrunTime = no data stored
+- v32 HwcPostrunTime = no data stored
+- v32 HwcSetPotmeter = no data stored
+- v32 HwcStarts = 0
+- v32 HwcSwitch = no data stored
+- v32 HwcTemp = 116.06;circuit
+- v32 HwcTempDesired = 0.00
+- 'v32 HwcTempMax =  (ERR: invalid position for 3118b509030d4304 / 01f0)'
+- v32 HwcTempMax = no data stored
+- v32 HwcTypes = no data stored
+- v32 HwcUnderHundredStarts = 3
+- v32 HwcWaterflow = no data stored
+- v32 HwcWaterflowMax = no data stored
+- v32 Ignitor = no data stored
+- v32 InitialisationEEPROM = no data stored
+- v32 IonisationVoltageLevel = no data stored
+- v32 Maintenancedata_HwcTempMax = 116.06
+- v32 MaxIgnitiontime = no data stored
+- v32 MinIgnitiontime = no data stored
+- v32 ModulationDesired = no data stored
+- v32 OutdoorstempSensor = -60.44;cutoff
+- v32 OverflowCounter = yes
+- v32 ParamToken = no data stored
+- v32 PartloadHcKW = no data stored
+- v32 PartloadHcKW = no data stored
+- v32 PartloadHwcKW = no data stored
+- v32 PartloadHwcKW = no data stored
+- v32 PartnumberBox = no data stored
+- v32 PositionValveSet = no data stored
+- 'v32 PowerValue =  (ERR: invalid position for 3118b509030daa00 / 00)'
+- 'v32 PrAPSCounter =  (ERR: invalid position for 3118b509030df200 / 00)'
+- v32 PrAPSSum = no data stored
+- 'v32 PrEnergyCountHc1 =  (ERR: invalid position for 3118b509030df600 / 00)'
+- v32 PrEnergyCountHc1 = no data stored
+- 'v32 PrEnergyCountHc2 =  (ERR: invalid position for 3118b509030df800 / 00)'
+- v32 PrEnergyCountHc2 = no data stored
+- v32 PrEnergyCountHc3 = no data stored
+- v32 PrEnergyCountHc3 = no data stored
+- 'v32 PrEnergyCountHwc1 =  (ERR: invalid position for 3118b509030dc600 / 00)'
+- v32 PrEnergyCountHwc1 = no data stored
+- v32 PrEnergyCountHwc2 = no data stored
+- v32 PrEnergyCountHwc2 = no data stored
+- v32 PrEnergyCountHwc3 = no data stored
+- v32 PrEnergyCountHwc3 = no data stored
+- 'v32 PrEnergySumHc1 =  (ERR: invalid position for 3118b509030df500 / 00)'
+- v32 PrEnergySumHc1 = no data stored
+- 'v32 PrEnergySumHc2 =  (ERR: invalid position for 3118b509030df700 / 00)'
+- v32 PrEnergySumHc2 = no data stored
+- v32 PrEnergySumHc3 = no data stored
+- v32 PrEnergySumHc3 = no data stored
+- 'v32 PrEnergySumHwc1 =  (ERR: invalid position for 3118b509030dc500 / 00)'
+- v32 PrEnergySumHwc1 = no data stored
+- 'v32 PrEnergySumHwc2 =  (ERR: invalid position for 3118b509030dc700 / 00)'
+- v32 PrEnergySumHwc2 = no data stored
+- v32 PrEnergySumHwc3 = no data stored
+- v32 PrEnergySumHwc3 = no data stored
+- v32 PrimaryCircuitFlowrate = no data stored
+- v32 ProductionByte = no data stored
+- 'v32 PrVortexFlowSensorValue =  (ERR: invalid position for 3118b509030df400 / 00)'
+- v32 PumpHours = 133
+- v32 PumpHwcFlowNumber = no data stored
+- v32 PumpHwcFlowSum = no data stored
+- v32 PumpPower = 0
+- 'v32 PumpPowerDesired =  (ERR: invalid position for 3118b509030da100 / 00)'
+- v32 PumpPowerDesired = no data stored
+- v32 RemainingBoilerblocktime = no data stored
+- v32 ReturnRegulation = no data stored
+- v32 ReturnRegulation = no data stored
+- v32 ReturnTemp = 55.31;64650;ok
+- v32 ReturnTempMax = 83.94
+- v32 SecondPumpMode = 0
+- v32 SecondPumpMode = no data stored
+- v32 SerialNumber = no data stored
+- v32 SetFactoryValues = no data stored
+- v32 SetFactoryValues = no data stored
+- v32 SetMode = auto;0.0;-;-;1;0;0;0;0;0
+- v32 SetMode = no data stored
+- v32 SHEMaxDeltaHwcFlow = no data stored
+- v32 SHEMaxFlowTemp = no data stored
+- v32 SolPostHeat = no data stored
+- v32 SolPostHeat = no data stored
+- v32 Statenumber = no data stored
+- v32 Status01 = 43.5;53.5;-;-;62.0;off
+- v32 Status02 = auto;60;68.0;70;70.0
+- 'v32 Status16 =  (ERR: invalid position for 3118b5040116 / 00)'
+- 'v32 Status =  (ERR: invalid position for 3118b5110103 / 00)'
+- v32 StatusCirPump = on
+- v32 Storageloadpump = no data stored
+- v32 StorageLoadPumpHours = 45
+- v32 StorageloadPumpStarts = 190
+- v32 StorageLoadTimeMax = no data stored
+- v32 StorageLoadTimeMax = no data stored
+- v32 StoragereleaseClock = no data stored
+- v32 StorageTemp = 62.25;ok
+- v32 StorageTempDesired = 46.00
+- v32 StorageTempMax = 72.75
+- v32 TargetFanSpeed = no data stored
+- v32 TargetFanSpeedOutput = no data stored
+- v32 TempDiffBlock = 0
+- v32 TempDiffFailure = 0
+- v32 TempGradientFailure = 0
+- v32 Templimiter = off
+- v32 TemplimiterWithNTC = yes
+- 'v32 TempMaxDiffExtTFT =  (ERR: invalid position for 3118b509030d2700 / 00)'
+- v32 Testbyte = no data stored
+- 'v32 TimerInputHc =  (ERR: invalid position for 3118b509030dde00 / 00)'
+- v32 ValveMode = 0
+- v32 ValveMode = no data stored
+- v32 ValveStarts = 2454
+- v32 VolatileLockout = no data stored
+- v32 VolatileLockoutIFCGV = no data stored
+- 'v32 VortexFlowSensor =  (ERR: invalid position for 3118b509030dd500 / 00)'
+- v32 WarmstartDemand = no data stored
+- v32 WarmstartOffset = no data stored
+- v32 WarmstartOffset = no data stored
+- v32 WaterHcFlowMax = no data stored
+- v32 WaterPressure = 1.771;ok
+- v32 WaterpressureBranchControlOff = no data stored
+- v32 WaterpressureMeasureCounter = 118
+- v32 WaterpressureVariantSum = no data stored
+- v32 WP = no data stored
+- v32 WPPostrunTime = 1
+- v32 WPPostrunTime = no data stored
+- v32 WPSecondStage = no data stored
+- vr_71 Clearerrorhistory = no data stored
+- vr_71 Currenterror = -;-;-;-;-
+- vr_71 Errorhistory = no data stored
+- vr_71 Mc1Operation = off;0.0;on;-100
+- vr_71 Mc2Operation = off;0.0;on;-100
+- vr_71 Mc3Operation = no data stored
+- vr_71 SensorData1 = 32.19;30.19;24.88;-;-;-;-;40 3d
+- vr_71 SensorData2 = -;-;-;-;0.00;8.00;80 57 05
+- vr_71 SetActorState = -;-;off;off;off;off;-;-;-;-;off;off;00 00
+- vwzio EnableTestHwcTemp = no data stored
+- vwzio EnableTestOutdoorTemp = no data stored
+- vwzio EnableTestThreeWayValve = no data stored
+- vwzio TestHwcTemp = no data stored
+- vwzio TestOutdoorTemp = no data stored
+- vwzio TestThreeWayValve = no data stored
+- ''
+before_registers:
+- circuit: Broadcast
+  name: Datetime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Error
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: Broadcast
+  name: HwcStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Id
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: IdAnswer
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: IdQuery
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Load
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Outsidetemp
+  fields:
+  - value
+  values:
+  - '28.582'
+  writable: false
+  has_data: true
+- circuit: Broadcast
+  name: Queryexistence
+  fields:
+  - value
+  values:
+  - (empty for 31fe07fe00 / )
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Signoflife
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Vdatetime
+  fields:
+  - value
+  values:
+  - 11:15:15;22.08.2026
+  writable: false
+  has_data: true
+- circuit: Broadcast
+  name: Vdatetime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: WaterPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: General
+  name: Valuerange
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Eeprom
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Eeprom
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Ram
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Ram
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Scan
+  name: Id
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Scan.15
+  name: Id
+  fields:
+  - value
+  values:
+  - 21;22;51;0020260913;0953;045677;N9
+  writable: false
+  has_data: true
+- circuit: Scan.18
+  name: Id
+  fields:
+  - value
+  values:
+  - 21;22;41;0010022017;0001;005945;N9
+  writable: false
+  has_data: true
+- circuit: Scan.26
+  name: Id
+  fields:
+  - value
+  values:
+  - 21;22;42;0020184847;0082;020249;N7
+  writable: false
+  has_data: true
+- circuit: Scan.35
+  name: Id
+  fields:
+  - value
+  values:
+  - 21;22;18;0020260925;0953;009293;N2
+  writable: false
+  has_data: true
+- circuit: Scan.76
+  name: Id
+  fields:
+  - value
+  values:
+  - 21;23;03;0010034193;1610;005152;N2
+  writable: false
+  has_data: true
+- circuit: Scan.f6
+  name: Id
+  fields:
+  - value
+  values:
+  - 21;22;45;0020292012;0933;083357;N0
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: AdaptHeatCurve
+  fields:
+  - value
+  values:
+  - 'no'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: AdaptHeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: CcTimer_Config
+  fields:
+  - value
+  values:
+  - 00 03 0a 00 00 00 ff ff 00
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: CcTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: CcTimer_Friday0
+  fields:
+  - value
+  values:
+  - 06:00;22:00
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: CcTimer_Friday1
+  fields:
+  - value
+  values:
+  - 00:00;00:00
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: CcTimer_Friday2
+  fields:
+  - value
+  values:
+  - 00:00;00:00
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: CcTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: CcTimer_Monday0
+  fields:
+  - value
+  values:
+  - 06:00;22:00
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: CcTimer_Monday1
+  fields:
+  - value
+  values:
+  - 00:00;00:00
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: CcTimer_Monday2
+  fields:
+  - value
+  values:
+  - 00:00;00:00
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: CcTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: CcTimer_Saturday0
+  fields:
+  - value
+  values:
+  - 07:30;23:30
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: CcTimer_Saturday1
+  fields:
+  - value
+  values:
+  - 00:00;00:00
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: CcTimer_Saturday2
+  fields:
+  - value
+  values:
+  - 00:00;00:00
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: CcTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: CcTimer_Sunday0
+  fields:
+  - value
+  values:
+  - 07:30;22:00
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: CcTimer_Sunday1
+  fields:
+  - value
+  values:
+  - 00:00;00:00
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: CcTimer_Sunday2
+  fields:
+  - value
+  values:
+  - 00:00;00:00
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: CcTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: CcTimer_Thursday0
+  fields:
+  - value
+  values:
+  - 06:00;22:00
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: CcTimer_Thursday1
+  fields:
+  - value
+  values:
+  - 00:00;00:00
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: CcTimer_Thursday2
+  fields:
+  - value
+  values:
+  - 00:00;00:00
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: CcTimer_Timeframes
+  fields:
+  - value
+  values:
+  - 1;1;1;1;1;1;1
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: CcTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: CcTimer_Tuesday0
+  fields:
+  - value
+  values:
+  - 06:00;22:00
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: CcTimer_Tuesday1
+  fields:
+  - value
+  values:
+  - 00:00;00:00
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: CcTimer_Tuesday2
+  fields:
+  - value
+  values:
+  - 00:00;00:00
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: CcTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: CcTimer_Wednesday0
+  fields:
+  - value
+  values:
+  - 06:00;22:00
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: CcTimer_Wednesday1
+  fields:
+  - value
+  values:
+  - 00:00;00:00
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: CcTimer_Wednesday2
+  fields:
+  - value
+  values:
+  - 00:00;00:00
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Clearerrorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: ContinuousHeating
+  fields:
+  - value
+  values:
+  - '-26'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: ContinuousHeating
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - -;-;-;-;-
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: CylinderChargeHyst
+  fields:
+  - value
+  values:
+  - '3'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: CylinderChargeHyst
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: CylinderChargeOffset
+  fields:
+  - value
+  values:
+  - '25'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: CylinderChargeOffset
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Date
+  fields:
+  - value
+  values:
+  - 22.08.2026
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Date
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: DisplayedOutsideTemp
+  fields:
+  - value
+  values:
+  - '28.5352'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: FrostOverRideTime
+  fields:
+  - value
+  values:
+  - '4'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: FrostOverRideTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc1AutoOffMode
+  fields:
+  - value
+  values:
+  - night
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc1AutoOffMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1CircuitType
+  fields:
+  - value
+  values:
+  - mixer
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc1CoolingEnabled
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1CoolingFlowTempMin
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1DewPointMonitoring
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1DewPointOffset
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1ExcessTemp
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc1ExcessTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1FlowTemp
+  fields:
+  - value
+  values:
+  - '30.1875'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc1HeatCurve
+  fields:
+  - value
+  values:
+  - '1.7'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc1HeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc1MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '65'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc1MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - '13'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc1MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - '48'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc1MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1MixerMovement
+  fields:
+  - value
+  values:
+  - '-100'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc1PumpStatus
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc1PumpStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1RoomTempModulation
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - thermostat
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc1RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1Status
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc1Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1SummerTempLimit
+  fields:
+  - value
+  values:
+  - '40'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc1SummerTempLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc2AutoOffMode
+  fields:
+  - value
+  values:
+  - night
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc2AutoOffMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2CircuitType
+  fields:
+  - value
+  values:
+  - mixer
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc2ExcessTemp
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc2ExcessTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2FlowTemp
+  fields:
+  - value
+  values:
+  - '24.875'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc2HeatCurve
+  fields:
+  - value
+  values:
+  - '1.7'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc2HeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc2MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '65'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc2MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - '20'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc2MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - '48'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc2MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2MixerMovement
+  fields:
+  - value
+  values:
+  - '-100'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc2PumpStatus
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc2PumpStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - thermostat
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc2RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2Status
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc2Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2SummerTempLimit
+  fields:
+  - value
+  values:
+  - '40'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc2SummerTempLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc3ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc3AutoOffMode
+  fields:
+  - value
+  values:
+  - eco
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc3AutoOffMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc3CircuitType
+  fields:
+  - value
+  values:
+  - inactive
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc3ExcessTemp
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc3ExcessTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc3FlowTemp
+  fields:
+  - value
+  values:
+  - (empty for 3115b52406020002020800 / 0800020800ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc3HeatCurve
+  fields:
+  - value
+  values:
+  - '1.2'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc3HeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc3HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc3MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '90'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc3MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc3MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - '20'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc3MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc3MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - '15'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc3MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc3MixerMovement
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc3PumpStatus
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc3PumpStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc3RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'off'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc3RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc3Status
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc3Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc3SummerTempLimit
+  fields:
+  - value
+  values:
+  - '21'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc3SummerTempLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HcStorageTempBottom
+  fields:
+  - value
+  values:
+  - (empty for 3115b5240602000000a000 / 080000a000ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HcStorageTempTop
+  fields:
+  - value
+  values:
+  - (empty for 3115b52406020000009f00 / 0800009f00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcBankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcBankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcBankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcBankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcFlowTemp
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: HwcHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 01.01.2015
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: HwcHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 01.01.2015
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: HwcHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcLockTime
+  fields:
+  - value
+  values:
+  - '60'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: HwcLockTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcMaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '75'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: HwcMaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcOpMode
+  fields:
+  - value
+  values:
+  - day
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: HwcOpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcParallelLoading
+  fields:
+  - value
+  values:
+  - 'off'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: HwcParallelLoading
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcSFMode
+  fields:
+  - value
+  values:
+  - auto
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: HwcSFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcSfMode
+  fields:
+  - value
+  values:
+  - auto
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcStorageTemp
+  fields:
+  - value
+  values:
+  - '62'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: HwcStorageTempBottom
+  fields:
+  - value
+  values:
+  - (empty for 3115b52406020000009e00 / 0800009e00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcStorageTempTop
+  fields:
+  - value
+  values:
+  - (empty for 3115b52406020000009d00 / 0800009d00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTempDesired
+  fields:
+  - value
+  values:
+  - '46'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: HwcTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTimer_Config
+  fields:
+  - value
+  values:
+  - 00 03 0a 0a 01 01 23 46 00
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: HwcTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTimer_Friday0
+  fields:
+  - value
+  values:
+  - 05:30;22:00;46.0
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: HwcTimer_Friday1
+  fields:
+  - value
+  values:
+  - 00:00;00:00;-
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: HwcTimer_Friday2
+  fields:
+  - value
+  values:
+  - 00:00;00:00;-
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: HwcTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTimer_Monday0
+  fields:
+  - value
+  values:
+  - 05:30;22:00;46.0
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: HwcTimer_Monday1
+  fields:
+  - value
+  values:
+  - 00:00;00:00;-
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: HwcTimer_Monday2
+  fields:
+  - value
+  values:
+  - 00:00;00:00;-
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: HwcTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTimer_Saturday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTimer_Saturday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTimer_Saturday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTimer_Sunday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTimer_Sunday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTimer_Sunday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTimer_Thursday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTimer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTimer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTimer_Timeframes
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTimer_Tuesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTimer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTimer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTimer_Wednesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTimer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTimer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HydraulicScheme
+  fields:
+  - value
+  values:
+  - '12'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: HydraulicScheme
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Installer1
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Installer1
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Installer2
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Installer2
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: KeyCodeforConfigMenu
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: KeyCodeforConfigMenu
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: MaintenanceDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: MaintenanceDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: MaintenanceDue
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: ManualCoolingEndDate
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: ManualCoolingEndDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: ManualCoolingStartDate
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: ManualCoolingStartDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: MaxCylinderChargeTime
+  fields:
+  - value
+  values:
+  - '60'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: MaxCylinderChargeTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: MaxRoomHumidity
+  fields:
+  - value
+  values:
+  - '40'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: MaxRoomHumidity
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: MultiRelaySetting
+  fields:
+  - value
+  values:
+  - circulation
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: MultiRelaySetting
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: OutsideTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: OutsideTempAvg
+  fields:
+  - value
+  values:
+  - '26.2656'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: OutsideTempAvg
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PhoneNumber1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PhoneNumber1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PhoneNumber2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PhoneNumber2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrEnergySum
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020000005c00 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrEnergySum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrEnergySumHc
+  fields:
+  - value
+  values:
+  - '6220'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: PrEnergySumHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrEnergySumHcLastMonth
+  fields:
+  - value
+  values:
+  - '13'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: PrEnergySumHcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrEnergySumHcThisMonth
+  fields:
+  - value
+  values:
+  - '9'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: PrEnergySumHcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrEnergySumHwc
+  fields:
+  - value
+  values:
+  - '2596'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: PrEnergySumHwc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrEnergySumHwcLastMonth
+  fields:
+  - value
+  values:
+  - '24'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: PrEnergySumHwcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrEnergySumHwcThisMonth
+  fields:
+  - value
+  values:
+  - '24'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: PrEnergySumHwcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrFuelSum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrFuelSum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrFuelSumHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrFuelSumHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrFuelSumHcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrFuelSumHcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrFuelSumHcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrFuelSumHcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrFuelSumHwc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrFuelSumHwc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrFuelSumHwcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrFuelSumHwcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrFuelSumHwcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrFuelSumHwcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PumpAdditionalTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PumpAdditionalTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: SolarYieldTotal
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: SolarYieldTotal
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: SystemFlowTemp
+  fields:
+  - value
+  values:
+  - '32.25'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Time
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Time
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: WaterPressure
+  fields:
+  - value
+  values:
+  - '1.6'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: YieldTotal
+  fields:
+  - value
+  values:
+  - '14845'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: YieldTotal
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - '5'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z1ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1CoolingManualTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingOpMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingSetbackTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingTemp
+  fields:
+  - value
+  values:
+  - '24'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z1CoolingTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1CoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1DayTemp
+  fields:
+  - value
+  values:
+  - '18'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z1DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 01.01.2015
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z1HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 01.01.2015
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z1HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1HolidayTemp
+  fields:
+  - value
+  values:
+  - '15'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z1HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1NightTemp
+  fields:
+  - value
+  values:
+  - '18.5'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z1NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1OpMode
+  fields:
+  - value
+  values:
+  - 'off'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z1OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1QuickVetoDuration
+  fields:
+  - value
+  values:
+  - '3'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z1QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1QuickVetoEndDate
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z1QuickVetoEndTime
+  fields:
+  - value
+  values:
+  - 00:00:00
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z1QuickVetoTemp
+  fields:
+  - value
+  values:
+  - '10'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z1QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1RoomTemp
+  fields:
+  - value
+  values:
+  - '27.85'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z1RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1SFMode
+  fields:
+  - value
+  values:
+  - auto
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z1SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Config
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Friday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Friday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Friday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Monday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Monday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Monday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Saturday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Saturday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Saturday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Sunday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Sunday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Sunday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Thursday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Timeframes
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Tuesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Wednesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - '5'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z2ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2CoolingTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2CoolingTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2DayTemp
+  fields:
+  - value
+  values:
+  - '18.5'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z2DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2OpMode
+  fields:
+  - value
+  values:
+  - 'off'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z2OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2QuickVetoEndDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2QuickVetoEndTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2RoomTemp
+  fields:
+  - value
+  values:
+  - '27.2875'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z2RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Config
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Friday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Friday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Friday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Monday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Monday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Monday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Saturday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Saturday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Saturday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Sunday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Sunday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Sunday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Thursday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Timeframes
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Tuesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Wednesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3QuickVetoEndDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3QuickVetoEndTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3RoomTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Config
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Friday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Friday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Friday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Monday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Monday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Monday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Saturday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Saturday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Saturday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Sunday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Sunday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Sunday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Thursday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Timeframes
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Tuesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Wednesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: z1RoomHumidity
+  fields:
+  - value
+  values:
+  - '57'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: BuildingCircuitFlow
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: BuildingCircuitPumpSpeed
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Clearerrorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: CompressorBlocktime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: CompressorHc
+  fields:
+  - value
+  values:
+  - no data stored (message not available due to condition)
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: CompressorHc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHwc
+  fields:
+  - value
+  values:
+  - no data stored (message not available due to condition)
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: CompressorHwc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHwc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CopCooling
+  fields:
+  - value
+  values:
+  - '1.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CopCoolingMonth
+  fields:
+  - value
+  values:
+  - '1.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CopHc
+  fields:
+  - value
+  values:
+  - '2.6'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CopHcMonth
+  fields:
+  - value
+  values:
+  - '1.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CopHwc
+  fields:
+  - value
+  values:
+  - '2.7'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CopHwcMonth
+  fields:
+  - value
+  values:
+  - '3.7'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CurrentCompressorUtil
+  fields:
+  - value
+  values:
+  - '0.00'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CurrentConsumedPower
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CurrentYieldPower
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - -;-;-;-;-
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: DateTime
+  fields:
+  - value
+  values:
+  - nosignal;-:-:-;-.-.-;-
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: EnergyIntegral
+  fields:
+  - value
+  values:
+  - '-178'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: FlowPressure
+  fields:
+  - value
+  values:
+  - no data stored (message not available due to condition)
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: FlowTemp
+  fields:
+  - value
+  values:
+  - '48.12'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: FlowTemperature
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: HoursCool
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: PowerConsumptionHmu
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3108b5160114 / 00)'
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: RunDataAirInletTemp
+  fields:
+  - value
+  values:
+  - '25.4612'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataBuildingCPumpPower
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataCompressorInletTemp
+  fields:
+  - value
+  values:
+  - '30.9524'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataCompressorOutletTemp
+  fields:
+  - value
+  values:
+  - '50.7246'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataCompressorSpeed
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataEEVOutletTemp
+  fields:
+  - value
+  values:
+  - '28.0747'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataEEVPositionAbs
+  fields:
+  - value
+  values:
+  - '155'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataFan1Speed
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataFan2Speed
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataHighPressure
+  fields:
+  - value
+  values:
+  - '14.739'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataLowPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunDataStatuscode
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStats4PortValveHours
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStats4PortValveSwitches
+  fields:
+  - value
+  values:
+  - '14'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsBuildingCPumpStarts
+  fields:
+  - value
+  values:
+  - '4092'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsBuildingPumpHours
+  fields:
+  - value
+  values:
+  - '4810'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsCompressorHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunStatsCompressorHc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHours
+  fields:
+  - value
+  values:
+  - '2546'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsCompressorHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunStatsCompressorHwc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHwc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorStarts
+  fields:
+  - value
+  values:
+  - '6521'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsFan1Hours
+  fields:
+  - value
+  values:
+  - '3040'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsFan1Starts
+  fields:
+  - value
+  values:
+  - '9955'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsFan2Hours
+  fields:
+  - value
+  values:
+  - '3040'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsFan2Starts
+  fields:
+  - value
+  values:
+  - '9955'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsHMUHours
+  fields:
+  - value
+  values:
+  - '26642'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsHcHours
+  fields:
+  - value
+  values:
+  - '2416'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsHwcHours
+  fields:
+  - value
+  values:
+  - '1135'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: SetMode
+  fields:
+  - value
+  values:
+  - auto;0.0;-;-;1;1;1;0;0;0
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: SetMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: SourceTempInput
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: SourceTempOutput
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatElectricEnergySum
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatElectricEnergySumCool
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatElectricEnergySumHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatElectricEnergySumHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatEnvironmentEnergySum
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatEnvironmentEnergySumCool
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatEnvironmentEnergySumHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatEnvironmentEnergySumHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3108b5110103 / 00)'
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: Status01
+  fields:
+  - value
+  values:
+  - 48.0;46.0;-;-;-;off
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: Status01.pumpstate
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.temp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.temp_1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.temp_2
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: Status01.temp_3
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: Status01.temp_4
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: Status02
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: Status16
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3108b5040116 / 00)'
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: StatusCirPump
+  fields:
+  - value
+  values:
+  - 'on'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: SupplyTempWeighted
+  fields:
+  - value
+  values:
+  - '20.00'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: TotalEnergyUsage
+  fields:
+  - value
+  values:
+  - '8556'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldCoolDay
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldCooling
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldCoolingMonth
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldHc
+  fields:
+  - value
+  values:
+  - '10137'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldHcDay
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldHcMonth
+  fields:
+  - value
+  values:
+  - '2.3'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldHwc
+  fields:
+  - value
+  values:
+  - '4709'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldHwcDay
+  fields:
+  - value
+  values:
+  - '1.1'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldHwcMonth
+  fields:
+  - value
+  values:
+  - '69.3'
+  writable: false
+  has_data: true
+- circuit: v32
+  name: ACRoomthermostat
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: APCComStatus
+  fields:
+  - value
+  values:
+  - no data stored (message not available due to condition)
+  writable: false
+  has_data: false
+- circuit: v32
+  name: APCLegioProtection
+  fields:
+  - value
+  values:
+  - no data stored (message not available due to condition)
+  writable: false
+  has_data: false
+- circuit: v32
+  name: APCLegioProtection
+  fields:
+  - value
+  values:
+  - no data stored (message not available due to condition)
+  writable: false
+  has_data: false
+- circuit: v32
+  name: AccessoriesOne
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: AccessoriesOne
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: AccessoriesTwo
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: AccessoriesTwo
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: AverageIgnitiontime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: BlockTimeHcMax
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: BlockTimeHcMax
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: BoilerType
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: BypassPosition
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: ChangesDSN
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: CirPump
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: Clearerrorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: CounterStartAttempts3
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: CounterStartAttempts4
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: CounterStartattempts1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: CounterStartattempts2
+  fields:
+  - value
+  values:
+  - '2'
+  writable: false
+  has_data: true
+- circuit: v32
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - -;-;-;-;-
+  writable: false
+  has_data: true
+- circuit: v32
+  name: DCFTimeDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: DCRoomthermostat
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: DSN
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: DSNOffset
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: DSNOffset
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: DSNStart
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: DateTime
+  fields:
+  - value
+  values:
+  - nosignal;-:-:-;-.-.-;-
+  writable: false
+  has_data: true
+- circuit: v32
+  name: DcfState
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: DeactivationsIFC
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: DeactivationsTemplimiter
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: v32
+  name: DeltaFlowReturnMax
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: DisplayMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: EBusHeatcontrol
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: EbusSourceOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: EbusVoltage
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: ExhaustAirHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: ExhaustAirTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: Expertlevel_ReturnTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: ExtFlowTempDesiredMin
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3118b509030d6e04 / 00)'
+  writable: false
+  has_data: false
+- circuit: v32
+  name: ExtStorageModulCon
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: ExtWP
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: ExternGasvalve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: ExternalFaultmessage
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: ExternalFlowTempDesired
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3118b509030d2500 / 00)'
+  writable: false
+  has_data: false
+- circuit: v32
+  name: ExternalHwcSwitch
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: FanHours
+  fields:
+  - value
+  values:
+  - '96'
+  writable: false
+  has_data: true
+- circuit: v32
+  name: FanMaxSpeedOperation
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: FanMinSpeedOperation
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: FanPWMSum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: FanPWMTest
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: FanSpeed
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: FanSpeedOffsetMax
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: FanSpeedOffsetMax
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: FanSpeedOffsetMin
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: FanSpeedOffsetMin
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: FanStarts
+  fields:
+  - value
+  values:
+  - '444'
+  writable: false
+  has_data: true
+- circuit: v32
+  name: Flame
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: FlameSensingASIC
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: FloorHeatingContact
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: FlowSetPotmeter
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: FlowTemp
+  fields:
+  - value
+  values:
+  - 47.06;ok
+  writable: false
+  has_data: true
+- circuit: v32
+  name: FlowTempDesired
+  fields:
+  - value
+  values:
+  - '0.00'
+  writable: false
+  has_data: true
+- circuit: v32
+  name: FlowTempMax
+  fields:
+  - value
+  values:
+  - '85.81'
+  writable: false
+  has_data: true
+- circuit: v32
+  name: FlowsetHcMax
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: FlowsetHcMax
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: FlowsetHwcMax
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: FlowsetHwcMax
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: Fluegasvalve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: FluegasvalveOpen
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: Gasvalve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: Gasvalve3UC
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: GasvalveASICFeedback
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: GasvalveUC
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: GasvalveUCFeedback
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: HcHours
+  fields:
+  - value
+  values:
+  - '47'
+  writable: false
+  has_data: true
+- circuit: v32
+  name: HcPumpMode
+  fields:
+  - value
+  values:
+  - post_run
+  writable: false
+  has_data: true
+- circuit: v32
+  name: HcPumpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: HcPumpStarts
+  fields:
+  - value
+  values:
+  - '2288'
+  writable: false
+  has_data: true
+- circuit: v32
+  name: HcStarts
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: v32
+  name: HcUnderHundredStarts
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: v32
+  name: HeatingSwitch
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: HoursTillService
+  fields:
+  - value
+  values:
+  - '2'
+  writable: false
+  has_data: true
+- circuit: v32
+  name: HoursTillService
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: HwcDemand
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: HwcHours
+  fields:
+  - value
+  values:
+  - '41'
+  writable: false
+  has_data: true
+- circuit: v32
+  name: HwcImpellorSwitch
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: HwcPostrunTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: HwcPostrunTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: HwcSetPotmeter
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: HwcStarts
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: v32
+  name: HwcSwitch
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: HwcTemp
+  fields:
+  - value
+  values:
+  - 116.06;circuit
+  writable: false
+  has_data: true
+- circuit: v32
+  name: HwcTempDesired
+  fields:
+  - value
+  values:
+  - '0.00'
+  writable: false
+  has_data: true
+- circuit: v32
+  name: HwcTempMax
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3118b509030d4304 / 01f0)'
+  writable: false
+  has_data: false
+- circuit: v32
+  name: HwcTempMax
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: HwcTypes
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: HwcUnderHundredStarts
+  fields:
+  - value
+  values:
+  - '3'
+  writable: false
+  has_data: true
+- circuit: v32
+  name: HwcWaterflow
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: HwcWaterflowMax
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: Ignitor
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: InitialisationEEPROM
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: IonisationVoltageLevel
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: Maintenancedata_HwcTempMax
+  fields:
+  - value
+  values:
+  - '116.06'
+  writable: false
+  has_data: true
+- circuit: v32
+  name: MaxAirHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: MaxIgnitiontime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: MinAirHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: MinIgnitiontime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: ModulationDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: OutdoorstempSensor
+  fields:
+  - value
+  values:
+  - -60.44;cutoff
+  writable: false
+  has_data: true
+- circuit: v32
+  name: OutsideAirTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: OverflowCounter
+  fields:
+  - value
+  values:
+  - 'yes'
+  writable: false
+  has_data: true
+- circuit: v32
+  name: ParamToken
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: v32
+  name: PartloadHcKW
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: PartloadHcKW
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: PartloadHwcKW
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: PartloadHwcKW
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: PartnumberBox
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: PositionValveSet
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: PowerValue
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3118b509030daa00 / 00)'
+  writable: false
+  has_data: false
+- circuit: v32
+  name: PrAPSCounter
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3118b509030df200 / 00)'
+  writable: false
+  has_data: false
+- circuit: v32
+  name: PrAPSSum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: PrEnergyCountHc1
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3118b509030df600 / 00)'
+  writable: false
+  has_data: false
+- circuit: v32
+  name: PrEnergyCountHc1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: PrEnergyCountHc2
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3118b509030df800 / 00)'
+  writable: false
+  has_data: false
+- circuit: v32
+  name: PrEnergyCountHc2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: PrEnergyCountHc3
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: PrEnergyCountHc3
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: PrEnergyCountHwc1
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3118b509030dc600 / 00)'
+  writable: false
+  has_data: false
+- circuit: v32
+  name: PrEnergyCountHwc1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: PrEnergyCountHwc2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: PrEnergyCountHwc2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: PrEnergyCountHwc3
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: PrEnergyCountHwc3
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: PrEnergySumHc1
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3118b509030df500 / 00)'
+  writable: false
+  has_data: false
+- circuit: v32
+  name: PrEnergySumHc1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: PrEnergySumHc2
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3118b509030df700 / 00)'
+  writable: false
+  has_data: false
+- circuit: v32
+  name: PrEnergySumHc2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: PrEnergySumHc3
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: PrEnergySumHc3
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: PrEnergySumHwc1
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3118b509030dc500 / 00)'
+  writable: false
+  has_data: false
+- circuit: v32
+  name: PrEnergySumHwc1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: PrEnergySumHwc2
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3118b509030dc700 / 00)'
+  writable: false
+  has_data: false
+- circuit: v32
+  name: PrEnergySumHwc2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: PrEnergySumHwc3
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: PrEnergySumHwc3
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: PrVortexFlowSensorValue
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3118b509030df400 / 00)'
+  writable: false
+  has_data: false
+- circuit: v32
+  name: PrimaryCircuitFlowrate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: ProductionByte
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: PumpHours
+  fields:
+  - value
+  values:
+  - '133'
+  writable: false
+  has_data: true
+- circuit: v32
+  name: PumpHwcFlowNumber
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: PumpHwcFlowSum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: PumpPower
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: v32
+  name: PumpPowerDesired
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3118b509030da100 / 00)'
+  writable: false
+  has_data: false
+- circuit: v32
+  name: PumpPowerDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: RemainingBoilerblocktime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: ReturnRegulation
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: ReturnRegulation
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: ReturnTemp
+  fields:
+  - value
+  values:
+  - 55.31;64650;ok
+  writable: false
+  has_data: true
+- circuit: v32
+  name: ReturnTempMax
+  fields:
+  - value
+  values:
+  - '83.94'
+  writable: false
+  has_data: true
+- circuit: v32
+  name: SHEMaxDeltaHwcFlow
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: SHEMaxFlowTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: SecondPumpMode
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: v32
+  name: SecondPumpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: SerialNumber
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: v32
+  name: SetFactoryValues
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: SetFactoryValues
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: SetMode
+  fields:
+  - value
+  values:
+  - auto;0.0;-;-;1;0;0;0;0;0
+  writable: false
+  has_data: true
+- circuit: v32
+  name: SetMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: SolPostHeat
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: SolPostHeat
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: Statenumber
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: Status
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3118b5110103 / 00)'
+  writable: false
+  has_data: false
+- circuit: v32
+  name: Status01
+  fields:
+  - value
+  values:
+  - 43.5;53.5;-;-;62.0;off
+  writable: false
+  has_data: true
+- circuit: v32
+  name: Status02
+  fields:
+  - value
+  values:
+  - auto;60;68.0;70;70.0
+  writable: false
+  has_data: true
+- circuit: v32
+  name: Status16
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3118b5040116 / 00)'
+  writable: false
+  has_data: false
+- circuit: v32
+  name: StatusCirPump
+  fields:
+  - value
+  values:
+  - 'on'
+  writable: false
+  has_data: true
+- circuit: v32
+  name: StorageLoadPumpHours
+  fields:
+  - value
+  values:
+  - '45'
+  writable: false
+  has_data: true
+- circuit: v32
+  name: StorageLoadTimeMax
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: StorageLoadTimeMax
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: StorageTemp
+  fields:
+  - value
+  values:
+  - 62.25;ok
+  writable: false
+  has_data: true
+- circuit: v32
+  name: StorageTempDesired
+  fields:
+  - value
+  values:
+  - '46.00'
+  writable: false
+  has_data: true
+- circuit: v32
+  name: StorageTempMax
+  fields:
+  - value
+  values:
+  - '72.75'
+  writable: false
+  has_data: true
+- circuit: v32
+  name: StorageloadPumpStarts
+  fields:
+  - value
+  values:
+  - '190'
+  writable: false
+  has_data: true
+- circuit: v32
+  name: Storageloadpump
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: StoragereleaseClock
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: SupplyAirTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: TargetFanSpeed
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: TargetFanSpeedOutput
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: TempDiffBlock
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: v32
+  name: TempDiffFailure
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: v32
+  name: TempGradientFailure
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: v32
+  name: TempMaxDiffExtTFT
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3118b509030d2700 / 00)'
+  writable: false
+  has_data: false
+- circuit: v32
+  name: Templimiter
+  fields:
+  - value
+  values:
+  - 'off'
+  writable: false
+  has_data: true
+- circuit: v32
+  name: TemplimiterWithNTC
+  fields:
+  - value
+  values:
+  - 'yes'
+  writable: false
+  has_data: true
+- circuit: v32
+  name: Testbyte
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: TimerInputHc
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3118b509030dde00 / 00)'
+  writable: false
+  has_data: false
+- circuit: v32
+  name: ValveMode
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: v32
+  name: ValveMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: ValveStarts
+  fields:
+  - value
+  values:
+  - '2454'
+  writable: false
+  has_data: true
+- circuit: v32
+  name: VentilationLevelDay
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: VentilationLevelNight
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: VolatileLockout
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: VolatileLockoutIFCGV
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: VortexFlowSensor
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3118b509030dd500 / 00)'
+  writable: false
+  has_data: false
+- circuit: v32
+  name: WP
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: WPPostrunTime
+  fields:
+  - value
+  values:
+  - '1'
+  writable: false
+  has_data: true
+- circuit: v32
+  name: WPPostrunTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: WPSecondStage
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: WarmstartDemand
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: WarmstartOffset
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: WarmstartOffset
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: WaterHcFlowMax
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: WaterPressure
+  fields:
+  - value
+  values:
+  - 1.771;ok
+  writable: false
+  has_data: true
+- circuit: v32
+  name: WaterpressureBranchControlOff
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: WaterpressureMeasureCounter
+  fields:
+  - value
+  values:
+  - '118'
+  writable: false
+  has_data: true
+- circuit: v32
+  name: WaterpressureVariantSum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: YieldMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldToday
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldTotal
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldYear
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Clearerrorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vr_71
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - -;-;-;-;-
+  writable: false
+  has_data: true
+- circuit: vr_71
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vr_71
+  name: Mc1Operation
+  fields:
+  - value
+  values:
+  - off;0.0;on;-100
+  writable: false
+  has_data: true
+- circuit: vr_71
+  name: Mc2Operation
+  fields:
+  - value
+  values:
+  - off;0.0;on;-100
+  writable: false
+  has_data: true
+- circuit: vr_71
+  name: Mc3Operation
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vr_71
+  name: SensorData1
+  fields:
+  - value
+  values:
+  - 32.19;30.19;24.88;-;-;-;-;40 3d
+  writable: false
+  has_data: true
+- circuit: vr_71
+  name: SensorData2
+  fields:
+  - value
+  values:
+  - -;-;-;-;0.00;8.00;80 57 05
+  writable: false
+  has_data: true
+- circuit: vr_71
+  name: SetActorState
+  fields:
+  - value
+  values:
+  - -;-;off;off;off;off;-;-;-;-;off;off;00 00
+  writable: false
+  has_data: true
+- circuit: vwz
+  name: TestHwcTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: vwz
+  name: TestOutdoorTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: vwz
+  name: TestThreeWayValve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: vwzio
+  name: EnableTestHwcTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: EnableTestOutdoorTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: EnableTestThreeWayValve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: TestHwcTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: TestOutdoorTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: TestThreeWayValve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+grab:
+- '[grab] grab continued'
+- '3108070400 / 0ab5484d55303005225103 = 1: scan.08'
+- '3115070400 / 0ab543544c563205141104 = 1: scan.15'
+- '3115b5090127 / 094e3930303030303030 = 7: Scan.15 Id'
+- '3118070400 / 0ab5563332000001066004 = 1: scan.18'
+- '3118b5090127 / 094e393c3c3c3c3c3c3c = 3: Scan.18 Id'
+- '3126070400 / 0ab556525f373101005904 = 1: scan.26'
+- '3126b5090127 / 094e3700000000000000 = 3: Scan.26 Id'
+- '3135070400 / 0ab556525f393205141204 = 1: scan.35'
+- '3135b5090127 / 094e3230303030303030 = 3: Scan.35 Id'
+- '3176070400 / 0ab556575a494f09015103 = 1: scan.76'
+- '3176b5090127 / 094e323c3c3c3c3c3c3c = 3: Scan.76 Id'
+- '31f6070400 / 0ab54e4554583301290404 = 1: scan.f6'
+- '31f6b5090127 / 094e30ffffffffffffff = 3: Scan.f6 Id'
+- '31fe07fe00 = 1: Broadcast Queryexistence'
+- '1008b51009000000ffffff070000 / 0101 = 109: hmu SetMode'
+- '1008b512020064 / 00 = 3: hmu StatusCirPump'
+- '1018b51009000000ffffff010000 / 0101 = 115: v32 SetMode'
+- '1018b512020064 / 00 = 3: v32 StatusCirPump'
+- '10feb516080015151122080626 = 19: Broadcast Vdatetime'
+- '10feb5160301951c = 17: Broadcast Outsidetemp'
+- 1008b5110100 / 09000310000000000000 = 15
+- '1008b5110101 / 0961600080ffff0000ff = 2: hmu Status01'
+- 1018b5110100 / 09bf0211001f10008000 = 18
+- '1018b5110101 / 0966710080ff7d0000ff = 2: v32 Status01'
+- '1018b5110102 / 06033c88468c5c = 1: v32 Status02'
+- '1026b5230106 / 100402e40191010080008000800080403d = 5: vr_71 SensorData1'
+- '1026b5230107 / 0f008000800080008000008000805705 = 5: vr_71 SensorData2'
+- 1076b5040100 / 0a0320151122080626a21c = 20
+- 1076b5110101 / 095b5ca21cff620000ff = 116
+- 10feb505025c00 = 20
+- 10feb508020900 = 2
+- 10feb510020601 = 3
+- '10feb5160301141c = 1: Broadcast Outsidetemp'
+- '3115b5090124 / 09003231323235313030 = 1: Scan.15 Id'
+- '3118b5090124 / 09003231323234313030 = 1: Scan.18 Id'
+- '3126b5090124 / 09003231323234323030 = 1: Scan.26 Id'
+- '3135b5090124 / 09003231323231383030 = 1: Scan.35 Id'
+- '3176b5090124 / 09003231323330333030 = 1: Scan.76 Id'
+- '31f6b5090124 / 09003231323234353030 = 1: Scan.f6 Id'
+- 7108b5110107 / 0a000b00c0003000000000 = 321
+- f108b5110100 / 09010310000000000000 = 4
+- f118b5110100 / 09c40211001f10008000 = 3
+- f176b5160114 / 09000000404000000000 = 18
+- '3108b5040100 / 0a00ffffffffffffff0080 = 1: hmu DateTime'
+- '3108b5040116 / 00 = 1: hmu Status16'
+- '1008b5110101 / 09605c0080ffff0000ff = 138: hmu Status01'
+- '3108b5110103 / 00 = 1: hmu Status'
+- '3108b5160114 / 00 = 1: hmu PowerConsumptionHmu'
+- '3118b5040100 / 0a00ffffffffffffff0080 = 1: v32 DateTime'
+- '3118b5040116 / 00 = 1: v32 Status16'
+- '1018b5110101 / 09576b0080ff7c0000ff = 115: v32 Status01'
+- '1018b5110102 / 06033c88468c5c = 40: v32 Status02'
+- '3118b5110103 / 00 = 1: v32 Status'
+- '1026b5230106 / 100302e3018f010080008000800080403d = 101: vr_71 SensorData1'
+- '1026b5230107 / 0f008000800080008000008000805705 = 99: vr_71 SensorData2'
+- '1026b5230f05ffff00000000ffffffff00000000 / 0101 = 108: vr_71 SetActorState'
+- 1008b507020900 / 02ac06 = 19
+- 1008b5120204ff / 00 = 3
+- 1008b513020528 / 0101 = 3
+- 1018b5120204ff / 0101 = 4
+- 1018b513020508 / 0101 = 3
+- 7108b509022802 / 0c020005165f0100484d553031 = 3
+- 'f108b503020001 / 0affffffffffffffffffff = 1: hmu Currenterror'
+- f108b503020002 / 0affffffffffffffffffff = 19
+- f108b503020003 / 0a6400ffffffffffffffff = 8
+- f108b503020004 / 0affffffffffffffffffff = 19
+- f108b503020005 / 00 = 21
+- 'f115b503020001 / 0affffffffffffffffffff = 2: ctlv2 Currenterror'
+- f115b503020002 / 0affffffffffffffffffff = 20
+- 'f118b503020001 / 0affffffffffffffffffff = 1: v32 Currenterror'
+- f118b503020002 / 0affffffffffffffffffff = 18
+- f118b503020003 / 0a1f00ffffffffffffffff = 8
+- f118b503020004 / 0affffffffffffffffffff = 20
+- f118b503020005 / 0affffffffffffffffffff = 15
+- f176b503020001 / 0affffffffffffffffffff = 21
+- 'f108b503020001 / 0affffffffffffffffffff = 20: hmu Currenterror'
+- 'f115b503020001 / 0affffffffffffffffffff = 18: ctlv2 Currenterror'
+- 'f118b503020001 / 0affffffffffffffffffff = 17: v32 Currenterror'
+- '3126b503020001 / 0affffffffffffffffffff = 1: vr_71 Currenterror'
+- '1026b5230402000000 / 02019c = 115: vr_71 Mc1Operation'
+- '1026b5230402010000 / 02019c = 117: vr_71 Mc2Operation'
+- 1018b5100305ff03 / 0101 = 3
+- 1076b512030f0201 / 07150300da0210ff = 112
+- 7108b51a03040036 / 0e0000000000000000000000000000 = 1
+- 7108b51a03040632 / 0e0607c0cfc07b3c00b01b20000000 = 1
+- 7108b51a03040733 / 0e070000008a000000000000000000 = 1
+- 7108b51a03040834 / 0e08cf2000c002210100180006d800 = 1
+- 7108b51a03041032 / 0e1007c0cfc07b3c00b01b20000000 = 1
+- 7108b51a03041133 / 0e110000008a000000000000000000 = 1
+- 7108b51a03041335 / 0e1300000000000100b00100000000 = 1
+- 7108b51a03041436 / 0e1400000000000000000000000000 = 1
+- 7108b51a03041a32 / 0e1a07c0cfc07b3c00b01b20000000 = 1
+- 7108b51a03041b33 / 0e1b0000008a000000000000000000 = 1
+- 7108b51a03041c34 / 0e1ccf2000c002210100180006d800 = 1
+- 7108b51a03041d35 / 0e1d00000000000100b00100000000 = 1
+- 7108b51a03041e36 / 0e1e00000000000000000000000000 = 1
+- 7108b51a03042f33 / 0e2f0000008a000000000000000000 = 1
+- 7108b51a03043034 / 0e30cf2000c002210100180006d800 = 1
+- 7108b51a03043135 / 0e3100000000000100b00100000000 = 1
+- 7108b51a03043236 / 0e3200000000000000000000000000 = 1
+- 7108b51a03043832 / 0e3807c0cfc07b3c00b01b20000000 = 1
+- 7108b51a03043933 / 0e390000008a000000000000000000 = 1
+- 7108b51a03043a34 / 0e3acf2000c002210100180006d800 = 1
+- 7108b51a03043b35 / 0e3b00000000000100b00100000000 = 1
+- 7108b51a03043c36 / 0e3c00000000000000000000000000 = 1
+- 7108b51a03044232 / 0e4207c0cfc07b3c00b01b20000000 = 1
+- 7108b51a03044333 / 0e430000008a000000000000000000 = 1
+- 7108b51a03044434 / 0e44cf2000c002210100180006d800 = 1
+- 7108b51a03044c32 / 0e4c07c0cfc07b3c00b01b20000000 = 1
+- 7108b51a03044d33 / 0e4d0000008a000000000000000000 = 1
+- 7108b51a03044e34 / 0e4ecf2000c002210100180006d800 = 1
+- 7108b51a03044f35 / 0e4f00000000000100b00100000000 = 1
+- 7108b51a03045036 / 0e5000000000000000000000000000 = 1
+- 7108b51a03045632 / 0e5607c0cfc07b3c00b01b20000000 = 1
+- 7108b51a03045733 / 0e570000008a000000000000000000 = 1
+- 7108b51a03045834 / 0e58cf2000c002210100180006d800 = 1
+- 7108b51a03045935 / 0e5900000000000100b00100000000 = 1
+- 7108b51a03045a36 / 0e5a00000000000000000000000000 = 1
+- 7108b51a03046032 / 0e6007c0cfc07b3c00b01b20000000 = 1
+- 7108b51a03046133 / 0e610000008a000000000000000000 = 1
+- 7108b51a03046234 / 0e62cf2000c002210100180006d800 = 1
+- 7108b51a03046335 / 0e6300000000000100b00100000000 = 1
+- 7108b51a03046436 / 0e6400000000000000000000000000 = 1
+- 7108b51a03046a32 / 0e6a07c0cfc07b3c00b01b20000000 = 1
+- 7108b51a03046b33 / 0e6b0000008a000000000000000000 = 1
+- 7108b51a03046c34 / 0e6ccf2000c002210100180006d800 = 1
+- 7108b51a03046d35 / 0e6d00000000000100b00100000000 = 1
+- 7108b51a03046e36 / 0e6e00000000000000000000000000 = 1
+- 7108b51a03047432 / 0e7407c0cfc07b3c00b01b20000000 = 1
+- 7108b51a03047533 / 0e750000008a000000000000000000 = 1
+- 7108b51a03047634 / 0e76cf2000c002210100180006d800 = 1
+- 7108b51a03047735 / 0e7700000000000100b00100000000 = 1
+- 7108b51a03047836 / 0e7800000000000000000000000000 = 1
+- 7108b51a03047e32 / 0e7e07c0cfc07b3c00b01b20000000 = 1
+- 7108b51a03047f33 / 0e7f0000008a000000000000000000 = 1
+- 7108b51a03048034 / 0e80cf2000c002210100180006d800 = 1
+- 7108b51a03048135 / 0e8100000000000100b00100000000 = 1
+- 7108b51a03048236 / 0e8200000000000000000000000000 = 1
+- 7108b51a03048832 / 0e8807c0cfc07b3c00b01b20000000 = 1
+- 7108b51a03048933 / 0e890000008a000000000000000000 = 1
+- 7108b51a03048a34 / 0e8acf2000c002210100180006d800 = 1
+- 7108b51a03048b35 / 0e8b00000000000100b00100000000 = 1
+- 7108b51a03048c36 / 0e8c00000000000000000000000000 = 1
+- 7108b51a03049232 / 0e9207c0cfc07b3c00b01b20000000 = 1
+- 7108b51a03049333 / 0e930000008a000000000000000000 = 1
+- 7108b51a03049434 / 0e94cf2000c002210100180006d800 = 1
+- 7108b51a03049535 / 0e9500000000000100b00100000000 = 1
+- 7108b51a03049636 / 0e9600000000000000000000000000 = 1
+- 7108b51a03049c32 / 0e9c07c0cfc07b3c00b01b20000000 = 1
+- 7108b51a03049d33 / 0e9d0000008a000000000000000000 = 1
+- 7108b51a03049e34 / 0e9ecf2000c002210100180006d800 = 1
+- 7108b51a03049f35 / 0e9f00000000000100b00100000000 = 1
+- 7108b51a0304a036 / 0ea000000000000000000000000000 = 1
+- 7108b51a0304a632 / 0ea607c0cfc07b3c00b01b20000000 = 1
+- 7108b51a0304a733 / 0ea70000008a000000000000000000 = 1
+- 7108b51a0304a834 / 0ea8cf2000c002210100180006d800 = 1
+- 7108b51a0304a935 / 0ea900000000000100b00100000000 = 1
+- 7108b51a0304aa36 / 0eaa00000000000000000000000000 = 1
+- 7108b51a0304de32 / 0ede07c0cfc07b3c00b01b20000000 = 1
+- 7108b51a0304df33 / 0edf0000008a000000000000000000 = 1
+- 7108b51a0304e034 / 0ee0cf2000c002210100180006d800 = 1
+- 7108b51a0304e135 / 0ee100000000000100b00100000000 = 1
+- 7108b51a0304e236 / 0ee200000000000000000000000000 = 1
+- 7108b51a0304e832 / 0ee807c0cfc07b3c00b01b20000000 = 1
+- 7108b51a0304e933 / 0ee90000008a000000000000000000 = 1
+- 7108b51a0304ea34 / 0eeacf2000c002210100180006d800 = 1
+- 7108b51a0304eb35 / 0eeb00000000000100b00100000000 = 1
+- 7108b51a0304ec36 / 0eec00000000000000000000000000 = 1
+- 7108b51a0304f232 / 0ef207c0cfc07b3c00b01b20000000 = 1
+- 7108b51a0304f333 / 0ef30000008a000000000000000000 = 1
+- 7108b51a0304f434 / 0ef4cf2000c002210100180006d800 = 1
+- 7108b51a0304f535 / 0ef500000000000100b00100000000 = 1
+- 7108b51a0304f636 / 0ef600000000000000000000000000 = 1
+- 7108b51a0304fc32 / 0efc07c0cfc07b3c00b01b20000000 = 1
+- 7108b51a0304fd33 / 0efd0000008a000000000000000000 = 1
+- 7108b51a0304fe34 / 0efecf2000c002210100180006d800 = 1
+- 7108b51a0304ff35 / 0eff00000000000100b00100000000 = 1
+- '3115b55503a30002 / 0900030a0a0101234600 = 1: ctlv2 HwcTimer_Config'
+- '3115b55503a30003 / 0900030a000000ffff00 = 2: ctlv2 CcTimer_Config'
+- '3115b55503a40003 / 09000101010101010100 = 2: ctlv2 CcTimer_Timeframes'
+- '3118b509030d0200 / 03eb0600 = 1: v32 WaterPressure'
+- '3118b509030d0400 / 02e002 = 1: v32 StorageTempDesired'
+- '3118b509030d0b04 / 0100 = 1: v32 SecondPumpMode'
+- '3118b509030d1100 / 0100 = 1: v32 TempGradientFailure'
+- '3118b509030d1200 / 0100 = 1: v32 TempDiffBlock'
+- '3118b509030d1300 / 0100 = 1: v32 TempDiffFailure'
+- '3118b509030d1400 / 028500 = 1: v32 PumpHours'
+- '3118b509030d1500 / 02f008 = 1: v32 HcPumpStarts'
+- '3118b509030d1600 / 03410755 = 1: v32 HwcTemp'
+- '3118b509030d1700 / 03e40300 = 1: v32 StorageTemp'
+- '3118b509030d1800 / 03f10200 = 1: v32 FlowTemp'
+- '3118b509030d1a00 / 029609 = 1: v32 ValveStarts'
+- '3118b509030d1b00 / 026000 = 1: v32 FanHours'
+- '3118b509030d1c00 / 02bc01 = 1: v32 FanStarts'
+- '3118b509030d1e00 / 0101 = 1: v32 OverflowCounter'
+- '3118b509030d2000 / 0100 = 1: v32 DeactivationsTemplimiter'
+- '3118b509030d2004 / 0402000000 = 1: v32 HoursTillService'
+- '3118b509030d2200 / 022900 = 1: v32 HwcHours'
+- '3118b509030d2300 / 020000 = 1: v32 HwcStarts'
+- '3118b509030d2500 / 00 = 1: v32 ExternalFlowTempDesired'
+- '[grab stop] grab stopped'
+labeled_telegrams:
+- msgid: '0704'
+  master: '31'
+  slave: 08
+  sub: '00'
+  resp: 0ab5484d55303005225103
+  count: '1'
+  label: scan.08
+- msgid: '0704'
+  master: '31'
+  slave: '15'
+  sub: '00'
+  resp: 0ab543544c563205141104
+  count: '1'
+  label: scan.15
+- msgid: b509
+  master: '31'
+  slave: '15'
+  sub: '0127'
+  resp: 094e3930303030303030
+  count: '7'
+  label: Scan.15 Id
+- msgid: '0704'
+  master: '31'
+  slave: '18'
+  sub: '00'
+  resp: 0ab5563332000001066004
+  count: '1'
+  label: scan.18
+- msgid: b509
+  master: '31'
+  slave: '18'
+  sub: '0127'
+  resp: 094e393c3c3c3c3c3c3c
+  count: '3'
+  label: Scan.18 Id
+- msgid: '0704'
+  master: '31'
+  slave: '26'
+  sub: '00'
+  resp: 0ab556525f373101005904
+  count: '1'
+  label: scan.26
+- msgid: b509
+  master: '31'
+  slave: '26'
+  sub: '0127'
+  resp: 094e3700000000000000
+  count: '3'
+  label: Scan.26 Id
+- msgid: '0704'
+  master: '31'
+  slave: '35'
+  sub: '00'
+  resp: 0ab556525f393205141204
+  count: '1'
+  label: scan.35
+- msgid: b509
+  master: '31'
+  slave: '35'
+  sub: '0127'
+  resp: 094e3230303030303030
+  count: '3'
+  label: Scan.35 Id
+- msgid: '0704'
+  master: '31'
+  slave: '76'
+  sub: '00'
+  resp: 0ab556575a494f09015103
+  count: '1'
+  label: scan.76
+- msgid: b509
+  master: '31'
+  slave: '76'
+  sub: '0127'
+  resp: 094e323c3c3c3c3c3c3c
+  count: '3'
+  label: Scan.76 Id
+- msgid: '0704'
+  master: '31'
+  slave: f6
+  sub: '00'
+  resp: 0ab54e4554583301290404
+  count: '1'
+  label: scan.f6
+- msgid: b509
+  master: '31'
+  slave: f6
+  sub: '0127'
+  resp: 094e30ffffffffffffff
+  count: '3'
+  label: Scan.f6 Id
+- msgid: 07fe
+  master: '31'
+  slave: fe
+  sub: '00'
+  resp: null
+  count: '1'
+  label: Broadcast Queryexistence
+- msgid: b510
+  master: '10'
+  slave: 08
+  sub: 09000000ffffff070000
+  resp: '0101'
+  count: '109'
+  label: hmu SetMode
+- msgid: b512
+  master: '10'
+  slave: 08
+  sub: '020064'
+  resp: '00'
+  count: '3'
+  label: hmu StatusCirPump
+- msgid: b510
+  master: '10'
+  slave: '18'
+  sub: 09000000ffffff010000
+  resp: '0101'
+  count: '115'
+  label: v32 SetMode
+- msgid: b512
+  master: '10'
+  slave: '18'
+  sub: '020064'
+  resp: '00'
+  count: '3'
+  label: v32 StatusCirPump
+- msgid: b516
+  master: '10'
+  slave: fe
+  sub: 080015151122080626
+  resp: null
+  count: '19'
+  label: Broadcast Vdatetime
+- msgid: b516
+  master: '10'
+  slave: fe
+  sub: 0301951c
+  resp: null
+  count: '17'
+  label: Broadcast Outsidetemp
+- msgid: b511
+  master: '10'
+  slave: 08
+  sub: '0101'
+  resp: 0961600080ffff0000ff
+  count: '2'
+  label: hmu Status01
+- msgid: b511
+  master: '10'
+  slave: '18'
+  sub: '0101'
+  resp: 0966710080ff7d0000ff
+  count: '2'
+  label: v32 Status01
+- msgid: b511
+  master: '10'
+  slave: '18'
+  sub: '0102'
+  resp: 06033c88468c5c
+  count: '1'
+  label: v32 Status02
+- msgid: b523
+  master: '10'
+  slave: '26'
+  sub: '0106'
+  resp: 100402e40191010080008000800080403d
+  count: '5'
+  label: vr_71 SensorData1
+- msgid: b523
+  master: '10'
+  slave: '26'
+  sub: '0107'
+  resp: 0f008000800080008000008000805705
+  count: '5'
+  label: vr_71 SensorData2
+- msgid: b516
+  master: '10'
+  slave: fe
+  sub: 0301141c
+  resp: null
+  count: '1'
+  label: Broadcast Outsidetemp
+- msgid: b509
+  master: '31'
+  slave: '15'
+  sub: '0124'
+  resp: 09003231323235313030
+  count: '1'
+  label: Scan.15 Id
+- msgid: b509
+  master: '31'
+  slave: '18'
+  sub: '0124'
+  resp: 09003231323234313030
+  count: '1'
+  label: Scan.18 Id
+- msgid: b509
+  master: '31'
+  slave: '26'
+  sub: '0124'
+  resp: 09003231323234323030
+  count: '1'
+  label: Scan.26 Id
+- msgid: b509
+  master: '31'
+  slave: '35'
+  sub: '0124'
+  resp: 09003231323231383030
+  count: '1'
+  label: Scan.35 Id
+- msgid: b509
+  master: '31'
+  slave: '76'
+  sub: '0124'
+  resp: 09003231323330333030
+  count: '1'
+  label: Scan.76 Id
+- msgid: b509
+  master: '31'
+  slave: f6
+  sub: '0124'
+  resp: 09003231323234353030
+  count: '1'
+  label: Scan.f6 Id
+- msgid: b504
+  master: '31'
+  slave: 08
+  sub: '0100'
+  resp: 0a00ffffffffffffff0080
+  count: '1'
+  label: hmu DateTime
+- msgid: b504
+  master: '31'
+  slave: 08
+  sub: '0116'
+  resp: '00'
+  count: '1'
+  label: hmu Status16
+- msgid: b511
+  master: '10'
+  slave: 08
+  sub: '0101'
+  resp: 09605c0080ffff0000ff
+  count: '138'
+  label: hmu Status01
+- msgid: b511
+  master: '31'
+  slave: 08
+  sub: '0103'
+  resp: '00'
+  count: '1'
+  label: hmu Status
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: '0114'
+  resp: '00'
+  count: '1'
+  label: hmu PowerConsumptionHmu
+- msgid: b504
+  master: '31'
+  slave: '18'
+  sub: '0100'
+  resp: 0a00ffffffffffffff0080
+  count: '1'
+  label: v32 DateTime
+- msgid: b504
+  master: '31'
+  slave: '18'
+  sub: '0116'
+  resp: '00'
+  count: '1'
+  label: v32 Status16
+- msgid: b511
+  master: '10'
+  slave: '18'
+  sub: '0101'
+  resp: 09576b0080ff7c0000ff
+  count: '115'
+  label: v32 Status01
+- msgid: b511
+  master: '10'
+  slave: '18'
+  sub: '0102'
+  resp: 06033c88468c5c
+  count: '40'
+  label: v32 Status02
+- msgid: b511
+  master: '31'
+  slave: '18'
+  sub: '0103'
+  resp: '00'
+  count: '1'
+  label: v32 Status
+- msgid: b523
+  master: '10'
+  slave: '26'
+  sub: '0106'
+  resp: 100302e3018f010080008000800080403d
+  count: '101'
+  label: vr_71 SensorData1
+- msgid: b523
+  master: '10'
+  slave: '26'
+  sub: '0107'
+  resp: 0f008000800080008000008000805705
+  count: '99'
+  label: vr_71 SensorData2
+- msgid: b523
+  master: '10'
+  slave: '26'
+  sub: 0f05ffff00000000ffffffff00000000
+  resp: '0101'
+  count: '108'
+  label: vr_71 SetActorState
+- msgid: b503
+  master: f1
+  slave: 08
+  sub: '020001'
+  resp: 0affffffffffffffffffff
+  count: '1'
+  label: hmu Currenterror
+- msgid: b503
+  master: f1
+  slave: '15'
+  sub: '020001'
+  resp: 0affffffffffffffffffff
+  count: '2'
+  label: ctlv2 Currenterror
+- msgid: b503
+  master: f1
+  slave: '18'
+  sub: '020001'
+  resp: 0affffffffffffffffffff
+  count: '1'
+  label: v32 Currenterror
+- msgid: b503
+  master: f1
+  slave: 08
+  sub: '020001'
+  resp: 0affffffffffffffffffff
+  count: '20'
+  label: hmu Currenterror
+- msgid: b503
+  master: f1
+  slave: '15'
+  sub: '020001'
+  resp: 0affffffffffffffffffff
+  count: '18'
+  label: ctlv2 Currenterror
+- msgid: b503
+  master: f1
+  slave: '18'
+  sub: '020001'
+  resp: 0affffffffffffffffffff
+  count: '17'
+  label: v32 Currenterror
+- msgid: b503
+  master: '31'
+  slave: '26'
+  sub: '020001'
+  resp: 0affffffffffffffffffff
+  count: '1'
+  label: vr_71 Currenterror
+- msgid: b523
+  master: '10'
+  slave: '26'
+  sub: '0402000000'
+  resp: 02019c
+  count: '115'
+  label: vr_71 Mc1Operation
+- msgid: b523
+  master: '10'
+  slave: '26'
+  sub: '0402010000'
+  resp: 02019c
+  count: '117'
+  label: vr_71 Mc2Operation
+- msgid: b555
+  master: '31'
+  slave: '15'
+  sub: 03a30002
+  resp: 0900030a0a0101234600
+  count: '1'
+  label: ctlv2 HwcTimer_Config
+- msgid: b555
+  master: '31'
+  slave: '15'
+  sub: 03a30003
+  resp: 0900030a000000ffff00
+  count: '2'
+  label: ctlv2 CcTimer_Config
+- msgid: b555
+  master: '31'
+  slave: '15'
+  sub: 03a40003
+  resp: 09000101010101010100
+  count: '2'
+  label: ctlv2 CcTimer_Timeframes
+- msgid: b509
+  master: '31'
+  slave: '18'
+  sub: 030d0200
+  resp: 03eb0600
+  count: '1'
+  label: v32 WaterPressure
+- msgid: b509
+  master: '31'
+  slave: '18'
+  sub: 030d0400
+  resp: 02e002
+  count: '1'
+  label: v32 StorageTempDesired
+- msgid: b509
+  master: '31'
+  slave: '18'
+  sub: 030d0b04
+  resp: '0100'
+  count: '1'
+  label: v32 SecondPumpMode
+- msgid: b509
+  master: '31'
+  slave: '18'
+  sub: 030d1100
+  resp: '0100'
+  count: '1'
+  label: v32 TempGradientFailure
+- msgid: b509
+  master: '31'
+  slave: '18'
+  sub: 030d1200
+  resp: '0100'
+  count: '1'
+  label: v32 TempDiffBlock
+- msgid: b509
+  master: '31'
+  slave: '18'
+  sub: 030d1300
+  resp: '0100'
+  count: '1'
+  label: v32 TempDiffFailure
+- msgid: b509
+  master: '31'
+  slave: '18'
+  sub: 030d1400
+  resp: 028500
+  count: '1'
+  label: v32 PumpHours
+- msgid: b509
+  master: '31'
+  slave: '18'
+  sub: 030d1500
+  resp: 02f008
+  count: '1'
+  label: v32 HcPumpStarts
+- msgid: b509
+  master: '31'
+  slave: '18'
+  sub: 030d1600
+  resp: '03410755'
+  count: '1'
+  label: v32 HwcTemp
+- msgid: b509
+  master: '31'
+  slave: '18'
+  sub: 030d1700
+  resp: 03e40300
+  count: '1'
+  label: v32 StorageTemp
+- msgid: b509
+  master: '31'
+  slave: '18'
+  sub: 030d1800
+  resp: 03f10200
+  count: '1'
+  label: v32 FlowTemp
+- msgid: b509
+  master: '31'
+  slave: '18'
+  sub: 030d1a00
+  resp: 029609
+  count: '1'
+  label: v32 ValveStarts
+- msgid: b509
+  master: '31'
+  slave: '18'
+  sub: 030d1b00
+  resp: '026000'
+  count: '1'
+  label: v32 FanHours
+- msgid: b509
+  master: '31'
+  slave: '18'
+  sub: 030d1c00
+  resp: 02bc01
+  count: '1'
+  label: v32 FanStarts
+- msgid: b509
+  master: '31'
+  slave: '18'
+  sub: 030d1e00
+  resp: '0101'
+  count: '1'
+  label: v32 OverflowCounter
+- msgid: b509
+  master: '31'
+  slave: '18'
+  sub: 030d2000
+  resp: '0100'
+  count: '1'
+  label: v32 DeactivationsTemplimiter
+- msgid: b509
+  master: '31'
+  slave: '18'
+  sub: 030d2004
+  resp: '0402000000'
+  count: '1'
+  label: v32 HoursTillService
+- msgid: b509
+  master: '31'
+  slave: '18'
+  sub: 030d2200
+  resp: 022900
+  count: '1'
+  label: v32 HwcHours
+- msgid: b509
+  master: '31'
+  slave: '18'
+  sub: 030d2300
+  resp: '020000'
+  count: '1'
+  label: v32 HwcStarts
+- msgid: b509
+  master: '31'
+  slave: '18'
+  sub: 030d2500
+  resp: '00'
+  count: '1'
+  label: v32 ExternalFlowTempDesired
+unknown_telegrams:
+- msgid: b511
+  master: '10'
+  slave: 08
+  sub: '0100'
+  resp: 09000310000000000000
+  count: '15'
+  label: null
+- msgid: b511
+  master: '10'
+  slave: '18'
+  sub: '0100'
+  resp: 09bf0211001f10008000
+  count: '18'
+  label: null
+- msgid: b504
+  master: '10'
+  slave: '76'
+  sub: '0100'
+  resp: 0a0320151122080626a21c
+  count: '20'
+  label: null
+- msgid: b511
+  master: '10'
+  slave: '76'
+  sub: '0101'
+  resp: 095b5ca21cff620000ff
+  count: '116'
+  label: null
+- msgid: b505
+  master: '10'
+  slave: fe
+  sub: 025c00
+  resp: null
+  count: '20'
+  label: null
+- msgid: b508
+  master: '10'
+  slave: fe
+  sub: 020900
+  resp: null
+  count: '2'
+  label: null
+- msgid: b510
+  master: '10'
+  slave: fe
+  sub: '020601'
+  resp: null
+  count: '3'
+  label: null
+- msgid: b511
+  master: '71'
+  slave: 08
+  sub: '0107'
+  resp: 0a000b00c0003000000000
+  count: '321'
+  label: null
+- msgid: b511
+  master: f1
+  slave: 08
+  sub: '0100'
+  resp: 09010310000000000000
+  count: '4'
+  label: null
+- msgid: b511
+  master: f1
+  slave: '18'
+  sub: '0100'
+  resp: 09c40211001f10008000
+  count: '3'
+  label: null
+- msgid: b516
+  master: f1
+  slave: '76'
+  sub: '0114'
+  resp: 09000000404000000000
+  count: '18'
+  label: null
+- msgid: b507
+  master: '10'
+  slave: 08
+  sub: 020900
+  resp: 02ac06
+  count: '19'
+  label: null
+- msgid: b512
+  master: '10'
+  slave: 08
+  sub: 0204ff
+  resp: '00'
+  count: '3'
+  label: null
+- msgid: b513
+  master: '10'
+  slave: 08
+  sub: 020528
+  resp: '0101'
+  count: '3'
+  label: null
+- msgid: b512
+  master: '10'
+  slave: '18'
+  sub: 0204ff
+  resp: '0101'
+  count: '4'
+  label: null
+- msgid: b513
+  master: '10'
+  slave: '18'
+  sub: 020508
+  resp: '0101'
+  count: '3'
+  label: null
+- msgid: b509
+  master: '71'
+  slave: 08
+  sub: 022802
+  resp: 0c020005165f0100484d553031
+  count: '3'
+  label: null
+- msgid: b503
+  master: f1
+  slave: 08
+  sub: '020002'
+  resp: 0affffffffffffffffffff
+  count: '19'
+  label: null
+- msgid: b503
+  master: f1
+  slave: 08
+  sub: '020003'
+  resp: 0a6400ffffffffffffffff
+  count: '8'
+  label: null
+- msgid: b503
+  master: f1
+  slave: 08
+  sub: '020004'
+  resp: 0affffffffffffffffffff
+  count: '19'
+  label: null
+- msgid: b503
+  master: f1
+  slave: 08
+  sub: '020005'
+  resp: '00'
+  count: '21'
+  label: null
+- msgid: b503
+  master: f1
+  slave: '15'
+  sub: '020002'
+  resp: 0affffffffffffffffffff
+  count: '20'
+  label: null
+- msgid: b503
+  master: f1
+  slave: '18'
+  sub: '020002'
+  resp: 0affffffffffffffffffff
+  count: '18'
+  label: null
+- msgid: b503
+  master: f1
+  slave: '18'
+  sub: '020003'
+  resp: 0a1f00ffffffffffffffff
+  count: '8'
+  label: null
+- msgid: b503
+  master: f1
+  slave: '18'
+  sub: '020004'
+  resp: 0affffffffffffffffffff
+  count: '20'
+  label: null
+- msgid: b503
+  master: f1
+  slave: '18'
+  sub: '020005'
+  resp: 0affffffffffffffffffff
+  count: '15'
+  label: null
+- msgid: b503
+  master: f1
+  slave: '76'
+  sub: '020001'
+  resp: 0affffffffffffffffffff
+  count: '21'
+  label: null
+- msgid: b510
+  master: '10'
+  slave: '18'
+  sub: 0305ff03
+  resp: '0101'
+  count: '3'
+  label: null
+- msgid: b512
+  master: '10'
+  slave: '76'
+  sub: 030f0201
+  resp: 07150300da0210ff
+  count: '112'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03040036'
+  resp: 0e0000000000000000000000000000
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03040632'
+  resp: 0e0607c0cfc07b3c00b01b20000000
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03040733'
+  resp: 0e070000008a000000000000000000
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03040834
+  resp: 0e08cf2000c002210100180006d800
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03041032'
+  resp: 0e1007c0cfc07b3c00b01b20000000
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03041133'
+  resp: 0e110000008a000000000000000000
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03041335'
+  resp: 0e1300000000000100b00100000000
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03041436'
+  resp: 0e1400000000000000000000000000
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03041a32
+  resp: 0e1a07c0cfc07b3c00b01b20000000
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03041b33
+  resp: 0e1b0000008a000000000000000000
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03041c34
+  resp: 0e1ccf2000c002210100180006d800
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03041d35
+  resp: 0e1d00000000000100b00100000000
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03041e36
+  resp: 0e1e00000000000000000000000000
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03042f33
+  resp: 0e2f0000008a000000000000000000
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03043034'
+  resp: 0e30cf2000c002210100180006d800
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03043135'
+  resp: 0e3100000000000100b00100000000
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03043236'
+  resp: 0e3200000000000000000000000000
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03043832
+  resp: 0e3807c0cfc07b3c00b01b20000000
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03043933
+  resp: 0e390000008a000000000000000000
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03043a34
+  resp: 0e3acf2000c002210100180006d800
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03043b35
+  resp: 0e3b00000000000100b00100000000
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03043c36
+  resp: 0e3c00000000000000000000000000
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03044232'
+  resp: 0e4207c0cfc07b3c00b01b20000000
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03044333'
+  resp: 0e430000008a000000000000000000
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03044434'
+  resp: 0e44cf2000c002210100180006d800
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03044c32
+  resp: 0e4c07c0cfc07b3c00b01b20000000
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03044d33
+  resp: 0e4d0000008a000000000000000000
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03044e34
+  resp: 0e4ecf2000c002210100180006d800
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03044f35
+  resp: 0e4f00000000000100b00100000000
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03045036'
+  resp: 0e5000000000000000000000000000
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03045632'
+  resp: 0e5607c0cfc07b3c00b01b20000000
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03045733'
+  resp: 0e570000008a000000000000000000
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03045834
+  resp: 0e58cf2000c002210100180006d800
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03045935
+  resp: 0e5900000000000100b00100000000
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03045a36
+  resp: 0e5a00000000000000000000000000
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03046032'
+  resp: 0e6007c0cfc07b3c00b01b20000000
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03046133'
+  resp: 0e610000008a000000000000000000
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03046234'
+  resp: 0e62cf2000c002210100180006d800
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03046335'
+  resp: 0e6300000000000100b00100000000
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03046436'
+  resp: 0e6400000000000000000000000000
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03046a32
+  resp: 0e6a07c0cfc07b3c00b01b20000000
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03046b33
+  resp: 0e6b0000008a000000000000000000
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03046c34
+  resp: 0e6ccf2000c002210100180006d800
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03046d35
+  resp: 0e6d00000000000100b00100000000
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03046e36
+  resp: 0e6e00000000000000000000000000
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03047432'
+  resp: 0e7407c0cfc07b3c00b01b20000000
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03047533'
+  resp: 0e750000008a000000000000000000
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03047634'
+  resp: 0e76cf2000c002210100180006d800
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03047735'
+  resp: 0e7700000000000100b00100000000
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03047836
+  resp: 0e7800000000000000000000000000
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03047e32
+  resp: 0e7e07c0cfc07b3c00b01b20000000
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03047f33
+  resp: 0e7f0000008a000000000000000000
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03048034
+  resp: 0e80cf2000c002210100180006d800
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03048135
+  resp: 0e8100000000000100b00100000000
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03048236
+  resp: 0e8200000000000000000000000000
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03048832
+  resp: 0e8807c0cfc07b3c00b01b20000000
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03048933
+  resp: 0e890000008a000000000000000000
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03048a34
+  resp: 0e8acf2000c002210100180006d800
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03048b35
+  resp: 0e8b00000000000100b00100000000
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03048c36
+  resp: 0e8c00000000000000000000000000
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03049232
+  resp: 0e9207c0cfc07b3c00b01b20000000
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03049333
+  resp: 0e930000008a000000000000000000
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03049434
+  resp: 0e94cf2000c002210100180006d800
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03049535
+  resp: 0e9500000000000100b00100000000
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03049636
+  resp: 0e9600000000000000000000000000
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03049c32
+  resp: 0e9c07c0cfc07b3c00b01b20000000
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03049d33
+  resp: 0e9d0000008a000000000000000000
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03049e34
+  resp: 0e9ecf2000c002210100180006d800
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03049f35
+  resp: 0e9f00000000000100b00100000000
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 0304a036
+  resp: 0ea000000000000000000000000000
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 0304a632
+  resp: 0ea607c0cfc07b3c00b01b20000000
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 0304a733
+  resp: 0ea70000008a000000000000000000
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 0304a834
+  resp: 0ea8cf2000c002210100180006d800
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 0304a935
+  resp: 0ea900000000000100b00100000000
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 0304aa36
+  resp: 0eaa00000000000000000000000000
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 0304de32
+  resp: 0ede07c0cfc07b3c00b01b20000000
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 0304df33
+  resp: 0edf0000008a000000000000000000
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 0304e034
+  resp: 0ee0cf2000c002210100180006d800
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 0304e135
+  resp: 0ee100000000000100b00100000000
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 0304e236
+  resp: 0ee200000000000000000000000000
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 0304e832
+  resp: 0ee807c0cfc07b3c00b01b20000000
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 0304e933
+  resp: 0ee90000008a000000000000000000
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 0304ea34
+  resp: 0eeacf2000c002210100180006d800
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 0304eb35
+  resp: 0eeb00000000000100b00100000000
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 0304ec36
+  resp: 0eec00000000000000000000000000
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 0304f232
+  resp: 0ef207c0cfc07b3c00b01b20000000
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 0304f333
+  resp: 0ef30000008a000000000000000000
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 0304f434
+  resp: 0ef4cf2000c002210100180006d800
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 0304f535
+  resp: 0ef500000000000100b00100000000
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 0304f636
+  resp: 0ef600000000000000000000000000
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 0304fc32
+  resp: 0efc07c0cfc07b3c00b01b20000000
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 0304fd33
+  resp: 0efd0000008a000000000000000000
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 0304fe34
+  resp: 0efecf2000c002210100180006d800
+  count: '1'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 0304ff35
+  resp: 0eff00000000000100b00100000000
+  count: '1'
+  label: null
+after_registers:
+- circuit: Broadcast
+  name: Datetime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Error
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: Broadcast
+  name: HwcStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Id
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: IdAnswer
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: IdQuery
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Load
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Outsidetemp
+  fields:
+  - value
+  values:
+  - '28.582'
+  writable: false
+  has_data: true
+- circuit: Broadcast
+  name: Queryexistence
+  fields:
+  - value
+  values:
+  - (empty for 31fe07fe00 / )
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Signoflife
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Vdatetime
+  fields:
+  - value
+  values:
+  - 11:15:15;22.08.2026
+  writable: false
+  has_data: true
+- circuit: Broadcast
+  name: Vdatetime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: WaterPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: General
+  name: Valuerange
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Eeprom
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Eeprom
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Ram
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Ram
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Scan
+  name: Id
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Scan.15
+  name: Id
+  fields:
+  - value
+  values:
+  - 21;22;51;0020260913;0953;045677;N9
+  writable: false
+  has_data: true
+- circuit: Scan.18
+  name: Id
+  fields:
+  - value
+  values:
+  - 21;22;41;0010022017;0001;005945;N9
+  writable: false
+  has_data: true
+- circuit: Scan.26
+  name: Id
+  fields:
+  - value
+  values:
+  - 21;22;42;0020184847;0082;020249;N7
+  writable: false
+  has_data: true
+- circuit: Scan.35
+  name: Id
+  fields:
+  - value
+  values:
+  - 21;22;18;0020260925;0953;009293;N2
+  writable: false
+  has_data: true
+- circuit: Scan.76
+  name: Id
+  fields:
+  - value
+  values:
+  - 21;23;03;0010034193;1610;005152;N2
+  writable: false
+  has_data: true
+- circuit: Scan.f6
+  name: Id
+  fields:
+  - value
+  values:
+  - 21;22;45;0020292012;0933;083357;N0
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: AdaptHeatCurve
+  fields:
+  - value
+  values:
+  - 'no'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: AdaptHeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: CcTimer_Config
+  fields:
+  - value
+  values:
+  - 00 03 0a 00 00 00 ff ff 00
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: CcTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: CcTimer_Friday0
+  fields:
+  - value
+  values:
+  - 06:00;22:00
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: CcTimer_Friday1
+  fields:
+  - value
+  values:
+  - 00:00;00:00
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: CcTimer_Friday2
+  fields:
+  - value
+  values:
+  - 00:00;00:00
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: CcTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: CcTimer_Monday0
+  fields:
+  - value
+  values:
+  - 06:00;22:00
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: CcTimer_Monday1
+  fields:
+  - value
+  values:
+  - 00:00;00:00
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: CcTimer_Monday2
+  fields:
+  - value
+  values:
+  - 00:00;00:00
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: CcTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: CcTimer_Saturday0
+  fields:
+  - value
+  values:
+  - 07:30;23:30
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: CcTimer_Saturday1
+  fields:
+  - value
+  values:
+  - 00:00;00:00
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: CcTimer_Saturday2
+  fields:
+  - value
+  values:
+  - 00:00;00:00
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: CcTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: CcTimer_Sunday0
+  fields:
+  - value
+  values:
+  - 07:30;22:00
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: CcTimer_Sunday1
+  fields:
+  - value
+  values:
+  - 00:00;00:00
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: CcTimer_Sunday2
+  fields:
+  - value
+  values:
+  - 00:00;00:00
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: CcTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: CcTimer_Thursday0
+  fields:
+  - value
+  values:
+  - 06:00;22:00
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: CcTimer_Thursday1
+  fields:
+  - value
+  values:
+  - 00:00;00:00
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: CcTimer_Thursday2
+  fields:
+  - value
+  values:
+  - 00:00;00:00
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: CcTimer_Timeframes
+  fields:
+  - value
+  values:
+  - 1;1;1;1;1;1;1
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: CcTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: CcTimer_Tuesday0
+  fields:
+  - value
+  values:
+  - 06:00;22:00
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: CcTimer_Tuesday1
+  fields:
+  - value
+  values:
+  - 00:00;00:00
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: CcTimer_Tuesday2
+  fields:
+  - value
+  values:
+  - 00:00;00:00
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: CcTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: CcTimer_Wednesday0
+  fields:
+  - value
+  values:
+  - 06:00;22:00
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: CcTimer_Wednesday1
+  fields:
+  - value
+  values:
+  - 00:00;00:00
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: CcTimer_Wednesday2
+  fields:
+  - value
+  values:
+  - 00:00;00:00
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Clearerrorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: ContinuousHeating
+  fields:
+  - value
+  values:
+  - '-26'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: ContinuousHeating
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - -;-;-;-;-
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: CylinderChargeHyst
+  fields:
+  - value
+  values:
+  - '3'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: CylinderChargeHyst
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: CylinderChargeOffset
+  fields:
+  - value
+  values:
+  - '25'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: CylinderChargeOffset
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Date
+  fields:
+  - value
+  values:
+  - 22.08.2026
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Date
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: DisplayedOutsideTemp
+  fields:
+  - value
+  values:
+  - '28.5352'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: FrostOverRideTime
+  fields:
+  - value
+  values:
+  - '4'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: FrostOverRideTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc1AutoOffMode
+  fields:
+  - value
+  values:
+  - night
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc1AutoOffMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1CircuitType
+  fields:
+  - value
+  values:
+  - mixer
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc1CoolingEnabled
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1CoolingFlowTempMin
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1DewPointMonitoring
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1DewPointOffset
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1ExcessTemp
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc1ExcessTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1FlowTemp
+  fields:
+  - value
+  values:
+  - '30.1875'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc1HeatCurve
+  fields:
+  - value
+  values:
+  - '1.7'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc1HeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc1MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '65'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc1MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - '13'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc1MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - '48'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc1MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1MixerMovement
+  fields:
+  - value
+  values:
+  - '-100'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc1PumpStatus
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc1PumpStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1RoomTempModulation
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - thermostat
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc1RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1Status
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc1Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1SummerTempLimit
+  fields:
+  - value
+  values:
+  - '40'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc1SummerTempLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc2AutoOffMode
+  fields:
+  - value
+  values:
+  - night
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc2AutoOffMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2CircuitType
+  fields:
+  - value
+  values:
+  - mixer
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc2ExcessTemp
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc2ExcessTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2FlowTemp
+  fields:
+  - value
+  values:
+  - '24.875'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc2HeatCurve
+  fields:
+  - value
+  values:
+  - '1.7'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc2HeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc2MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '65'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc2MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - '20'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc2MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - '48'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc2MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2MixerMovement
+  fields:
+  - value
+  values:
+  - '-100'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc2PumpStatus
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc2PumpStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - thermostat
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc2RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2Status
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc2Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2SummerTempLimit
+  fields:
+  - value
+  values:
+  - '40'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc2SummerTempLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc3ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc3AutoOffMode
+  fields:
+  - value
+  values:
+  - eco
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc3AutoOffMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc3CircuitType
+  fields:
+  - value
+  values:
+  - inactive
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc3ExcessTemp
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc3ExcessTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc3FlowTemp
+  fields:
+  - value
+  values:
+  - (empty for 3115b52406020002020800 / 0800020800ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc3HeatCurve
+  fields:
+  - value
+  values:
+  - '1.2'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc3HeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc3HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc3MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '90'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc3MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc3MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - '20'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc3MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc3MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - '15'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc3MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc3MixerMovement
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc3PumpStatus
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc3PumpStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc3RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'off'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc3RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc3Status
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc3Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc3SummerTempLimit
+  fields:
+  - value
+  values:
+  - '21'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Hc3SummerTempLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HcStorageTempBottom
+  fields:
+  - value
+  values:
+  - (empty for 3115b5240602000000a000 / 080000a000ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HcStorageTempTop
+  fields:
+  - value
+  values:
+  - (empty for 3115b52406020000009f00 / 0800009f00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcBankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcBankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcBankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcBankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcFlowTemp
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: HwcHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 01.01.2015
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: HwcHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 01.01.2015
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: HwcHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcLockTime
+  fields:
+  - value
+  values:
+  - '60'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: HwcLockTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcMaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '75'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: HwcMaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcOpMode
+  fields:
+  - value
+  values:
+  - day
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: HwcOpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcParallelLoading
+  fields:
+  - value
+  values:
+  - 'off'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: HwcParallelLoading
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcSFMode
+  fields:
+  - value
+  values:
+  - auto
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: HwcSFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcSfMode
+  fields:
+  - value
+  values:
+  - auto
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcStorageTemp
+  fields:
+  - value
+  values:
+  - '62'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: HwcStorageTempBottom
+  fields:
+  - value
+  values:
+  - (empty for 3115b52406020000009e00 / 0800009e00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcStorageTempTop
+  fields:
+  - value
+  values:
+  - (empty for 3115b52406020000009d00 / 0800009d00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTempDesired
+  fields:
+  - value
+  values:
+  - '46'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: HwcTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTimer_Config
+  fields:
+  - value
+  values:
+  - 00 03 0a 0a 01 01 23 46 00
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: HwcTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTimer_Friday0
+  fields:
+  - value
+  values:
+  - 05:30;22:00;46.0
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: HwcTimer_Friday1
+  fields:
+  - value
+  values:
+  - 00:00;00:00;-
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: HwcTimer_Friday2
+  fields:
+  - value
+  values:
+  - 00:00;00:00;-
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: HwcTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTimer_Monday0
+  fields:
+  - value
+  values:
+  - 05:30;22:00;46.0
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: HwcTimer_Monday1
+  fields:
+  - value
+  values:
+  - 00:00;00:00;-
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: HwcTimer_Monday2
+  fields:
+  - value
+  values:
+  - 00:00;00:00;-
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: HwcTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTimer_Saturday0
+  fields:
+  - value
+  values:
+  - 07:00;23:30;46.0
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: HwcTimer_Saturday1
+  fields:
+  - value
+  values:
+  - 00:00;00:00;-
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: HwcTimer_Saturday2
+  fields:
+  - value
+  values:
+  - 00:00;00:00;-
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: HwcTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTimer_Sunday0
+  fields:
+  - value
+  values:
+  - 07:00;22:00;46.0
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: HwcTimer_Sunday1
+  fields:
+  - value
+  values:
+  - 00:00;00:00;-
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: HwcTimer_Sunday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTimer_Thursday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTimer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTimer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTimer_Timeframes
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTimer_Tuesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTimer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTimer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTimer_Wednesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTimer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HwcTimer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: HydraulicScheme
+  fields:
+  - value
+  values:
+  - '12'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: HydraulicScheme
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Installer1
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Installer1
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Installer2
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Installer2
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: KeyCodeforConfigMenu
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: KeyCodeforConfigMenu
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: MaintenanceDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: MaintenanceDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: MaintenanceDue
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: ManualCoolingEndDate
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: ManualCoolingEndDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: ManualCoolingStartDate
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: ManualCoolingStartDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: MaxCylinderChargeTime
+  fields:
+  - value
+  values:
+  - '60'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: MaxCylinderChargeTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: MaxRoomHumidity
+  fields:
+  - value
+  values:
+  - '40'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: MaxRoomHumidity
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: MultiRelaySetting
+  fields:
+  - value
+  values:
+  - circulation
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: MultiRelaySetting
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: OutsideTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: OutsideTempAvg
+  fields:
+  - value
+  values:
+  - '26.2656'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: OutsideTempAvg
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PhoneNumber1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PhoneNumber1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PhoneNumber2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PhoneNumber2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrEnergySum
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020000005c00 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrEnergySum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrEnergySumHc
+  fields:
+  - value
+  values:
+  - '6220'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: PrEnergySumHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrEnergySumHcLastMonth
+  fields:
+  - value
+  values:
+  - '13'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: PrEnergySumHcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrEnergySumHcThisMonth
+  fields:
+  - value
+  values:
+  - '9'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: PrEnergySumHcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrEnergySumHwc
+  fields:
+  - value
+  values:
+  - '2596'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: PrEnergySumHwc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrEnergySumHwcLastMonth
+  fields:
+  - value
+  values:
+  - '24'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: PrEnergySumHwcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrEnergySumHwcThisMonth
+  fields:
+  - value
+  values:
+  - '24'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: PrEnergySumHwcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrFuelSum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrFuelSum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrFuelSumHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrFuelSumHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrFuelSumHcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrFuelSumHcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrFuelSumHcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrFuelSumHcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrFuelSumHwc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrFuelSumHwc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrFuelSumHwcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrFuelSumHwcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrFuelSumHwcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PrFuelSumHwcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PumpAdditionalTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: PumpAdditionalTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: SolarYieldTotal
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: SolarYieldTotal
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: SystemFlowTemp
+  fields:
+  - value
+  values:
+  - '32.25'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Time
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Time
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: WaterPressure
+  fields:
+  - value
+  values:
+  - '1.6'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: YieldTotal
+  fields:
+  - value
+  values:
+  - '14845'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: YieldTotal
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - '5'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z1ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1CoolingManualTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingOpMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingSetbackTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingTemp
+  fields:
+  - value
+  values:
+  - '24'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z1CoolingTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1CoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1DayTemp
+  fields:
+  - value
+  values:
+  - '18'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z1DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 01.01.2015
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z1HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 01.01.2015
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z1HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1HolidayTemp
+  fields:
+  - value
+  values:
+  - '15'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z1HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1NightTemp
+  fields:
+  - value
+  values:
+  - '18.5'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z1NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1OpMode
+  fields:
+  - value
+  values:
+  - 'off'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z1OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1QuickVetoDuration
+  fields:
+  - value
+  values:
+  - '3'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z1QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1QuickVetoEndDate
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z1QuickVetoEndTime
+  fields:
+  - value
+  values:
+  - 00:00:00
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z1QuickVetoTemp
+  fields:
+  - value
+  values:
+  - '10'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z1QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1RoomTemp
+  fields:
+  - value
+  values:
+  - '27.85'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z1RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1SFMode
+  fields:
+  - value
+  values:
+  - auto
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z1SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Config
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Friday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Friday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Friday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Monday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Monday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Monday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Saturday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Saturday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Saturday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Sunday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Sunday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Sunday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Thursday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Timeframes
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Tuesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Wednesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1Timer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z1ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - '5'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z2ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2CoolingTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2CoolingTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2DayTemp
+  fields:
+  - value
+  values:
+  - '18.5'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z2DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2OpMode
+  fields:
+  - value
+  values:
+  - 'off'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z2OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2QuickVetoEndDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2QuickVetoEndTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2RoomTemp
+  fields:
+  - value
+  values:
+  - '27.2875'
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: Z2RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Config
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Friday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Friday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Friday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Monday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Monday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Monday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Saturday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Saturday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Saturday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Sunday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Sunday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Sunday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Thursday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Timeframes
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Tuesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Wednesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2Timer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z2ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3QuickVetoEndDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3QuickVetoEndTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3RoomTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Config
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Friday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Friday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Friday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Monday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Monday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Monday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Saturday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Saturday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Saturday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Sunday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Sunday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Sunday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Thursday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Timeframes
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Tuesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Wednesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3Timer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Z3ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: z1RoomHumidity
+  fields:
+  - value
+  values:
+  - '57'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: BuildingCircuitFlow
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: BuildingCircuitPumpSpeed
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Clearerrorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: CompressorBlocktime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: CompressorHc
+  fields:
+  - value
+  values:
+  - no data stored (message not available due to condition)
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: CompressorHc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHwc
+  fields:
+  - value
+  values:
+  - no data stored (message not available due to condition)
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: CompressorHwc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHwc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CopCooling
+  fields:
+  - value
+  values:
+  - '1.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CopCoolingMonth
+  fields:
+  - value
+  values:
+  - '1.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CopHc
+  fields:
+  - value
+  values:
+  - '2.6'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CopHcMonth
+  fields:
+  - value
+  values:
+  - '1.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CopHwc
+  fields:
+  - value
+  values:
+  - '2.7'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CopHwcMonth
+  fields:
+  - value
+  values:
+  - '3.7'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CurrentCompressorUtil
+  fields:
+  - value
+  values:
+  - '0.00'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CurrentConsumedPower
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CurrentYieldPower
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - -;-;-;-;-
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: DateTime
+  fields:
+  - value
+  values:
+  - nosignal;-:-:-;-.-.-;-
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: EnergyIntegral
+  fields:
+  - value
+  values:
+  - '-178'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: FlowPressure
+  fields:
+  - value
+  values:
+  - no data stored (message not available due to condition)
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: FlowTemp
+  fields:
+  - value
+  values:
+  - '48.12'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: FlowTemperature
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: HoursCool
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: PowerConsumptionHmu
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3108b5160114 / 00)'
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: RunDataAirInletTemp
+  fields:
+  - value
+  values:
+  - '25.4612'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataBuildingCPumpPower
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataCompressorInletTemp
+  fields:
+  - value
+  values:
+  - '30.9524'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataCompressorOutletTemp
+  fields:
+  - value
+  values:
+  - '50.7246'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataCompressorSpeed
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataEEVOutletTemp
+  fields:
+  - value
+  values:
+  - '28.0747'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataEEVPositionAbs
+  fields:
+  - value
+  values:
+  - '155'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataFan1Speed
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataFan2Speed
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataHighPressure
+  fields:
+  - value
+  values:
+  - '14.739'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataLowPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunDataStatuscode
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStats4PortValveHours
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStats4PortValveSwitches
+  fields:
+  - value
+  values:
+  - '14'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsBuildingCPumpStarts
+  fields:
+  - value
+  values:
+  - '4092'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsBuildingPumpHours
+  fields:
+  - value
+  values:
+  - '4810'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsCompressorHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunStatsCompressorHc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHours
+  fields:
+  - value
+  values:
+  - '2546'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsCompressorHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunStatsCompressorHwc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHwc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorStarts
+  fields:
+  - value
+  values:
+  - '6521'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsFan1Hours
+  fields:
+  - value
+  values:
+  - '3040'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsFan1Starts
+  fields:
+  - value
+  values:
+  - '9955'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsFan2Hours
+  fields:
+  - value
+  values:
+  - '3040'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsFan2Starts
+  fields:
+  - value
+  values:
+  - '9955'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsHMUHours
+  fields:
+  - value
+  values:
+  - '26642'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsHcHours
+  fields:
+  - value
+  values:
+  - '2416'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsHwcHours
+  fields:
+  - value
+  values:
+  - '1135'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: SetMode
+  fields:
+  - value
+  values:
+  - auto;0.0;-;-;1;1;1;0;0;0
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: SetMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: SourceTempInput
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: SourceTempOutput
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatElectricEnergySum
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatElectricEnergySumCool
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatElectricEnergySumHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatElectricEnergySumHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatEnvironmentEnergySum
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatEnvironmentEnergySumCool
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatEnvironmentEnergySumHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatEnvironmentEnergySumHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3108b5110103 / 00)'
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: Status01
+  fields:
+  - value
+  values:
+  - 48.0;46.0;-;-;-;off
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: Status01.pumpstate
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.temp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.temp_1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.temp_2
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: Status01.temp_3
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: Status01.temp_4
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: Status02
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: Status16
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3108b5040116 / 00)'
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: StatusCirPump
+  fields:
+  - value
+  values:
+  - 'on'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: SupplyTempWeighted
+  fields:
+  - value
+  values:
+  - '20.00'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: TotalEnergyUsage
+  fields:
+  - value
+  values:
+  - '8556'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldCoolDay
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldCooling
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldCoolingMonth
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldHc
+  fields:
+  - value
+  values:
+  - '10137'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldHcDay
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldHcMonth
+  fields:
+  - value
+  values:
+  - '2.3'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldHwc
+  fields:
+  - value
+  values:
+  - '4709'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldHwcDay
+  fields:
+  - value
+  values:
+  - '1.1'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldHwcMonth
+  fields:
+  - value
+  values:
+  - '69.3'
+  writable: false
+  has_data: true
+- circuit: v32
+  name: ACRoomthermostat
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: APCComStatus
+  fields:
+  - value
+  values:
+  - no data stored (message not available due to condition)
+  writable: false
+  has_data: false
+- circuit: v32
+  name: APCLegioProtection
+  fields:
+  - value
+  values:
+  - no data stored (message not available due to condition)
+  writable: false
+  has_data: false
+- circuit: v32
+  name: APCLegioProtection
+  fields:
+  - value
+  values:
+  - no data stored (message not available due to condition)
+  writable: false
+  has_data: false
+- circuit: v32
+  name: AccessoriesOne
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: AccessoriesOne
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: AccessoriesTwo
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: AccessoriesTwo
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: AverageIgnitiontime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: BlockTimeHcMax
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: BlockTimeHcMax
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: BoilerType
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: BypassPosition
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: ChangesDSN
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: CirPump
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: Clearerrorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: CounterStartAttempts3
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: CounterStartAttempts4
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: CounterStartattempts1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: CounterStartattempts2
+  fields:
+  - value
+  values:
+  - '2'
+  writable: false
+  has_data: true
+- circuit: v32
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - -;-;-;-;-
+  writable: false
+  has_data: true
+- circuit: v32
+  name: DCFTimeDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: DCRoomthermostat
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: DSN
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: DSNOffset
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: DSNOffset
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: DSNStart
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: DateTime
+  fields:
+  - value
+  values:
+  - nosignal;-:-:-;-.-.-;-
+  writable: false
+  has_data: true
+- circuit: v32
+  name: DcfState
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: DeactivationsIFC
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: DeactivationsTemplimiter
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: v32
+  name: DeltaFlowReturnMax
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: DisplayMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: EBusHeatcontrol
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: EbusSourceOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: EbusVoltage
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: ExhaustAirHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: ExhaustAirTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: Expertlevel_ReturnTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: ExtFlowTempDesiredMin
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3118b509030d6e04 / 00)'
+  writable: false
+  has_data: false
+- circuit: v32
+  name: ExtStorageModulCon
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: ExtWP
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: ExternGasvalve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: ExternalFaultmessage
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: ExternalFlowTempDesired
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3118b509030d2500 / 00)'
+  writable: false
+  has_data: false
+- circuit: v32
+  name: ExternalHwcSwitch
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: FanHours
+  fields:
+  - value
+  values:
+  - '96'
+  writable: false
+  has_data: true
+- circuit: v32
+  name: FanMaxSpeedOperation
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: FanMinSpeedOperation
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: FanPWMSum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: FanPWMTest
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: FanSpeed
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: FanSpeedOffsetMax
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: FanSpeedOffsetMax
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: FanSpeedOffsetMin
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: FanSpeedOffsetMin
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: FanStarts
+  fields:
+  - value
+  values:
+  - '444'
+  writable: false
+  has_data: true
+- circuit: v32
+  name: Flame
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: FlameSensingASIC
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: FloorHeatingContact
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: FlowSetPotmeter
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: FlowTemp
+  fields:
+  - value
+  values:
+  - 47.06;ok
+  writable: false
+  has_data: true
+- circuit: v32
+  name: FlowTempDesired
+  fields:
+  - value
+  values:
+  - '0.00'
+  writable: false
+  has_data: true
+- circuit: v32
+  name: FlowTempMax
+  fields:
+  - value
+  values:
+  - '85.81'
+  writable: false
+  has_data: true
+- circuit: v32
+  name: FlowsetHcMax
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: FlowsetHcMax
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: FlowsetHwcMax
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: FlowsetHwcMax
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: Fluegasvalve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: FluegasvalveOpen
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: Gasvalve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: Gasvalve3UC
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: GasvalveASICFeedback
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: GasvalveUC
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: GasvalveUCFeedback
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: HcHours
+  fields:
+  - value
+  values:
+  - '47'
+  writable: false
+  has_data: true
+- circuit: v32
+  name: HcPumpMode
+  fields:
+  - value
+  values:
+  - post_run
+  writable: false
+  has_data: true
+- circuit: v32
+  name: HcPumpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: HcPumpStarts
+  fields:
+  - value
+  values:
+  - '2288'
+  writable: false
+  has_data: true
+- circuit: v32
+  name: HcStarts
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: v32
+  name: HcUnderHundredStarts
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: v32
+  name: HeatingSwitch
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: HoursTillService
+  fields:
+  - value
+  values:
+  - '2'
+  writable: false
+  has_data: true
+- circuit: v32
+  name: HoursTillService
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: HwcDemand
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: HwcHours
+  fields:
+  - value
+  values:
+  - '41'
+  writable: false
+  has_data: true
+- circuit: v32
+  name: HwcImpellorSwitch
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: HwcPostrunTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: HwcPostrunTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: HwcSetPotmeter
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: HwcStarts
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: v32
+  name: HwcSwitch
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: HwcTemp
+  fields:
+  - value
+  values:
+  - 116.06;circuit
+  writable: false
+  has_data: true
+- circuit: v32
+  name: HwcTempDesired
+  fields:
+  - value
+  values:
+  - '0.00'
+  writable: false
+  has_data: true
+- circuit: v32
+  name: HwcTempMax
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3118b509030d4304 / 01f0)'
+  writable: false
+  has_data: false
+- circuit: v32
+  name: HwcTempMax
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: HwcTypes
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: HwcUnderHundredStarts
+  fields:
+  - value
+  values:
+  - '3'
+  writable: false
+  has_data: true
+- circuit: v32
+  name: HwcWaterflow
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: HwcWaterflowMax
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: Ignitor
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: InitialisationEEPROM
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: IonisationVoltageLevel
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: Maintenancedata_HwcTempMax
+  fields:
+  - value
+  values:
+  - '116.06'
+  writable: false
+  has_data: true
+- circuit: v32
+  name: MaxAirHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: MaxIgnitiontime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: MinAirHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: MinIgnitiontime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: ModulationDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: OutdoorstempSensor
+  fields:
+  - value
+  values:
+  - -60.44;cutoff
+  writable: false
+  has_data: true
+- circuit: v32
+  name: OutsideAirTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: OverflowCounter
+  fields:
+  - value
+  values:
+  - 'yes'
+  writable: false
+  has_data: true
+- circuit: v32
+  name: ParamToken
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: v32
+  name: PartloadHcKW
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: PartloadHcKW
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: PartloadHwcKW
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: PartloadHwcKW
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: PartnumberBox
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: PositionValveSet
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: PowerValue
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3118b509030daa00 / 00)'
+  writable: false
+  has_data: false
+- circuit: v32
+  name: PrAPSCounter
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3118b509030df200 / 00)'
+  writable: false
+  has_data: false
+- circuit: v32
+  name: PrAPSSum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: PrEnergyCountHc1
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3118b509030df600 / 00)'
+  writable: false
+  has_data: false
+- circuit: v32
+  name: PrEnergyCountHc1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: PrEnergyCountHc2
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3118b509030df800 / 00)'
+  writable: false
+  has_data: false
+- circuit: v32
+  name: PrEnergyCountHc2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: PrEnergyCountHc3
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: PrEnergyCountHc3
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: PrEnergyCountHwc1
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3118b509030dc600 / 00)'
+  writable: false
+  has_data: false
+- circuit: v32
+  name: PrEnergyCountHwc1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: PrEnergyCountHwc2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: PrEnergyCountHwc2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: PrEnergyCountHwc3
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: PrEnergyCountHwc3
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: PrEnergySumHc1
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3118b509030df500 / 00)'
+  writable: false
+  has_data: false
+- circuit: v32
+  name: PrEnergySumHc1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: PrEnergySumHc2
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3118b509030df700 / 00)'
+  writable: false
+  has_data: false
+- circuit: v32
+  name: PrEnergySumHc2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: PrEnergySumHc3
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: PrEnergySumHc3
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: PrEnergySumHwc1
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3118b509030dc500 / 00)'
+  writable: false
+  has_data: false
+- circuit: v32
+  name: PrEnergySumHwc1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: PrEnergySumHwc2
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3118b509030dc700 / 00)'
+  writable: false
+  has_data: false
+- circuit: v32
+  name: PrEnergySumHwc2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: PrEnergySumHwc3
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: PrEnergySumHwc3
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: PrVortexFlowSensorValue
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3118b509030df400 / 00)'
+  writable: false
+  has_data: false
+- circuit: v32
+  name: PrimaryCircuitFlowrate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: ProductionByte
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: PumpHours
+  fields:
+  - value
+  values:
+  - '133'
+  writable: false
+  has_data: true
+- circuit: v32
+  name: PumpHwcFlowNumber
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: PumpHwcFlowSum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: PumpPower
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: v32
+  name: PumpPowerDesired
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3118b509030da100 / 00)'
+  writable: false
+  has_data: false
+- circuit: v32
+  name: PumpPowerDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: RemainingBoilerblocktime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: ReturnRegulation
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: ReturnRegulation
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: ReturnTemp
+  fields:
+  - value
+  values:
+  - 55.31;64650;ok
+  writable: false
+  has_data: true
+- circuit: v32
+  name: ReturnTempMax
+  fields:
+  - value
+  values:
+  - '83.94'
+  writable: false
+  has_data: true
+- circuit: v32
+  name: SHEMaxDeltaHwcFlow
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: SHEMaxFlowTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: SecondPumpMode
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: v32
+  name: SecondPumpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: SerialNumber
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: v32
+  name: SetFactoryValues
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: SetFactoryValues
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: SetMode
+  fields:
+  - value
+  values:
+  - auto;0.0;-;-;1;0;0;0;0;0
+  writable: false
+  has_data: true
+- circuit: v32
+  name: SetMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: SolPostHeat
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: SolPostHeat
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: Statenumber
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: Status
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3118b5110103 / 00)'
+  writable: false
+  has_data: false
+- circuit: v32
+  name: Status01
+  fields:
+  - value
+  values:
+  - 43.5;53.0;-;-;62.0;off
+  writable: false
+  has_data: true
+- circuit: v32
+  name: Status02
+  fields:
+  - value
+  values:
+  - auto;60;68.0;70;70.0
+  writable: false
+  has_data: true
+- circuit: v32
+  name: Status16
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3118b5040116 / 00)'
+  writable: false
+  has_data: false
+- circuit: v32
+  name: StatusCirPump
+  fields:
+  - value
+  values:
+  - 'on'
+  writable: false
+  has_data: true
+- circuit: v32
+  name: StorageLoadPumpHours
+  fields:
+  - value
+  values:
+  - '45'
+  writable: false
+  has_data: true
+- circuit: v32
+  name: StorageLoadTimeMax
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: StorageLoadTimeMax
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: StorageTemp
+  fields:
+  - value
+  values:
+  - 62.25;ok
+  writable: false
+  has_data: true
+- circuit: v32
+  name: StorageTempDesired
+  fields:
+  - value
+  values:
+  - '46.00'
+  writable: false
+  has_data: true
+- circuit: v32
+  name: StorageTempMax
+  fields:
+  - value
+  values:
+  - '72.75'
+  writable: false
+  has_data: true
+- circuit: v32
+  name: StorageloadPumpStarts
+  fields:
+  - value
+  values:
+  - '190'
+  writable: false
+  has_data: true
+- circuit: v32
+  name: Storageloadpump
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: StoragereleaseClock
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: SupplyAirTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: TargetFanSpeed
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: TargetFanSpeedOutput
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: TempDiffBlock
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: v32
+  name: TempDiffFailure
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: v32
+  name: TempGradientFailure
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: v32
+  name: TempMaxDiffExtTFT
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3118b509030d2700 / 00)'
+  writable: false
+  has_data: false
+- circuit: v32
+  name: Templimiter
+  fields:
+  - value
+  values:
+  - 'off'
+  writable: false
+  has_data: true
+- circuit: v32
+  name: TemplimiterWithNTC
+  fields:
+  - value
+  values:
+  - 'yes'
+  writable: false
+  has_data: true
+- circuit: v32
+  name: Testbyte
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: TimerInputHc
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3118b509030dde00 / 00)'
+  writable: false
+  has_data: false
+- circuit: v32
+  name: ValveMode
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: v32
+  name: ValveMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: ValveStarts
+  fields:
+  - value
+  values:
+  - '2454'
+  writable: false
+  has_data: true
+- circuit: v32
+  name: VentilationLevelDay
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: VentilationLevelNight
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: VolatileLockout
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: VolatileLockoutIFCGV
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: VortexFlowSensor
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3118b509030dd500 / 00)'
+  writable: false
+  has_data: false
+- circuit: v32
+  name: WP
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: WPPostrunTime
+  fields:
+  - value
+  values:
+  - '1'
+  writable: false
+  has_data: true
+- circuit: v32
+  name: WPPostrunTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: WPSecondStage
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: WarmstartDemand
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: WarmstartOffset
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: WarmstartOffset
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: WaterHcFlowMax
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: WaterPressure
+  fields:
+  - value
+  values:
+  - 1.771;ok
+  writable: false
+  has_data: true
+- circuit: v32
+  name: WaterpressureBranchControlOff
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: WaterpressureMeasureCounter
+  fields:
+  - value
+  values:
+  - '118'
+  writable: false
+  has_data: true
+- circuit: v32
+  name: WaterpressureVariantSum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: YieldMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldToday
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldTotal
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldYear
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Clearerrorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vr_71
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - -;-;-;-;-
+  writable: false
+  has_data: true
+- circuit: vr_71
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vr_71
+  name: Mc1Operation
+  fields:
+  - value
+  values:
+  - off;0.0;on;-100
+  writable: false
+  has_data: true
+- circuit: vr_71
+  name: Mc2Operation
+  fields:
+  - value
+  values:
+  - off;0.0;on;-100
+  writable: false
+  has_data: true
+- circuit: vr_71
+  name: Mc3Operation
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vr_71
+  name: SensorData1
+  fields:
+  - value
+  values:
+  - 32.19;30.12;24.94;-;-;-;-;40 3d
+  writable: false
+  has_data: true
+- circuit: vr_71
+  name: SensorData2
+  fields:
+  - value
+  values:
+  - -;-;-;-;0.00;8.00;80 57 05
+  writable: false
+  has_data: true
+- circuit: vr_71
+  name: SetActorState
+  fields:
+  - value
+  values:
+  - -;-;off;off;off;off;-;-;-;-;off;off;00 00
+  writable: false
+  has_data: true
+- circuit: vwz
+  name: TestHwcTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: vwz
+  name: TestOutdoorTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: vwz
+  name: TestThreeWayValve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: vwzio
+  name: EnableTestHwcTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: EnableTestOutdoorTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: EnableTestThreeWayValve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: TestHwcTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: TestOutdoorTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: TestThreeWayValve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+raw_find_lines_after:
+- Broadcast Datetime = no data stored
+- Broadcast Error = no data stored
+- Broadcast HwcStatus = no data stored
+- Broadcast Id = no data stored
+- Broadcast IdAnswer = no data stored
+- Broadcast IdQuery = no data stored
+- Broadcast Load = no data stored
+- Broadcast Outsidetemp = 28.582
+- Broadcast Queryexistence =  (empty for 31fe07fe00 / )
+- Broadcast Signoflife = no data stored
+- Broadcast Vdatetime = 11:15:15;22.08.2026
+- Broadcast Vdatetime = no data stored
+- ctlv2 AdaptHeatCurve = no
+- ctlv2 AdaptHeatCurve = no data stored
+- ctlv2 CcTimer_Config = 00 03 0a 00 00 00 ff ff 00
+- ctlv2 CcTimer_Friday0 = 06:00;22:00
+- ctlv2 CcTimer_Friday1 = 00:00;00:00
+- ctlv2 CcTimer_Friday2 = 00:00;00:00
+- ctlv2 CcTimer_Friday = no data stored
+- ctlv2 CcTimer_Monday0 = 06:00;22:00
+- ctlv2 CcTimer_Monday1 = 00:00;00:00
+- ctlv2 CcTimer_Monday2 = 00:00;00:00
+- ctlv2 CcTimer_Monday = no data stored
+- ctlv2 CcTimer_Saturday0 = 07:30;23:30
+- ctlv2 CcTimer_Saturday1 = 00:00;00:00
+- ctlv2 CcTimer_Saturday2 = 00:00;00:00
+- ctlv2 CcTimer_Saturday = no data stored
+- ctlv2 CcTimer_Sunday0 = 07:30;22:00
+- ctlv2 CcTimer_Sunday1 = 00:00;00:00
+- ctlv2 CcTimer_Sunday2 = 00:00;00:00
+- ctlv2 CcTimer_Sunday = no data stored
+- ctlv2 CcTimer_Thursday0 = 06:00;22:00
+- ctlv2 CcTimer_Thursday1 = 00:00;00:00
+- ctlv2 CcTimer_Thursday2 = 00:00;00:00
+- ctlv2 CcTimer_Thursday = no data stored
+- ctlv2 CcTimer_Timeframes = 1;1;1;1;1;1;1
+- ctlv2 CcTimer_Tuesday0 = 06:00;22:00
+- ctlv2 CcTimer_Tuesday1 = 00:00;00:00
+- ctlv2 CcTimer_Tuesday2 = 00:00;00:00
+- ctlv2 CcTimer_Tuesday = no data stored
+- ctlv2 CcTimer_Wednesday0 = 06:00;22:00
+- ctlv2 CcTimer_Wednesday1 = 00:00;00:00
+- ctlv2 CcTimer_Wednesday2 = 00:00;00:00
+- ctlv2 CcTimer_Wednesday = no data stored
+- ctlv2 Clearerrorhistory = no data stored
+- ctlv2 ContinuousHeating = -26
+- ctlv2 ContinuousHeating = no data stored
+- ctlv2 Currenterror = -;-;-;-;-
+- ctlv2 CylinderChargeHyst = 3
+- ctlv2 CylinderChargeHyst = no data stored
+- ctlv2 CylinderChargeOffset = 25
+- ctlv2 CylinderChargeOffset = no data stored
+- ctlv2 Date = 22.08.2026
+- ctlv2 Date = no data stored
+- ctlv2 DisplayedOutsideTemp = 28.5352
+- ctlv2 Errorhistory = no data stored
+- ctlv2 FrostOverRideTime = 4
+- ctlv2 FrostOverRideTime = no data stored
+- ctlv2 Hc1ActualFlowTempDesired = 0.0
+- ctlv2 Hc1AutoOffMode = night
+- ctlv2 Hc1AutoOffMode = no data stored
+- ctlv2 Hc1CircuitType = mixer
+- ctlv2 Hc1ExcessTemp = 0.0
+- ctlv2 Hc1ExcessTemp = no data stored
+- ctlv2 Hc1FlowTemp = 30.1875
+- ctlv2 Hc1HeatCurve = 1.7
+- ctlv2 Hc1HeatCurve = no data stored
+- ctlv2 Hc1HeatCurveAdaption = 0.0
+- ctlv2 Hc1MaxFlowTempDesired = 65
+- ctlv2 Hc1MaxFlowTempDesired = no data stored
+- ctlv2 Hc1MinCoolingTempDesired = 13
+- ctlv2 Hc1MinCoolingTempDesired = no data stored
+- ctlv2 Hc1MinFlowTempDesired = 48
+- ctlv2 Hc1MinFlowTempDesired = no data stored
+- ctlv2 Hc1MixerMovement = -100
+- ctlv2 Hc1PumpStatus = 0
+- ctlv2 Hc1PumpStatus = no data stored
+- ctlv2 Hc1RoomTempSwitchOn = thermostat
+- ctlv2 Hc1RoomTempSwitchOn = no data stored
+- ctlv2 Hc1Status = 0
+- ctlv2 Hc1Status = no data stored
+- ctlv2 Hc1SummerTempLimit = 40
+- ctlv2 Hc1SummerTempLimit = no data stored
+- ctlv2 Hc2ActualFlowTempDesired = 0.0
+- ctlv2 Hc2AutoOffMode = night
+- ctlv2 Hc2AutoOffMode = no data stored
+- ctlv2 Hc2CircuitType = mixer
+- ctlv2 Hc2ExcessTemp = 0.0
+- ctlv2 Hc2ExcessTemp = no data stored
+- ctlv2 Hc2FlowTemp = 24.875
+- ctlv2 Hc2HeatCurve = 1.7
+- ctlv2 Hc2HeatCurve = no data stored
+- ctlv2 Hc2HeatCurveAdaption = 0.0
+- ctlv2 Hc2MaxFlowTempDesired = 65
+- ctlv2 Hc2MaxFlowTempDesired = no data stored
+- ctlv2 Hc2MinCoolingTempDesired = 20
+- ctlv2 Hc2MinCoolingTempDesired = no data stored
+- ctlv2 Hc2MinFlowTempDesired = 48
+- ctlv2 Hc2MinFlowTempDesired = no data stored
+- ctlv2 Hc2MixerMovement = -100
+- ctlv2 Hc2PumpStatus = 0
+- ctlv2 Hc2PumpStatus = no data stored
+- ctlv2 Hc2RoomTempSwitchOn = thermostat
+- ctlv2 Hc2RoomTempSwitchOn = no data stored
+- ctlv2 Hc2Status = 0
+- ctlv2 Hc2Status = no data stored
+- ctlv2 Hc2SummerTempLimit = 40
+- ctlv2 Hc2SummerTempLimit = no data stored
+- ctlv2 Hc3ActualFlowTempDesired = 0.0
+- ctlv2 Hc3AutoOffMode = eco
+- ctlv2 Hc3AutoOffMode = no data stored
+- ctlv2 Hc3CircuitType = inactive
+- ctlv2 Hc3ExcessTemp = 0.0
+- ctlv2 Hc3ExcessTemp = no data stored
+- ctlv2 Hc3FlowTemp =  (empty for 3115b52406020002020800 / 0800020800ffffff7f)
+- ctlv2 Hc3HeatCurve = 1.2
+- ctlv2 Hc3HeatCurve = no data stored
+- ctlv2 Hc3HeatCurveAdaption = 0.0
+- ctlv2 Hc3MaxFlowTempDesired = 90
+- ctlv2 Hc3MaxFlowTempDesired = no data stored
+- ctlv2 Hc3MinCoolingTempDesired = 20
+- ctlv2 Hc3MinCoolingTempDesired = no data stored
+- ctlv2 Hc3MinFlowTempDesired = 15
+- ctlv2 Hc3MinFlowTempDesired = no data stored
+- ctlv2 Hc3MixerMovement = 0.0
+- ctlv2 Hc3PumpStatus = 0
+- ctlv2 Hc3PumpStatus = no data stored
+- ctlv2 Hc3RoomTempSwitchOn = off
+- ctlv2 Hc3RoomTempSwitchOn = no data stored
+- ctlv2 Hc3Status = 0
+- ctlv2 Hc3Status = no data stored
+- ctlv2 Hc3SummerTempLimit = 21
+- ctlv2 Hc3SummerTempLimit = no data stored
+- ctlv2 HcStorageTempBottom =  (empty for 3115b5240602000000a000 / 080000a000ffffff7f)
+- ctlv2 HcStorageTempTop =  (empty for 3115b52406020000009f00 / 0800009f00ffffff7f)
+- ctlv2 HwcBankHolidayEndPeriod = no data stored
+- ctlv2 HwcBankHolidayEndPeriod = no data stored
+- ctlv2 HwcBankHolidayStartPeriod = no data stored
+- ctlv2 HwcBankHolidayStartPeriod = no data stored
+- ctlv2 HwcFlowTemp = 0.0
+- ctlv2 HwcHolidayEndPeriod = 01.01.2015
+- ctlv2 HwcHolidayEndPeriod = no data stored
+- ctlv2 HwcHolidayStartPeriod = 01.01.2015
+- ctlv2 HwcHolidayStartPeriod = no data stored
+- ctlv2 HwcLockTime = 60
+- ctlv2 HwcLockTime = no data stored
+- ctlv2 HwcMaxFlowTempDesired = 75
+- ctlv2 HwcMaxFlowTempDesired = no data stored
+- ctlv2 HwcOpMode = day
+- ctlv2 HwcOpMode = no data stored
+- ctlv2 HwcParallelLoading = off
+- ctlv2 HwcParallelLoading = no data stored
+- ctlv2 HwcSFMode = auto
+- ctlv2 HwcSFMode = no data stored
+- ctlv2 HwcStorageTemp = 62
+- ctlv2 HwcStorageTempBottom =  (empty for 3115b52406020000009e00 / 0800009e00ffffff7f)
+- ctlv2 HwcStorageTempTop =  (empty for 3115b52406020000009d00 / 0800009d00ffffff7f)
+- ctlv2 HwcTempDesired = 46
+- ctlv2 HwcTempDesired = no data stored
+- ctlv2 HwcTimer_Config = 00 03 0a 0a 01 01 23 46 00
+- ctlv2 HwcTimer_Friday0 = 05:30;22:00;46.0
+- ctlv2 HwcTimer_Friday1 = 00:00;00:00;-
+- ctlv2 HwcTimer_Friday2 = 00:00;00:00;-
+- ctlv2 HwcTimer_Friday = no data stored
+- ctlv2 HwcTimer_Monday0 = 05:30;22:00;46.0
+- ctlv2 HwcTimer_Monday1 = 00:00;00:00;-
+- ctlv2 HwcTimer_Monday2 = 00:00;00:00;-
+- ctlv2 HwcTimer_Monday = no data stored
+- ctlv2 HwcTimer_Saturday0 = 07:00;23:30;46.0
+- ctlv2 HwcTimer_Saturday1 = 00:00;00:00;-
+- ctlv2 HwcTimer_Saturday2 = 00:00;00:00;-
+- ctlv2 HwcTimer_Saturday = no data stored
+- ctlv2 HwcTimer_Sunday0 = 07:00;22:00;46.0
+- ctlv2 HwcTimer_Sunday1 = 00:00;00:00;-
+- ctlv2 HwcTimer_Sunday2 = no data stored
+- ctlv2 HwcTimer_Sunday = no data stored
+- ctlv2 HwcTimer_Thursday0 = no data stored
+- ctlv2 HwcTimer_Thursday1 = no data stored
+- ctlv2 HwcTimer_Thursday2 = no data stored
+- ctlv2 HwcTimer_Thursday = no data stored
+- ctlv2 HwcTimer_Timeframes = no data stored
+- ctlv2 HwcTimer_Tuesday0 = no data stored
+- ctlv2 HwcTimer_Tuesday1 = no data stored
+- ctlv2 HwcTimer_Tuesday2 = no data stored
+- ctlv2 HwcTimer_Tuesday = no data stored
+- ctlv2 HwcTimer_Wednesday0 = no data stored
+- ctlv2 HwcTimer_Wednesday1 = no data stored
+- ctlv2 HwcTimer_Wednesday2 = no data stored
+- ctlv2 HwcTimer_Wednesday = no data stored
+- ctlv2 HydraulicScheme = 12
+- ctlv2 HydraulicScheme = no data stored
+- ctlv2 Installer1 = no data stored
+- ctlv2 Installer1 = no data stored
+- ctlv2 Installer2 = no data stored
+- ctlv2 Installer2 = no data stored
+- ctlv2 KeyCodeforConfigMenu = no data stored
+- ctlv2 KeyCodeforConfigMenu = no data stored
+- ctlv2 MaintenanceDate = no data stored
+- ctlv2 MaintenanceDate = no data stored
+- ctlv2 MaintenanceDue = no data stored
+- ctlv2 ManualCoolingEndDate = 01.01.2019
+- ctlv2 ManualCoolingEndDate = no data stored
+- ctlv2 ManualCoolingStartDate = 01.01.2019
+- ctlv2 ManualCoolingStartDate = no data stored
+- ctlv2 MaxCylinderChargeTime = 60
+- ctlv2 MaxCylinderChargeTime = no data stored
+- ctlv2 MaxRoomHumidity = 40
+- ctlv2 MaxRoomHumidity = no data stored
+- ctlv2 MultiRelaySetting = circulation
+- ctlv2 MultiRelaySetting = no data stored
+- ctlv2 OutsideTempAvg = 26.2656
+- ctlv2 OutsideTempAvg = no data stored
+- ctlv2 PhoneNumber1 = no data stored
+- ctlv2 PhoneNumber1 = no data stored
+- ctlv2 PhoneNumber2 = no data stored
+- ctlv2 PhoneNumber2 = no data stored
+- 'ctlv2 PrEnergySum =  (ERR: invalid position for 3115b52406020000005c00 / 00)'
+- ctlv2 PrEnergySum = no data stored
+- ctlv2 PrEnergySumHc = 6220
+- ctlv2 PrEnergySumHc = no data stored
+- ctlv2 PrEnergySumHcLastMonth = 13
+- ctlv2 PrEnergySumHcLastMonth = no data stored
+- ctlv2 PrEnergySumHcThisMonth = 9
+- ctlv2 PrEnergySumHcThisMonth = no data stored
+- ctlv2 PrEnergySumHwc = 2596
+- ctlv2 PrEnergySumHwc = no data stored
+- ctlv2 PrEnergySumHwcLastMonth = 24
+- ctlv2 PrEnergySumHwcLastMonth = no data stored
+- ctlv2 PrEnergySumHwcThisMonth = 24
+- ctlv2 PrEnergySumHwcThisMonth = no data stored
+- ctlv2 PrFuelSum = no data stored
+- ctlv2 PrFuelSum = no data stored
+- ctlv2 PrFuelSumHc = no data stored
+- ctlv2 PrFuelSumHc = no data stored
+- ctlv2 PrFuelSumHcLastMonth = no data stored
+- ctlv2 PrFuelSumHcLastMonth = no data stored
+- ctlv2 PrFuelSumHcThisMonth = no data stored
+- ctlv2 PrFuelSumHcThisMonth = no data stored
+- ctlv2 PrFuelSumHwc = no data stored
+- ctlv2 PrFuelSumHwc = no data stored
+- ctlv2 PrFuelSumHwcLastMonth = no data stored
+- ctlv2 PrFuelSumHwcLastMonth = no data stored
+- ctlv2 PrFuelSumHwcThisMonth = no data stored
+- ctlv2 PrFuelSumHwcThisMonth = no data stored
+- ctlv2 PumpAdditionalTime = no data stored
+- ctlv2 PumpAdditionalTime = no data stored
+- ctlv2 SolarYieldTotal = no data stored
+- ctlv2 SolarYieldTotal = no data stored
+- ctlv2 SystemFlowTemp = 32.25
+- ctlv2 Time = no data stored
+- ctlv2 Time = no data stored
+- ctlv2 WaterPressure = 1.6
+- ctlv2 YieldTotal = 14845
+- ctlv2 YieldTotal = no data stored
+- ctlv2 Z1ActualRoomTempDesired = 5
+- ctlv2 Z1ActualRoomTempDesired = no data stored
+- ctlv2 Z1BankHolidayEndPeriod = no data stored
+- ctlv2 Z1BankHolidayEndPeriod = no data stored
+- ctlv2 Z1BankHolidayStartPeriod = no data stored
+- ctlv2 Z1BankHolidayStartPeriod = no data stored
+- ctlv2 Z1CoolingTemp = 24
+- ctlv2 Z1CoolingTemp = no data stored
+- ctlv2 Z1DayTemp = 18
+- ctlv2 Z1DayTemp = no data stored
+- ctlv2 Z1HolidayEndPeriod = 01.01.2015
+- ctlv2 Z1HolidayEndPeriod = no data stored
+- ctlv2 Z1HolidayStartPeriod = 01.01.2015
+- ctlv2 Z1HolidayStartPeriod = no data stored
+- ctlv2 Z1HolidayTemp = 15
+- ctlv2 Z1HolidayTemp = no data stored
+- ctlv2 Z1Name1 = no data stored
+- ctlv2 Z1Name1 = no data stored
+- ctlv2 Z1Name2 = no data stored
+- ctlv2 Z1Name2 = no data stored
+- ctlv2 Z1NightTemp = 18.5
+- ctlv2 Z1NightTemp = no data stored
+- ctlv2 Z1OpMode = off
+- ctlv2 Z1OpMode = no data stored
+- ctlv2 Z1QuickVetoDuration = 3
+- ctlv2 Z1QuickVetoDuration = no data stored
+- ctlv2 Z1QuickVetoEndDate = 01.01.2019
+- ctlv2 Z1QuickVetoEndTime = 00:00:00
+- ctlv2 Z1QuickVetoTemp = 10
+- ctlv2 Z1QuickVetoTemp = no data stored
+- ctlv2 z1RoomHumidity = 57
+- ctlv2 Z1RoomTemp = 27.85
+- ctlv2 Z1RoomZoneMapping = no data stored
+- ctlv2 Z1RoomZoneMapping = no data stored
+- ctlv2 Z1SFMode = auto
+- ctlv2 Z1SFMode = no data stored
+- ctlv2 Z1Shortname = no data stored
+- ctlv2 Z1Shortname = no data stored
+- ctlv2 Z1Timer_Config = no data stored
+- ctlv2 Z1Timer_Friday0 = no data stored
+- ctlv2 Z1Timer_Friday1 = no data stored
+- ctlv2 Z1Timer_Friday2 = no data stored
+- ctlv2 Z1Timer_Friday = no data stored
+- ctlv2 Z1Timer_Monday0 = no data stored
+- ctlv2 Z1Timer_Monday1 = no data stored
+- ctlv2 Z1Timer_Monday2 = no data stored
+- ctlv2 Z1Timer_Monday = no data stored
+- ctlv2 Z1Timer_Saturday0 = no data stored
+- ctlv2 Z1Timer_Saturday1 = no data stored
+- ctlv2 Z1Timer_Saturday2 = no data stored
+- ctlv2 Z1Timer_Saturday = no data stored
+- ctlv2 Z1Timer_Sunday0 = no data stored
+- ctlv2 Z1Timer_Sunday1 = no data stored
+- ctlv2 Z1Timer_Sunday2 = no data stored
+- ctlv2 Z1Timer_Sunday = no data stored
+- ctlv2 Z1Timer_Thursday0 = no data stored
+- ctlv2 Z1Timer_Thursday1 = no data stored
+- ctlv2 Z1Timer_Thursday2 = no data stored
+- ctlv2 Z1Timer_Thursday = no data stored
+- ctlv2 Z1Timer_Timeframes = no data stored
+- ctlv2 Z1Timer_Tuesday0 = no data stored
+- ctlv2 Z1Timer_Tuesday1 = no data stored
+- ctlv2 Z1Timer_Tuesday2 = no data stored
+- ctlv2 Z1Timer_Tuesday = no data stored
+- ctlv2 Z1Timer_Wednesday0 = no data stored
+- ctlv2 Z1Timer_Wednesday1 = no data stored
+- ctlv2 Z1Timer_Wednesday2 = no data stored
+- ctlv2 Z1Timer_Wednesday = no data stored
+- ctlv2 Z1ValveStatus = no data stored
+- ctlv2 Z1ValveStatus = no data stored
+- ctlv2 Z2ActualRoomTempDesired = 5
+- ctlv2 Z2ActualRoomTempDesired = no data stored
+- ctlv2 Z2BankHolidayEndPeriod = no data stored
+- ctlv2 Z2BankHolidayEndPeriod = no data stored
+- ctlv2 Z2BankHolidayStartPeriod = no data stored
+- ctlv2 Z2BankHolidayStartPeriod = no data stored
+- ctlv2 Z2CoolingTemp = no data stored
+- ctlv2 Z2CoolingTemp = no data stored
+- ctlv2 Z2DayTemp = 18.5
+- ctlv2 Z2DayTemp = no data stored
+- ctlv2 Z2HolidayEndPeriod = no data stored
+- ctlv2 Z2HolidayEndPeriod = no data stored
+- ctlv2 Z2HolidayStartPeriod = no data stored
+- ctlv2 Z2HolidayStartPeriod = no data stored
+- ctlv2 Z2HolidayTemp = no data stored
+- ctlv2 Z2HolidayTemp = no data stored
+- ctlv2 Z2Name1 = no data stored
+- ctlv2 Z2Name1 = no data stored
+- ctlv2 Z2Name2 = no data stored
+- ctlv2 Z2Name2 = no data stored
+- ctlv2 Z2NightTemp = no data stored
+- ctlv2 Z2NightTemp = no data stored
+- ctlv2 Z2OpMode = off
+- ctlv2 Z2OpMode = no data stored
+- ctlv2 Z2QuickVetoDuration = no data stored
+- ctlv2 Z2QuickVetoDuration = no data stored
+- ctlv2 Z2QuickVetoEndDate = no data stored
+- ctlv2 Z2QuickVetoEndTime = no data stored
+- ctlv2 Z2QuickVetoTemp = no data stored
+- ctlv2 Z2QuickVetoTemp = no data stored
+- ctlv2 Z2RoomTemp = 27.2875
+- ctlv2 Z2RoomZoneMapping = no data stored
+- ctlv2 Z2RoomZoneMapping = no data stored
+- ctlv2 Z2SFMode = no data stored
+- ctlv2 Z2SFMode = no data stored
+- ctlv2 Z2Shortname = no data stored
+- ctlv2 Z2Shortname = no data stored
+- ctlv2 Z2Timer_Config = no data stored
+- ctlv2 Z2Timer_Friday0 = no data stored
+- ctlv2 Z2Timer_Friday1 = no data stored
+- ctlv2 Z2Timer_Friday2 = no data stored
+- ctlv2 Z2Timer_Friday = no data stored
+- ctlv2 Z2Timer_Monday0 = no data stored
+- ctlv2 Z2Timer_Monday1 = no data stored
+- ctlv2 Z2Timer_Monday2 = no data stored
+- ctlv2 Z2Timer_Monday = no data stored
+- ctlv2 Z2Timer_Saturday0 = no data stored
+- ctlv2 Z2Timer_Saturday1 = no data stored
+- ctlv2 Z2Timer_Saturday2 = no data stored
+- ctlv2 Z2Timer_Saturday = no data stored
+- ctlv2 Z2Timer_Sunday0 = no data stored
+- ctlv2 Z2Timer_Sunday1 = no data stored
+- ctlv2 Z2Timer_Sunday2 = no data stored
+- ctlv2 Z2Timer_Sunday = no data stored
+- ctlv2 Z2Timer_Thursday0 = no data stored
+- ctlv2 Z2Timer_Thursday1 = no data stored
+- ctlv2 Z2Timer_Thursday2 = no data stored
+- ctlv2 Z2Timer_Thursday = no data stored
+- ctlv2 Z2Timer_Timeframes = no data stored
+- ctlv2 Z2Timer_Tuesday0 = no data stored
+- ctlv2 Z2Timer_Tuesday1 = no data stored
+- ctlv2 Z2Timer_Tuesday2 = no data stored
+- ctlv2 Z2Timer_Tuesday = no data stored
+- ctlv2 Z2Timer_Wednesday0 = no data stored
+- ctlv2 Z2Timer_Wednesday1 = no data stored
+- ctlv2 Z2Timer_Wednesday2 = no data stored
+- ctlv2 Z2Timer_Wednesday = no data stored
+- ctlv2 Z2ValveStatus = no data stored
+- ctlv2 Z2ValveStatus = no data stored
+- ctlv2 Z3ActualRoomTempDesired = no data stored
+- ctlv2 Z3ActualRoomTempDesired = no data stored
+- ctlv2 Z3BankHolidayEndPeriod = no data stored
+- ctlv2 Z3BankHolidayEndPeriod = no data stored
+- ctlv2 Z3BankHolidayStartPeriod = no data stored
+- ctlv2 Z3BankHolidayStartPeriod = no data stored
+- ctlv2 Z3DayTemp = no data stored
+- ctlv2 Z3DayTemp = no data stored
+- ctlv2 Z3HolidayEndPeriod = no data stored
+- ctlv2 Z3HolidayEndPeriod = no data stored
+- ctlv2 Z3HolidayStartPeriod = no data stored
+- ctlv2 Z3HolidayStartPeriod = no data stored
+- ctlv2 Z3HolidayTemp = no data stored
+- ctlv2 Z3HolidayTemp = no data stored
+- ctlv2 Z3Name1 = no data stored
+- ctlv2 Z3Name1 = no data stored
+- ctlv2 Z3Name2 = no data stored
+- ctlv2 Z3Name2 = no data stored
+- ctlv2 Z3NightTemp = no data stored
+- ctlv2 Z3NightTemp = no data stored
+- ctlv2 Z3OpMode = no data stored
+- ctlv2 Z3OpMode = no data stored
+- ctlv2 Z3QuickVetoDuration = no data stored
+- ctlv2 Z3QuickVetoDuration = no data stored
+- ctlv2 Z3QuickVetoEndDate = no data stored
+- ctlv2 Z3QuickVetoEndTime = no data stored
+- ctlv2 Z3QuickVetoTemp = no data stored
+- ctlv2 Z3QuickVetoTemp = no data stored
+- ctlv2 Z3RoomTemp = no data stored
+- ctlv2 Z3RoomZoneMapping = no data stored
+- ctlv2 Z3RoomZoneMapping = no data stored
+- ctlv2 Z3SFMode = no data stored
+- ctlv2 Z3SFMode = no data stored
+- ctlv2 Z3Shortname = no data stored
+- ctlv2 Z3Shortname = no data stored
+- ctlv2 Z3Timer_Config = no data stored
+- ctlv2 Z3Timer_Friday0 = no data stored
+- ctlv2 Z3Timer_Friday1 = no data stored
+- ctlv2 Z3Timer_Friday2 = no data stored
+- ctlv2 Z3Timer_Friday = no data stored
+- ctlv2 Z3Timer_Monday0 = no data stored
+- ctlv2 Z3Timer_Monday1 = no data stored
+- ctlv2 Z3Timer_Monday2 = no data stored
+- ctlv2 Z3Timer_Monday = no data stored
+- ctlv2 Z3Timer_Saturday0 = no data stored
+- ctlv2 Z3Timer_Saturday1 = no data stored
+- ctlv2 Z3Timer_Saturday2 = no data stored
+- ctlv2 Z3Timer_Saturday = no data stored
+- ctlv2 Z3Timer_Sunday0 = no data stored
+- ctlv2 Z3Timer_Sunday1 = no data stored
+- ctlv2 Z3Timer_Sunday2 = no data stored
+- ctlv2 Z3Timer_Sunday = no data stored
+- ctlv2 Z3Timer_Thursday0 = no data stored
+- ctlv2 Z3Timer_Thursday1 = no data stored
+- ctlv2 Z3Timer_Thursday2 = no data stored
+- ctlv2 Z3Timer_Thursday = no data stored
+- ctlv2 Z3Timer_Timeframes = no data stored
+- ctlv2 Z3Timer_Tuesday0 = no data stored
+- ctlv2 Z3Timer_Tuesday1 = no data stored
+- ctlv2 Z3Timer_Tuesday2 = no data stored
+- ctlv2 Z3Timer_Tuesday = no data stored
+- ctlv2 Z3Timer_Wednesday0 = no data stored
+- ctlv2 Z3Timer_Wednesday1 = no data stored
+- ctlv2 Z3Timer_Wednesday2 = no data stored
+- ctlv2 Z3Timer_Wednesday = no data stored
+- ctlv2 Z3ValveStatus = no data stored
+- ctlv2 Z3ValveStatus = no data stored
+- General Valuerange = no data stored
+- hmu BuildingCircuitFlow = 0
+- hmu Clearerrorhistory = no data stored
+- hmu CompressorBlocktime = no data stored
+- hmu CompressorHc = no data stored (message not available due to condition)
+- hmu CompressorHwc = no data stored (message not available due to condition)
+- hmu CopCooling = 1.0
+- hmu CopCoolingMonth = 1.0
+- hmu CopHc = 2.6
+- hmu CopHcMonth = 1.0
+- hmu CopHwc = 2.7
+- hmu CopHwcMonth = 3.7
+- hmu CurrentCompressorUtil = 0.00
+- hmu CurrentConsumedPower = 0.0
+- hmu Currenterror = -;-;-;-;-
+- hmu CurrentYieldPower = 0.0
+- hmu DateTime = nosignal;-:-:-;-.-.-;-
+- hmu EnergyIntegral = -178
+- hmu Errorhistory = no data stored
+- hmu FlowPressure = no data stored (message not available due to condition)
+- hmu FlowTemp = 48.12
+- 'hmu PowerConsumptionHmu =  (ERR: invalid position for 3108b5160114 / 00)'
+- hmu RunDataAirInletTemp = 25.4612
+- hmu RunDataBuildingCPumpPower = 0.0
+- hmu RunDataCompressorInletTemp = 30.9524
+- hmu RunDataCompressorOutletTemp = 50.7246
+- hmu RunDataCompressorSpeed = 0.0
+- hmu RunDataEEVOutletTemp = 28.0747
+- hmu RunDataEEVPositionAbs = 155
+- hmu RunDataFan1Speed = 0.0
+- hmu RunDataFan2Speed = 0.0
+- hmu RunDataHighPressure = 14.739
+- hmu RunDataStatuscode = standby
+- hmu RunStats4PortValveHours = 0
+- hmu RunStats4PortValveSwitches = 14
+- hmu RunStatsBuildingCPumpStarts = 4092
+- hmu RunStatsBuildingPumpHours = 4810
+- hmu RunStatsCompressorHours = 2546
+- hmu RunStatsCompressorStarts = 6521
+- hmu RunStatsFan1Hours = 3040
+- hmu RunStatsFan1Starts = 9955
+- hmu RunStatsFan2Hours = 3040
+- hmu RunStatsFan2Starts = 9955
+- hmu RunStatsHcHours = 2416
+- hmu RunStatsHMUHours = 26642
+- hmu RunStatsHwcHours = 1135
+- hmu SetMode = auto;0.0;-;-;1;1;1;0;0;0
+- hmu SetMode = no data stored
+- hmu Status01 = 48.0;46.0;-;-;-;off
+- hmu Status02 = no data stored
+- 'hmu Status16 =  (ERR: invalid position for 3108b5040116 / 00)'
+- 'hmu Status =  (ERR: invalid position for 3108b5110103 / 00)'
+- hmu StatusCirPump = on
+- hmu SupplyTempWeighted = 20.00
+- hmu TotalEnergyUsage = 8556
+- hmu YieldCoolDay = 0.0
+- hmu YieldCooling = 0.0
+- hmu YieldCoolingMonth = 0.0
+- hmu YieldHc = 10137
+- hmu YieldHcDay = 0.0
+- hmu YieldHcMonth = 2.3
+- hmu YieldHwc = 4709
+- hmu YieldHwcDay = 1.1
+- hmu YieldHwcMonth = 69.3
+- Memory Eeprom = no data stored
+- Memory Eeprom = no data stored
+- Memory Ram = no data stored
+- Memory Ram = no data stored
+- Scan Id = no data stored
+- scan.08  = Vaillant;HMU00;0522;5103
+- scan.15  = Vaillant;CTLV2;0514;1104
+- Scan.15 Id = 21;22;51;0020260913;0953;045677;N9
+- scan.18  = Vaillant;V32;0106;6004
+- Scan.18 Id = 21;22;41;0010022017;0001;005945;N9
+- scan.26  = Vaillant;VR_71;0100;5904
+- Scan.26 Id = 21;22;42;0020184847;0082;020249;N7
+- scan.35  = Vaillant;VR_92;0514;1204
+- Scan.35 Id = 21;22;18;0020260925;0953;009293;N2
+- scan.76  = Vaillant;VWZIO;0901;5103
+- Scan.76 Id = 21;23;03;0010034193;1610;005152;N2
+- scan.f6  = Vaillant;NETX3;0129;0404
+- Scan.f6 Id = 21;22;45;0020292012;0933;083357;N0
+- v32 AccessoriesOne = no data stored
+- v32 AccessoriesOne = no data stored
+- v32 AccessoriesTwo = no data stored
+- v32 AccessoriesTwo = no data stored
+- v32 ACRoomthermostat = no data stored
+- v32 APCComStatus = no data stored (message not available due to condition)
+- v32 APCLegioProtection = no data stored (message not available due to condition)
+- v32 APCLegioProtection = no data stored (message not available due to condition)
+- v32 AverageIgnitiontime = no data stored
+- v32 BlockTimeHcMax = no data stored
+- v32 BlockTimeHcMax = no data stored
+- v32 BoilerType = no data stored
+- v32 ChangesDSN = no data stored
+- v32 CirPump = no data stored
+- v32 Clearerrorhistory = no data stored
+- v32 CounterStartattempts1 = no data stored
+- v32 CounterStartattempts2 = 2
+- v32 CounterStartAttempts3 = no data stored
+- v32 CounterStartAttempts4 = no data stored
+- v32 Currenterror = -;-;-;-;-
+- v32 DateTime = nosignal;-:-:-;-.-.-;-
+- v32 DcfState = no data stored
+- v32 DCFTimeDate = no data stored
+- v32 DCRoomthermostat = no data stored
+- v32 DeactivationsIFC = no data stored
+- v32 DeactivationsTemplimiter = 0
+- v32 DeltaFlowReturnMax = no data stored
+- v32 DisplayMode = no data stored
+- v32 DSN = no data stored
+- v32 DSNOffset = no data stored
+- v32 DSNOffset = no data stored
+- v32 DSNStart = no data stored
+- v32 EBusHeatcontrol = no data stored
+- v32 EbusSourceOn = no data stored
+- v32 EbusVoltage = no data stored
+- v32 Errorhistory = no data stored
+- v32 Expertlevel_ReturnTemp = no data stored
+- v32 ExternalFaultmessage = no data stored
+- 'v32 ExternalFlowTempDesired =  (ERR: invalid position for 3118b509030d2500 / 00)'
+- v32 ExternalHwcSwitch = no data stored
+- v32 ExternGasvalve = no data stored
+- 'v32 ExtFlowTempDesiredMin =  (ERR: invalid position for 3118b509030d6e04 / 00)'
+- v32 ExtStorageModulCon = no data stored
+- v32 ExtWP = no data stored
+- v32 FanHours = 96
+- v32 FanMaxSpeedOperation = no data stored
+- v32 FanMinSpeedOperation = no data stored
+- v32 FanPWMSum = no data stored
+- v32 FanPWMTest = no data stored
+- v32 FanSpeed = no data stored
+- v32 FanSpeedOffsetMax = no data stored
+- v32 FanSpeedOffsetMax = no data stored
+- v32 FanSpeedOffsetMin = no data stored
+- v32 FanSpeedOffsetMin = no data stored
+- v32 FanStarts = 444
+- v32 Flame = no data stored
+- v32 FlameSensingASIC = no data stored
+- v32 FloorHeatingContact = no data stored
+- v32 FlowsetHcMax = no data stored
+- v32 FlowsetHcMax = no data stored
+- v32 FlowsetHwcMax = no data stored
+- v32 FlowsetHwcMax = no data stored
+- v32 FlowSetPotmeter = no data stored
+- v32 FlowTemp = 47.06;ok
+- v32 FlowTempDesired = 0.00
+- v32 FlowTempMax = 85.81
+- v32 Fluegasvalve = no data stored
+- v32 FluegasvalveOpen = no data stored
+- v32 Gasvalve3UC = no data stored
+- v32 Gasvalve = no data stored
+- v32 GasvalveASICFeedback = no data stored
+- v32 GasvalveUC = no data stored
+- v32 GasvalveUCFeedback = no data stored
+- v32 HcHours = 47
+- v32 HcPumpMode = post_run
+- v32 HcPumpMode = no data stored
+- v32 HcPumpStarts = 2288
+- v32 HcStarts = 0
+- v32 HcUnderHundredStarts = 0
+- v32 HeatingSwitch = no data stored
+- v32 HoursTillService = 2
+- v32 HoursTillService = no data stored
+- v32 HwcDemand = no data stored
+- v32 HwcHours = 41
+- v32 HwcImpellorSwitch = no data stored
+- v32 HwcPostrunTime = no data stored
+- v32 HwcPostrunTime = no data stored
+- v32 HwcSetPotmeter = no data stored
+- v32 HwcStarts = 0
+- v32 HwcSwitch = no data stored
+- v32 HwcTemp = 116.06;circuit
+- v32 HwcTempDesired = 0.00
+- 'v32 HwcTempMax =  (ERR: invalid position for 3118b509030d4304 / 01f0)'
+- v32 HwcTempMax = no data stored
+- v32 HwcTypes = no data stored
+- v32 HwcUnderHundredStarts = 3
+- v32 HwcWaterflow = no data stored
+- v32 HwcWaterflowMax = no data stored
+- v32 Ignitor = no data stored
+- v32 InitialisationEEPROM = no data stored
+- v32 IonisationVoltageLevel = no data stored
+- v32 Maintenancedata_HwcTempMax = 116.06
+- v32 MaxIgnitiontime = no data stored
+- v32 MinIgnitiontime = no data stored
+- v32 ModulationDesired = no data stored
+- v32 OutdoorstempSensor = -60.44;cutoff
+- v32 OverflowCounter = yes
+- v32 ParamToken = no data stored
+- v32 PartloadHcKW = no data stored
+- v32 PartloadHcKW = no data stored
+- v32 PartloadHwcKW = no data stored
+- v32 PartloadHwcKW = no data stored
+- v32 PartnumberBox = no data stored
+- v32 PositionValveSet = no data stored
+- 'v32 PowerValue =  (ERR: invalid position for 3118b509030daa00 / 00)'
+- 'v32 PrAPSCounter =  (ERR: invalid position for 3118b509030df200 / 00)'
+- v32 PrAPSSum = no data stored
+- 'v32 PrEnergyCountHc1 =  (ERR: invalid position for 3118b509030df600 / 00)'
+- v32 PrEnergyCountHc1 = no data stored
+- 'v32 PrEnergyCountHc2 =  (ERR: invalid position for 3118b509030df800 / 00)'
+- v32 PrEnergyCountHc2 = no data stored
+- v32 PrEnergyCountHc3 = no data stored
+- v32 PrEnergyCountHc3 = no data stored
+- 'v32 PrEnergyCountHwc1 =  (ERR: invalid position for 3118b509030dc600 / 00)'
+- v32 PrEnergyCountHwc1 = no data stored
+- v32 PrEnergyCountHwc2 = no data stored
+- v32 PrEnergyCountHwc2 = no data stored
+- v32 PrEnergyCountHwc3 = no data stored
+- v32 PrEnergyCountHwc3 = no data stored
+- 'v32 PrEnergySumHc1 =  (ERR: invalid position for 3118b509030df500 / 00)'
+- v32 PrEnergySumHc1 = no data stored
+- 'v32 PrEnergySumHc2 =  (ERR: invalid position for 3118b509030df700 / 00)'
+- v32 PrEnergySumHc2 = no data stored
+- v32 PrEnergySumHc3 = no data stored
+- v32 PrEnergySumHc3 = no data stored
+- 'v32 PrEnergySumHwc1 =  (ERR: invalid position for 3118b509030dc500 / 00)'
+- v32 PrEnergySumHwc1 = no data stored
+- 'v32 PrEnergySumHwc2 =  (ERR: invalid position for 3118b509030dc700 / 00)'
+- v32 PrEnergySumHwc2 = no data stored
+- v32 PrEnergySumHwc3 = no data stored
+- v32 PrEnergySumHwc3 = no data stored
+- v32 PrimaryCircuitFlowrate = no data stored
+- v32 ProductionByte = no data stored
+- 'v32 PrVortexFlowSensorValue =  (ERR: invalid position for 3118b509030df400 / 00)'
+- v32 PumpHours = 133
+- v32 PumpHwcFlowNumber = no data stored
+- v32 PumpHwcFlowSum = no data stored
+- v32 PumpPower = 0
+- 'v32 PumpPowerDesired =  (ERR: invalid position for 3118b509030da100 / 00)'
+- v32 PumpPowerDesired = no data stored
+- v32 RemainingBoilerblocktime = no data stored
+- v32 ReturnRegulation = no data stored
+- v32 ReturnRegulation = no data stored
+- v32 ReturnTemp = 55.31;64650;ok
+- v32 ReturnTempMax = 83.94
+- v32 SecondPumpMode = 0
+- v32 SecondPumpMode = no data stored
+- v32 SerialNumber = no data stored
+- v32 SetFactoryValues = no data stored
+- v32 SetFactoryValues = no data stored
+- v32 SetMode = auto;0.0;-;-;1;0;0;0;0;0
+- v32 SetMode = no data stored
+- v32 SHEMaxDeltaHwcFlow = no data stored
+- v32 SHEMaxFlowTemp = no data stored
+- v32 SolPostHeat = no data stored
+- v32 SolPostHeat = no data stored
+- v32 Statenumber = no data stored
+- v32 Status01 = 43.5;53.0;-;-;62.0;off
+- v32 Status02 = auto;60;68.0;70;70.0
+- 'v32 Status16 =  (ERR: invalid position for 3118b5040116 / 00)'
+- 'v32 Status =  (ERR: invalid position for 3118b5110103 / 00)'
+- v32 StatusCirPump = on
+- v32 Storageloadpump = no data stored
+- v32 StorageLoadPumpHours = 45
+- v32 StorageloadPumpStarts = 190
+- v32 StorageLoadTimeMax = no data stored
+- v32 StorageLoadTimeMax = no data stored
+- v32 StoragereleaseClock = no data stored
+- v32 StorageTemp = 62.25;ok
+- v32 StorageTempDesired = 46.00
+- v32 StorageTempMax = 72.75
+- v32 TargetFanSpeed = no data stored
+- v32 TargetFanSpeedOutput = no data stored
+- v32 TempDiffBlock = 0
+- v32 TempDiffFailure = 0
+- v32 TempGradientFailure = 0
+- v32 Templimiter = off
+- v32 TemplimiterWithNTC = yes
+- 'v32 TempMaxDiffExtTFT =  (ERR: invalid position for 3118b509030d2700 / 00)'
+- v32 Testbyte = no data stored
+- 'v32 TimerInputHc =  (ERR: invalid position for 3118b509030dde00 / 00)'
+- v32 ValveMode = 0
+- v32 ValveMode = no data stored
+- v32 ValveStarts = 2454
+- v32 VolatileLockout = no data stored
+- v32 VolatileLockoutIFCGV = no data stored
+- 'v32 VortexFlowSensor =  (ERR: invalid position for 3118b509030dd500 / 00)'
+- v32 WarmstartDemand = no data stored
+- v32 WarmstartOffset = no data stored
+- v32 WarmstartOffset = no data stored
+- v32 WaterHcFlowMax = no data stored
+- v32 WaterPressure = 1.771;ok
+- v32 WaterpressureBranchControlOff = no data stored
+- v32 WaterpressureMeasureCounter = 118
+- v32 WaterpressureVariantSum = no data stored
+- v32 WP = no data stored
+- v32 WPPostrunTime = 1
+- v32 WPPostrunTime = no data stored
+- v32 WPSecondStage = no data stored
+- vr_71 Clearerrorhistory = no data stored
+- vr_71 Currenterror = -;-;-;-;-
+- vr_71 Errorhistory = no data stored
+- vr_71 Mc1Operation = off;0.0;on;-100
+- vr_71 Mc2Operation = off;0.0;on;-100
+- vr_71 Mc3Operation = no data stored
+- vr_71 SensorData1 = 32.19;30.12;24.94;-;-;-;-;40 3d
+- vr_71 SensorData2 = -;-;-;-;0.00;8.00;80 57 05
+- vr_71 SetActorState = -;-;off;off;off;off;-;-;-;-;off;off;00 00
+- vwzio EnableTestHwcTemp = no data stored
+- vwzio EnableTestOutdoorTemp = no data stored
+- vwzio EnableTestThreeWayValve = no data stored
+- vwzio TestHwcTemp = no data stored
+- vwzio TestOutdoorTemp = no data stored
+- vwzio TestThreeWayValve = no data stored
+- ''

--- a/tests/test_b516_registers.py
+++ b/tests/test_b516_registers.py
@@ -100,26 +100,68 @@ def test_b516_cooling_register_entities() -> None:
         "hmu CoolEnvYieldDay = 8000",
         "hmu CoolEnvYieldMonth = 139818",
         "hmu CoolElecConsTotal = 153000",
+        "hmu CoolElecConsDay = 1200",
+        "hmu HcElecConsTotal = 2400000",
+        "hmu HcElecConsDay = 18000",
+        "hmu HwcElecConsTotal = 950000",
+        "hmu HwcElecConsDay = 7000",
+        # CSV/find-based electric registers that supplement the b516 counters.
+        "hmu ConsumptionTotal = 12345",
+        "hmu RunDataElectricPowerConsumption = 1500",
+        "hmu LiveMonitorCurrentConsumedPower = 15",
+        "hmu StatSolarEnergySum = 0",
+        "hmu StatSolarEnergySumHc = 0",
+        "hmu StatSolarEnergySumHwc = 0",
     ]
     graph = DiscoveryService.build_device_graph(lines)
     entities = EntityFactoryService().generate(graph)
     by_key = {e.key: e for e in entities}
 
     expected_names = {
-        "hmu.CoolEnvYieldTotal.value": "Cooling Energy Total",
-        "hmu.CoolEnvYieldDay.value": "Cooling Energy Today",
-        "hmu.CoolEnvYieldMonth.value": "Cooling Energy Month",
-        "hmu.CoolElecConsTotal.value": "Cooling Electricity Total",
+        "hmu.CoolEnvYieldTotal.value": ("Cooling Energy Total", "Wh"),
+        "hmu.CoolEnvYieldDay.value": ("Cooling Energy Today", "Wh"),
+        "hmu.CoolEnvYieldMonth.value": ("Cooling Energy Month", "Wh"),
+        "hmu.CoolElecConsTotal.value": ("Cooling Electricity Total", "Wh"),
+        "hmu.CoolElecConsDay.value": ("Cooling Electricity Today", "Wh"),
+        "hmu.HcElecConsTotal.value": ("Heating Electricity Total", "Wh"),
+        "hmu.HcElecConsDay.value": ("Heating Electricity Today", "Wh"),
+        "hmu.HwcElecConsTotal.value": ("DHW Electricity Total", "Wh"),
+        "hmu.HwcElecConsDay.value": ("DHW Electricity Today", "Wh"),
+        "hmu.ConsumptionTotal.value": ("Electrical Energy Consumption", "kWh"),
+        "hmu.StatSolarEnergySum.value": ("Solar Energy Sum", "kWh"),
+        "hmu.StatSolarEnergySumHc.value": ("Solar Energy Sum (Heating)", "kWh"),
+        "hmu.StatSolarEnergySumHwc.value": ("Solar Energy Sum (DHW)", "kWh"),
     }
-    for key, friendly in expected_names.items():
+    for key, (friendly, unit) in expected_names.items():
         entity = by_key.get(key)
         assert entity is not None, f"{key} must be an entity"
         assert entity.meta.friendly_name == friendly
         assert entity.entity_type == "sensor"
         assert entity.meta.device_class == "energy"
-        assert entity.meta.unit == "Wh"
+        assert entity.meta.unit == unit
 
-    assert by_key["hmu.CoolEnvYieldTotal.value"].meta.state_class == "total_increasing"
-    assert by_key["hmu.CoolElecConsTotal.value"].meta.state_class == "total_increasing"
-    # Daily/monthly yields reset, so they must not be marked total_increasing.
-    assert by_key["hmu.CoolEnvYieldDay.value"].meta.state_class != "total_increasing"
+    # Lifetime totals are monotonic; daily counters reset each day.
+    for key in (
+        "hmu.CoolEnvYieldTotal.value",
+        "hmu.CoolElecConsTotal.value",
+        "hmu.HcElecConsTotal.value",
+        "hmu.HwcElecConsTotal.value",
+        "hmu.ConsumptionTotal.value",
+        "hmu.StatSolarEnergySum.value",
+        "hmu.StatSolarEnergySumHc.value",
+        "hmu.StatSolarEnergySumHwc.value",
+    ):
+        assert by_key[key].meta.state_class == "total_increasing"
+    for key in (
+        "hmu.CoolEnvYieldDay.value",
+        "hmu.CoolElecConsDay.value",
+        "hmu.HcElecConsDay.value",
+        "hmu.HwcElecConsDay.value",
+    ):
+        assert by_key[key].meta.state_class != "total_increasing"
+
+    # Power registers use the power device class with the upstream units.
+    assert by_key["hmu.RunDataElectricPowerConsumption.value"].meta.device_class == "power"
+    assert by_key["hmu.RunDataElectricPowerConsumption.value"].meta.unit == "W"
+    assert by_key["hmu.LiveMonitorCurrentConsumedPower.value"].meta.device_class == "power"
+    assert by_key["hmu.LiveMonitorCurrentConsumedPower.value"].meta.unit == "kW"

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -492,7 +492,7 @@ async def test_define_custom_registers_delegates_to_ebus() -> None:
         c.ebus = mock_ebus
         await c._define_custom_registers()
 
-        assert mock_ebus.define_register.call_count == 22
+        assert mock_ebus.define_register.call_count == 27
         calls = [c.args[0] for c in mock_ebus.define_register.call_args_list]
         assert any("z1RoomHumidity" in d for d in calls)
         assert any("ManualCoolingStartDate" in d and d.startswith("r5") for d in calls)
@@ -505,6 +505,14 @@ async def test_define_custom_registers_delegates_to_ebus() -> None:
         assert any("CoolElecConsTotal" in d and "1000ffff03050000" in d for d in calls)
         assert any(",B516,1001ffff0205" in d for d in calls)
         assert any(",B516,1002ffff0205" in d for d in calls)
+        # Daily electric for cooling (issue #50 follow-up) plus the lifetime and
+        # daily electric counters for heating (Z=3) and DHW (Z=4) on the same
+        # b516 statistics API.
+        assert any("CoolElecConsDay" in d and ",B516,1001ffff0305" in d for d in calls)
+        assert any("HcElecConsTotal" in d and "1000ffff03030000" in d for d in calls)
+        assert any("HcElecConsDay" in d and ",B516,1001ffff0303" in d for d in calls)
+        assert any("HwcElecConsTotal" in d and "1000ffff03040000" in d for d in calls)
+        assert any("HwcElecConsDay" in d and ",B516,1001ffff0304" in d for d in calls)
         # SourceTempInput runtime define (issue #49), layout verified upstream
         # in john30/ebusd-configuration PR #565 on brine units.
         assert any(

--- a/tests/test_no_data_values.py
+++ b/tests/test_no_data_values.py
@@ -35,9 +35,33 @@ def test_prefix_and_error_forms() -> None:
         assert is_no_data_value(raw), f"{raw!r} should be no-data"
 
 
+# Sensor fault statuses (Values_sensor enum: circuit=85, cutoff=170) mean the
+# sensor is not present, so the register carries no usable measurement.
+def test_sensor_fault_statuses_are_no_data() -> None:
+    for raw in (
+        "116.06;circuit",
+        "-60.44;cutoff",
+        "circuit",
+        "cutoff",
+    ):
+        assert is_no_data_value(raw), f"{raw!r} should be no-data"
+
+
 # Real measured values and legitimate domain strings stay live
 def test_live_values_pass() -> None:
-    for raw in ("21.5", "none", "on", "off", "day", "auto", "58.0;1200"):
+    for raw in (
+        "21.5",
+        "none",
+        "on",
+        "off",
+        "day",
+        "auto",
+        "58.0;1200",
+        "55.31;64650;ok",
+        "47.06;ok",
+        "1.771;ok",
+        "43.5;53.5;-;-;62.0;off",
+    ):
         assert not is_no_data_value(raw), f"{raw!r} should stay live"
 
 

--- a/tests/test_v32_boiler.py
+++ b/tests/test_v32_boiler.py
@@ -1,0 +1,218 @@
+"""Tests for the v32 gas-boiler community fixture (GitHub issue #83).
+
+The fixture captures a hybrid system: heat pump (HMU00) plus an ecoTEC plus gas
+boiler exposed on the v32 circuit through a VR32 interface board (CSV
+08.bai.csv copied as 18.v32.csv). These tests pin the boiler register behavior:
+metadata, multi-field splitting, sensor-fault filtering, and the absence of
+ventilation-only registers.
+"""
+
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import sys
+from pathlib import Path
+
+from tests.fake_ebusd import load_find_lines
+
+BACKEND_PATH = Path(__file__).parents[1] / "custom_components/vaillant_ebus/backend"
+COMPONENT_PATH = BACKEND_PATH.parent
+
+for name in ("vaillant_ebus", "vaillant_ebus.backend"):
+    pkg = importlib.util.module_from_spec(importlib.machinery.ModuleSpec(name, None))
+    pkg.__path__ = [str(COMPONENT_PATH)] if name == "vaillant_ebus" else [str(BACKEND_PATH)]
+    sys.modules[name] = pkg
+
+MODELS_SPEC = importlib.util.spec_from_file_location("vaillant_ebus.backend.models", BACKEND_PATH / "models.py")
+assert MODELS_SPEC and MODELS_SPEC.loader
+MODELS = importlib.util.module_from_spec(MODELS_SPEC)
+sys.modules["vaillant_ebus.backend.models"] = MODELS
+MODELS_SPEC.loader.exec_module(MODELS)
+
+MAPPING_SPEC = importlib.util.spec_from_file_location(
+    "vaillant_ebus.backend.mapping", BACKEND_PATH / "mapping.py"
+)
+assert MAPPING_SPEC and MAPPING_SPEC.loader
+MAPPING = importlib.util.module_from_spec(MAPPING_SPEC)
+sys.modules["vaillant_ebus.backend.mapping"] = MAPPING
+MAPPING_SPEC.loader.exec_module(MAPPING)
+
+ENTITY_SPEC = importlib.util.spec_from_file_location(
+    "vaillant_ebus.backend.entity_factory", BACKEND_PATH / "entity_factory.py"
+)
+assert ENTITY_SPEC and ENTITY_SPEC.loader
+ENTITY = importlib.util.module_from_spec(ENTITY_SPEC)
+sys.modules["vaillant_ebus.backend.entity_factory"] = ENTITY
+ENTITY_SPEC.loader.exec_module(ENTITY)
+
+DISCOVERY_SPEC = importlib.util.spec_from_file_location(
+    "vaillant_ebus.backend.discovery_service", BACKEND_PATH / "discovery_service.py"
+)
+assert DISCOVERY_SPEC and DISCOVERY_SPEC.loader
+DISCOVERY = importlib.util.module_from_spec(DISCOVERY_SPEC)
+sys.modules["vaillant_ebus.backend.discovery_service"] = DISCOVERY
+DISCOVERY_SPEC.loader.exec_module(DISCOVERY)
+
+DiscoveryService = DISCOVERY.DiscoveryService
+DeviceType = DISCOVERY.DeviceType
+
+V32_BOILER_LINES = load_find_lines("community/v32_boiler_discovery.yaml")
+
+# Ventilation-only registers from the bai CSV that must never become entities
+# on this boiler setup (they return ERR: element not found).
+VENTILATION_ONLY_REGISTERS = (
+    "BypassPosition",
+    "ExhaustAirHumidity",
+    "ExhaustAirTemp",
+    "MaxAirHumidity",
+    "MinAirHumidity",
+    "OutsideAirTemp",
+    "SupplyAirTemp",
+    "VentilationLevelDay",
+    "VentilationLevelNight",
+    "YieldMonth",
+    "YieldToday",
+    "YieldTotal",
+    "YieldYear",
+)
+
+
+def _graph():
+    return DiscoveryService.build_device_graph(V32_BOILER_LINES)
+
+
+def _v32_entities():
+    return [e for e in ENTITY.EntityFactoryService().generate(_graph()) if e.circuit == "v32"]
+
+
+def test_v32_boiler_graph() -> None:
+    graph = _graph()
+    node = graph.nodes["v32"]
+    assert node.has_data is True
+    assert "v32.FlowTemp" in graph.raw_registers
+    assert "v32.ReturnTemp" in graph.raw_registers
+    assert "v32.WaterPressure" in graph.raw_registers
+    # The boiler registers surface as a DHW sub-device of v32.
+    assert "v32.HwcHours" in graph.nodes["dhw"].registers
+
+
+# Category 1 from issue #83: sensors missing device_class/unit.
+def test_v32_boiler_temperature_metadata() -> None:
+    by_key = {e.key: e for e in _v32_entities()}
+    for key in (
+        "v32.ReturnTemp.value",
+        "v32.StorageTemp.value",
+        "v32.StorageTempDesired.value",
+        "v32.FlowTempDesired.value",
+        "v32.FlowTempMax.value",
+        "v32.ReturnTempMax.value",
+    ):
+        meta = by_key[key].meta
+        assert meta.device_class == "temperature", key
+        assert meta.unit == "°C", key
+
+
+def test_v32_boiler_duration_metadata() -> None:
+    by_key = {e.key: e for e in _v32_entities()}
+    for key, state_class in (
+        ("v32.FanHours.value", "total_increasing"),
+        ("v32.HcHours.value", "total_increasing"),
+        ("v32.HwcHours.value", "total_increasing"),
+        ("v32.PumpHours.value", "total_increasing"),
+        ("v32.StorageLoadPumpHours.value", "total_increasing"),
+        ("v32.HoursTillService.value", ""),
+    ):
+        meta = by_key[key].meta
+        assert meta.device_class == "duration", key
+        assert meta.unit == "h", key
+        assert meta.state_class == state_class, key
+
+
+def test_v32_boiler_pump_power_and_pressure() -> None:
+    by_key = {e.key: e for e in _v32_entities()}
+    pump = by_key["v32.PumpPower.value"]
+    assert pump.entity_type == "sensor", "PumpPower must not be a binary_sensor"
+    assert pump.meta.device_class == "power"
+    assert pump.meta.unit == "W"
+
+    pressure = by_key["v32.WaterPressure.value"]
+    assert pressure.meta.device_class == "pressure"
+    assert pressure.meta.unit == "bar"
+
+
+# Category 2 from issue #83: semicolon-separated values must be split.
+def test_v32_boiler_multi_field_split() -> None:
+    split = MAPPING.split_multi_field
+    assert split("v32.ReturnTemp", "55.31;64650;ok")["value"] == "55.31"
+    assert split("v32.FlowTemp", "47.06;ok")["value"] == "47.06"
+    assert split("v32.StorageTemp", "62.25;ok")["value"] == "62.25"
+    assert split("v32.WaterPressure", "1.771;ok")["value"] == "1.771"
+    status01 = split("v32.Status01", "43.5;53.5;-;-;62.0;off")
+    assert status01 == {
+        "value": "43.5;53.5;-;-;62.0;off",
+        "temp": "43.5",
+        "temp_1": "53.5",
+        "temp_2": "-",
+        "temp_3": "-",
+        "temp_4": "62.0",
+        "pumpstate": "off",
+    }
+    status02 = split("v32.Status02", "auto;60;68.0;70;70.0")
+    assert status02 == {
+        "value": "auto;60;68.0;70;70.0",
+        "hwcmode": "auto",
+        "temp0": "60",
+        "temp1": "68.0",
+        "temp0_1": "70",
+        "temp1_1": "70.0",
+    }
+
+
+def test_v32_boiler_status_entities() -> None:
+    entities = _v32_entities()
+    by_key = {e.key: e for e in entities}
+    # Status01 fields reuse the hmu Status01 metadata via the circuit alias.
+    # Field entities are keyed without a ".value" suffix.
+    assert by_key["v32.Status01.temp"].meta.device_class == "temperature"
+    assert by_key["v32.Status01.temp_1"].meta.device_class == "temperature"
+    assert by_key["v32.Status01.pumpstate"].entity_type == "binary_sensor"
+    # Single-field mappings must not create a duplicate base "value" entity.
+    assert sum(1 for e in entities if e.key == "v32.FlowTemp.value") == 1
+    assert sum(1 for e in entities if e.key == "v32.ReturnTemp.value") == 1
+    assert by_key["v32.FlowTemp.value"].raw_value == "47.06;ok"
+    assert by_key["v32.ReturnTemp.value"].raw_value == "55.31;64650;ok"
+
+
+# Category 3 from issue #83: ventilation-only registers must not appear.
+def test_v32_boiler_ventilation_registers_absent() -> None:
+    names = {e.name for e in _v32_entities()}
+    for name in VENTILATION_ONLY_REGISTERS:
+        assert name not in names, f"ventilation-only register {name} must not be an entity"
+
+
+# Category 4 from issue #83: faulty-sensor values must carry no data.
+def test_v32_boiler_faulty_sensor_values_no_data() -> None:
+    graph = _graph()
+    # Sensor-fault statuses ("circuit"/"cutoff") are parsed as no-data.
+    assert "v32.HwcTemp" not in graph.raw_registers
+    assert "v32.OutdoorstempSensor" not in graph.raw_registers
+    assert DiscoveryService._parse_register("v32 HwcTemp = 116.06;circuit")[2] is None
+    assert DiscoveryService._parse_register("v32 OutdoorstempSensor = -60.44;cutoff")[2] is None
+
+    by_key = {e.key: e for e in _v32_entities()}
+    # The faulty-sensor entities exist but stay disabled by default.
+    assert by_key["v32.HwcTemp.value"].enabled_by_default is False
+    assert by_key["v32.OutdoorstempSensor.value"].enabled_by_default is False
+    # The maintenance max of the same faulty sensor is diagnostic + disabled.
+    maint = by_key["v32.Maintenancedata_HwcTempMax.value"]
+    assert maint.enabled_by_default is False
+    assert maint.meta.entity_category == "diagnostic"
+
+
+# The healthy sibling values keep working after the fault filtering.
+def test_v32_boiler_valid_values_stay_live() -> None:
+    graph = _graph()
+    assert graph.raw_registers["v32.ReturnTemp"] == "55.31;64650;ok"
+    assert graph.raw_registers["v32.FlowTemp"] == "47.06;ok"
+    assert graph.raw_registers["v32.WaterPressure"] == "1.771;ok"


### PR DESCRIPTION
Release v1.5.3.

### Added

- Daily electric consumption counters for cooling, heating, and DHW on the b516 statistics API (issue #50 follow-up): `CoolElecConsDay`, `HcElecConsDay`, `HwcElecConsDay`, plus lifetime electric totals `HcElecConsTotal` and `HwcElecConsTotal`. Layout verified upstream (john30/ebusd-configuration #490) and consistent with the already live-verified cooling family.
- Additional electric registers from the standard find output (issue #50): `hmu.ConsumptionTotal`, `hmu.RunDataElectricPowerConsumption`, `hmu.LiveMonitorCurrentConsumedPower`, and the `hmu.StatSolarEnergySum*` family — opt-in, metadata-only.
- v32 gas boiler (ecoTEC plus via VR32) register handling fixes (#83).

See CHANGELOG.md for details.