### PR TITLE
release: v1.5.4 - cooling-program calendars (#92), DHW boost desired-state fix (#31)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ captures/
 /scripts/
 strings.json
 data-dump/
+.analysis/
 discovery_dumps/
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## 1.5.4 - 2026-08-27
+
+### Added
+
+- **Read-only cooling-program calendars (#92).** The bus carries separate
+  per-day cooling schedules (`Z1CoolingTimer_*` / `Z2CoolingTimer_*`) alongside
+  the heating (`CcTimer`), zone (`Z1Timer`), and DHW (`HwcTimer`) programs, which
+  is what the Vaillant app uses for heating and cooling intervals independently.
+  Adds additive **"Cooling Program"** and **"Cooling Program 2"** calendar
+  entities that populate from those registers and stay empty on hardware that
+  does not expose them. The write side (setting intervals from Home Assistant)
+  remains a follow-up.
+
+### Fixed
+
+- **DHW boost switch/water-heater state (#31).** `HwcSFMode` reports "load"
+  while the cylinder is actively charging even after boost is turned off, so a
+  switch reading the raw register could never flip back to off until the charge
+  finished. The boost switch and water heater now track the desired DHW boost
+  state (falling back to the raw register on first load), so the switch reflects
+  a toggle immediately. The `HwcSFMode` write is now verified non-strictly
+  (ebusd answers "done" while the physical state lags the accepted write); all
+  other writes keep strict read-back verification. MichaelLachmann's boost
+  on/off discovery dumps were adopted as community fixtures with a regression
+  test.
+
 ## 1.5.3 - 2026-08-27
 
 ### Added

--- a/custom_components/vaillant_ebus/backend/ebus_service.py
+++ b/custom_components/vaillant_ebus/backend/ebus_service.py
@@ -27,6 +27,35 @@ def _strip_suffix(value: str) -> str:
     return value
 
 
+# Normalize a register value for write/read-back comparison. ebusd echoes
+# multi-field registers with ";" separators while callers write them with
+# spaces, and numeric fields may gain or lose trailing zeros. Split on either
+# separator and compare field-wise so only real value changes are flagged.
+def _value_tokens(value: str) -> list[str]:
+    return [tok for tok in value.replace(";", " ").split() if tok]
+
+
+# Compare a written value against the ebusd read-back, tolerating separator
+# and numeric-format differences but not actual value changes. Used to detect
+# writes that ebusd accepted but did not apply (e.g. HwcSFMode stays "load"
+# after writing "auto" while a boost cycle is still running).
+def _values_match(written: str, read_back: str) -> bool:
+    written_tokens = _value_tokens(written)
+    read_tokens = _value_tokens(read_back)
+    if len(written_tokens) != len(read_tokens):
+        return False
+    for expected, actual in zip(written_tokens, read_tokens):
+        if expected == actual:
+            continue
+        try:
+            if float(expected) == float(actual):
+                continue
+        except ValueError:
+            pass
+        return False
+    return True
+
+
 # Reject empty identifiers and CR/LF injection at the backend boundary, before
 # they are interpolated into protocol commands. Spaces and semicolons remain
 # valid inside register names and values (ebusd syntax).
@@ -200,8 +229,14 @@ class EbusService:
         raw = result.data.strip()
         return _strip_suffix(raw) if raw else None
 
-    # Write a value to an ebusd register, verify by read-back
-    async def write_register(self, circuit: str, name: str, value: str) -> WriteResult:
+    # Write a value to an ebusd register, verify by read-back. When
+    # strict_verify is False a read-back that does not match the written value
+    # is logged but not treated as a failure. This is used for registers whose
+    # physical state lags the accepted write (e.g. HwcSFMode keeps reporting
+    # "load" while the cylinder finishes charging after boost is turned off).
+    async def write_register(
+        self, circuit: str, name: str, value: str, strict_verify: bool = True
+    ) -> WriteResult:
         _validate_identifier("circuit", circuit)
         _validate_identifier("register name", name)
         cmd = f"write -c {circuit} {name} {value}"
@@ -216,6 +251,19 @@ class EbusService:
             return WriteResult(success=False, error_message="Write verification returned empty")
         if verified and verified.startswith("ERR:"):
             return WriteResult(success=False, error_message=f"Write verification failed: {verified}")
+        if verified and not _values_match(value, verified):
+            _LOGGER.warning(
+                "Write verification mismatch %s.%s: wrote %r, read back %r",
+                circuit,
+                name,
+                value,
+                verified,
+            )
+            if strict_verify:
+                return WriteResult(
+                    success=False,
+                    error_message=f"Write verification mismatch: wrote {value!r}, read back {verified!r}",
+                )
         return WriteResult(success=True, verified_value=verified)
 
     # Send 'info' command and parse key=value response

--- a/custom_components/vaillant_ebus/calendar.py
+++ b/custom_components/vaillant_ebus/calendar.py
@@ -19,6 +19,11 @@ SCHEDULES = {
     "Heating Program": "CcTimer",
     "Zone Program": "Z1Timer",
     "Domestic Hot Water Program": "HwcTimer",
+    # Additive: empty on hardware without cooling-timer registers. The bus
+    # carries separate per-day cooling schedules (Z1/Z2CoolingTimer_*), which
+    # the Vaillant app uses for heating/cooling intervals independently.
+    "Cooling Program": "Z1CoolingTimer",
+    "Cooling Program 2": "Z2CoolingTimer",
 }
 
 

--- a/custom_components/vaillant_ebus/coordinator.py
+++ b/custom_components/vaillant_ebus/coordinator.py
@@ -110,6 +110,11 @@ class VaillantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._started = False
         self._ebusd_connected = False
         self._heating_circuit = "ctlv2"
+        # Desired DHW boost state (True when boost was requested). HwcSFMode
+        # reports "load" while the cylinder charges even after boost is turned
+        # off, so the switch/water-heater report this desired value instead of
+        # the raw register. None until the user toggles boost.
+        self.dhw_boost_desired: bool | None = None
 
         self.ebus: EbusService | None = None
         self.discovery: DiscoveryService | None = None
@@ -875,11 +880,12 @@ class VaillantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     async def async_write_registers(
         self,
         writes: list[tuple[str, str, str]],
+        strict_verify: bool = True,
     ) -> bool:
         if not self.ebus or not self.ebus.is_connected:
             return False
         for circuit, name, value in writes:
-            result = await self.ebus.write_register(circuit, name, value)
+            result = await self.ebus.write_register(circuit, name, value, strict_verify=strict_verify)
             if not result.success:
                 _LOGGER.warning("Write failed %s.%s=%s: %s", circuit, name, value, result.error_message)
                 return False
@@ -887,8 +893,10 @@ class VaillantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         return True
 
     # Convenience wrapper for a single-register write through the central path.
-    async def async_write_register(self, circuit: str, name: str, value: str) -> bool:
-        return await self.async_write_registers([(circuit, name, value)])
+    async def async_write_register(
+        self, circuit: str, name: str, value: str, strict_verify: bool = True
+    ) -> bool:
+        return await self.async_write_registers([(circuit, name, value)], strict_verify=strict_verify)
 
     async def async_stop(self) -> None:
         if self._cancel_delayed_rediscovery:

--- a/custom_components/vaillant_ebus/manifest.json
+++ b/custom_components/vaillant_ebus/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/MarkBovee/vaillant-ebus/issues",
   "requirements": [],
-  "version": "1.5.3"
+  "version": "1.5.4"
 }

--- a/custom_components/vaillant_ebus/switch.py
+++ b/custom_components/vaillant_ebus/switch.py
@@ -199,9 +199,15 @@ class HwcBoostSwitch(CoordinatorEntity[VaillantCoordinator], SwitchEntity):
         self._attr_icon = "mdi:water-boiler"
         self._attr_device_info = coordinator.get_device_info("dhw")
 
-    # True when HwcSFMode register equals "load"
+    # True when DHW boost was requested (desired state), falling back to the
+    # raw HwcSFMode register on first load. The raw register reports "load"
+    # while the cylinder charges even after boost is turned off, so the desired
+    # state is the authoritative source once a toggle has happened.
     @property
     def is_on(self) -> bool | None:
+        desired = self.coordinator.dhw_boost_desired
+        if desired is not None:
+            return desired
         data = self.coordinator.data.get("ebusd", {})
         raw = data.get(f"{self.coordinator.heating_circuit}.HwcSFMode.value")
         if raw is None:
@@ -210,11 +216,17 @@ class HwcBoostSwitch(CoordinatorEntity[VaillantCoordinator], SwitchEntity):
 
     # Write "load" to HwcSFMode to start DHW boost
     async def async_turn_on(self, **kwargs: Any) -> None:
-        await self.coordinator.async_write_register(self.coordinator.heating_circuit, "HwcSFMode", "load")
+        self.coordinator.dhw_boost_desired = True
+        await self.coordinator.async_write_register(
+            self.coordinator.heating_circuit, "HwcSFMode", "load", strict_verify=False
+        )
 
     # Write "auto" to HwcSFMode to stop DHW boost
     async def async_turn_off(self, **kwargs: Any) -> None:
-        await self.coordinator.async_write_register(self.coordinator.heating_circuit, "HwcSFMode", "auto")
+        self.coordinator.dhw_boost_desired = False
+        await self.coordinator.async_write_register(
+            self.coordinator.heating_circuit, "HwcSFMode", "auto", strict_verify=False
+        )
 
 
 class HwcAwayModeSwitch(CoordinatorEntity[VaillantCoordinator], SwitchEntity):

--- a/custom_components/vaillant_ebus/water_heater.py
+++ b/custom_components/vaillant_ebus/water_heater.py
@@ -108,11 +108,15 @@ class EbusdWaterHeater(CoordinatorEntity[VaillantCoordinator], WaterHeaterEntity
         value = _float(_value(self.coordinator, "HwcTempDesired"))
         return value if value is not None and 30 <= value <= 70 else None
 
-    # Current operation mode: off/auto/manual/boost (boost from HwcSFMode)
+    # Current operation mode: off/auto/manual/boost (boost from desired DHW
+    # boost state, falling back to HwcSFMode on first load)
     @property
     def current_operation(self) -> str | None:
+        desired = self.coordinator.dhw_boost_desired
+        if desired is True:
+            return "boost"
         sf = (_value(self.coordinator, "HwcSFMode") or "").lower()
-        if sf == "load":
+        if desired is None and sf == "load":
             return "boost"
         operation = (_value(self.coordinator, "HwcOpMode") or "").lower()
         return EBUSD_TO_HA_OPMODE.get(operation)
@@ -133,14 +137,19 @@ class EbusdWaterHeater(CoordinatorEntity[VaillantCoordinator], WaterHeaterEntity
             raise ValueError(f"Unsupported DHW operation: {operation_mode}")
         ckt = self.coordinator.heating_circuit
         if operation_mode == "boost":
-            await self.coordinator.async_write_registers([(ckt, "HwcSFMode", "load")])
+            self.coordinator.dhw_boost_desired = True
+            await self.coordinator.async_write_registers(
+                [(ckt, "HwcSFMode", "load")], strict_verify=False
+            )
         else:
+            self.coordinator.dhw_boost_desired = False
             ebusd_mode = HA_TO_EBUSD_OPMODE.get(operation_mode, operation_mode)
             await self.coordinator.async_write_registers(
                 [
                     (ckt, "HwcSFMode", "auto"),
                     (ckt, "HwcOpMode", ebusd_mode),
-                ]
+                ],
+                strict_verify=False,
             )
 
     # Turn DHW on by setting operation mode to auto

--- a/tests/fixtures/community/arotherm_basv_boost_off_discovery.yaml
+++ b/tests/fixtures/community/arotherm_basv_boost_off_discovery.yaml
@@ -1,0 +1,13615 @@
+# Discovery dump for vaillant_ebus
+# Review this file for sensitive information before sharing
+metadata:
+  timestamp: '2026-08-26T11:18:07.268181'
+  ebusd_version: null
+  register_count: 743
+  grab_duration: 10
+  dump_version: 3
+raw_find_lines:
+- basv AdaptHeatCurve = no
+- basv AdaptHeatCurve = no data stored
+- basv BankHolidayEndPeriod = no data stored
+- basv BankHolidayEndPeriod = no data stored
+- basv BankHolidayStartPeriod = no data stored
+- basv BankHolidayStartPeriod = no data stored
+- basv CcTimer_Friday = no data stored
+- basv CcTimer_Friday = no data stored
+- basv CcTimer_Monday = no data stored
+- basv CcTimer_Monday = no data stored
+- basv CcTimer_Saturday = no data stored
+- basv CcTimer_Saturday = no data stored
+- basv CcTimer_Sunday = no data stored
+- basv CcTimer_Sunday = no data stored
+- basv CcTimer_Thursday = no data stored
+- basv CcTimer_Thursday = no data stored
+- basv CcTimer_Tuesday = no data stored
+- basv CcTimer_Tuesday = no data stored
+- basv CcTimer_Wednesday = no data stored
+- basv CcTimer_Wednesday = no data stored
+- basv Clearerrorhistory = no data stored
+- basv ContinuosHeating = -26
+- basv ContinuosHeating = no data stored
+- basv Currenterror = -;-;-;-;-
+- basv CylinderChargeHyst = 5
+- basv CylinderChargeHyst = no data stored
+- basv CylinderChargeOffset = 25
+- basv CylinderChargeOffset = no data stored
+- basv Date = 26.08.2026
+- basv Date = no data stored
+- basv DisplayedOutsideTemp = 21.4492
+- basv Errorhistory = no data stored
+- basv FrostOverRideTime = 4
+- basv FrostOverRideTime = no data stored
+- basv GlobalSystemOff = no
+- basv GlobalSystemOff = no data stored
+- basv Hc1ActualFlowTempDesired = 0.0
+- basv Hc1AutoOffMode = eco
+- basv Hc1AutoOffMode = no data stored
+- basv Hc1CircuitType = mixer
+- basv Hc1ExcessTemp = 0.0
+- basv Hc1ExcessTemp = no data stored
+- basv Hc1FlowTemp = 53
+- basv Hc1HeatCurve = 0.7
+- basv Hc1HeatCurve = no data stored
+- basv Hc1HeatCurveAdaption = 0.0
+- basv Hc1MaxFlowTempDesired = 60
+- basv Hc1MaxFlowTempDesired = no data stored
+- basv Hc1MinFlowTempDesired = 17
+- basv Hc1MinFlowTempDesired = no data stored
+- basv Hc1MixerMovement = 0.0
+- basv Hc1PumpStatus = 0
+- basv Hc1PumpStatus = no data stored
+- basv Hc1RoomTempSwitchOn = thermostat
+- basv Hc1RoomTempSwitchOn = no data stored
+- basv Hc1Status = 0
+- basv Hc1Status = no data stored
+- basv Hc1SummerTempLimit = 22
+- basv Hc1SummerTempLimit = no data stored
+- basv Hc2ActualFlowTempDesired = 0.0
+- basv Hc2AutoOffMode = eco
+- basv Hc2AutoOffMode = no data stored
+- basv Hc2CircuitType = inactive
+- basv Hc2ExcessTemp = 0.0
+- basv Hc2ExcessTemp = no data stored
+- basv Hc2FlowTemp =  (empty for 3115b52406020002010800 / 0800020800ffffff7f)
+- basv Hc2HeatCurve = 0.6
+- basv Hc2HeatCurve = no data stored
+- basv Hc2HeatCurveAdaption = 0.0
+- basv Hc2MaxFlowTempDesired = 55
+- basv Hc2MaxFlowTempDesired = no data stored
+- basv Hc2MinFlowTempDesired = 15
+- basv Hc2MinFlowTempDesired = no data stored
+- basv Hc2MixerMovement = 0.0
+- basv Hc2PumpStatus = 0
+- basv Hc2PumpStatus = no data stored
+- basv Hc2RoomTempSwitchOn = off
+- basv Hc2RoomTempSwitchOn = no data stored
+- basv Hc2Status = 0
+- basv Hc2Status = no data stored
+- basv Hc2SummerTempLimit = 21
+- basv Hc2SummerTempLimit = no data stored
+- basv Hc3ActualFlowTempDesired = 0.0
+- basv Hc3AutoOffMode = eco
+- basv Hc3AutoOffMode = no data stored
+- basv Hc3CircuitType = inactive
+- basv Hc3ExcessTemp = 0.0
+- basv Hc3ExcessTemp = no data stored
+- basv Hc3FlowTemp =  (empty for 3115b52406020002020800 / 0800020800ffffff7f)
+- basv Hc3HeatCurve = 0.6
+- basv Hc3HeatCurve = no data stored
+- basv Hc3HeatCurveAdaption = 0.0
+- basv Hc3MaxFlowTempDesired = 55
+- basv Hc3MaxFlowTempDesired = no data stored
+- basv Hc3MinFlowTempDesired = 15
+- basv Hc3MinFlowTempDesired = no data stored
+- basv Hc3MixerMovement = 0.0
+- basv Hc3PumpStatus = 0
+- basv Hc3PumpStatus = no data stored
+- basv Hc3RoomTempSwitchOn = off
+- basv Hc3RoomTempSwitchOn = no data stored
+- basv Hc3Status = 0
+- basv Hc3Status = no data stored
+- basv Hc3SummerTempLimit = 21
+- basv Hc3SummerTempLimit = no data stored
+- basv HcStorageTempBottom =  (empty for f115b5240602000000a000 / 080000a000ffffff7f)
+- basv HcStorageTempTop =  (empty for f115b52406020000009f00 / 0800009f00ffffff7f)
+- basv HolidayEndPeriod = no data stored
+- basv HolidayEndPeriod = no data stored
+- basv HolidayStartPeriod = no data stored
+- basv HolidayStartPeriod = no data stored
+- basv HolidayTemp = no data stored
+- basv HolidayTemp = no data stored
+- basv HwcBankHolidayEndPeriod = no data stored
+- basv HwcBankHolidayEndPeriod = no data stored
+- basv HwcBankHolidayStartPeriod = no data stored
+- basv HwcBankHolidayStartPeriod = no data stored
+- basv HwcFlowTemp = 93
+- basv HwcHolidayEndPeriod = 02.01.2026
+- basv HwcHolidayEndPeriod = no data stored
+- basv HwcHolidayStartPeriod = 30.12.2025
+- basv HwcHolidayStartPeriod = no data stored
+- basv HwcLockTime = 60
+- basv HwcLockTime = no data stored
+- basv HwcMaxFlowTempDesired = 80
+- basv HwcMaxFlowTempDesired = no data stored
+- basv HwcOpMode = auto
+- basv HwcOpMode = no data stored
+- basv HwcParallelLoading = off
+- basv HwcParallelLoading = no data stored
+- basv HwcSFMode = load
+- basv HwcSFMode = no data stored
+- basv HwcStorageTemp = 46
+- basv HwcStorageTempBottom =  (empty for f115b52406020000009e00 / 0800009e00ffffff7f)
+- basv HwcStorageTempTop =  (empty for f115b52406020000009d00 / 0800009d00ffffff7f)
+- basv HwcTempDesired = 68
+- basv HwcTempDesired = no data stored
+- basv HwcTimer_Friday = no data stored
+- basv HwcTimer_Friday = no data stored
+- basv HwcTimer_Monday = no data stored
+- basv HwcTimer_Monday = no data stored
+- basv HwcTimer_Saturday = no data stored
+- basv HwcTimer_Saturday = no data stored
+- basv HwcTimer_Sunday = no data stored
+- basv HwcTimer_Sunday = no data stored
+- basv HwcTimer_Thursday = no data stored
+- basv HwcTimer_Thursday = no data stored
+- basv HwcTimer_Tuesday = no data stored
+- basv HwcTimer_Tuesday = no data stored
+- basv HwcTimer_Wednesday = no data stored
+- basv HwcTimer_Wednesday = no data stored
+- basv HydraulicScheme = 8
+- basv HydraulicScheme = no data stored
+- basv Installer1 = no data stored
+- basv Installer1 = no data stored
+- basv Installer2 = no data stored
+- basv Installer2 = no data stored
+- basv KeyCodeforConfigMenu = no data stored
+- basv KeyCodeforConfigMenu = no data stored
+- basv MaintenanceDate = no data stored
+- basv MaintenanceDate = no data stored
+- basv MaintenanceDue = no data stored
+- basv ManualCooling = no data stored
+- basv ManualCooling = no data stored
+- basv MaxCylinderChargeTime = 120
+- basv MaxCylinderChargeTime = no data stored
+- basv MaxRoomHumidity = 40
+- basv MaxRoomHumidity = no data stored
+- basv MultiRelaySetting = 4
+- basv MultiRelaySetting = no data stored
+- basv NoiseReductionTimer_Friday = no data stored
+- basv NoiseReductionTimer_Friday = no data stored
+- basv NoiseReductionTimer_Monday = no data stored
+- basv NoiseReductionTimer_Monday = no data stored
+- basv NoiseReductionTimer_Saturday = no data stored
+- basv NoiseReductionTimer_Saturday = no data stored
+- basv NoiseReductionTimer_Sunday = no data stored
+- basv NoiseReductionTimer_Sunday = no data stored
+- basv NoiseReductionTimer_Thursday = no data stored
+- basv NoiseReductionTimer_Thursday = no data stored
+- basv NoiseReductionTimer_Tuesday = no data stored
+- basv NoiseReductionTimer_Tuesday = no data stored
+- basv NoiseReductionTimer_Wednesday = no data stored
+- basv NoiseReductionTimer_Wednesday = no data stored
+- basv OpMode = no data stored
+- basv OpMode = no data stored
+- basv OpModeCooling = no data stored
+- basv OpModeCooling = no data stored
+- basv OpModeEffect = no data stored
+- basv OpModeEffect = no data stored
+- basv OpModeVentilation = no data stored
+- basv OpModeVentilation = no data stored
+- basv OutsideTempAvg = 17.6992
+- basv OutsideTempAvg = no data stored
+- basv PhoneNumber1 = no data stored
+- basv PhoneNumber1 = no data stored
+- basv PhoneNumber2 = no data stored
+- basv PhoneNumber2 = no data stored
+- 'basv PrEnergySum =  (ERR: invalid position for 3115b52406020000005c00 / 00)'
+- basv PrEnergySum = no data stored
+- basv PrEnergySumHc = 7192
+- basv PrEnergySumHc = no data stored
+- basv PrEnergySumHcLastMonth = 7
+- basv PrEnergySumHcLastMonth = no data stored
+- basv PrEnergySumHcThisMonth = 6
+- basv PrEnergySumHcThisMonth = no data stored
+- basv PrEnergySumHwc = 1279
+- basv PrEnergySumHwc = no data stored
+- basv PrEnergySumHwcLastMonth = 28
+- basv PrEnergySumHwcLastMonth = no data stored
+- basv PrEnergySumHwcThisMonth = 23
+- basv PrEnergySumHwcThisMonth = no data stored
+- basv PrFuelSum = no data stored
+- basv PrFuelSum = no data stored
+- basv PrFuelSumHc = no data stored
+- basv PrFuelSumHc = no data stored
+- basv PrFuelSumHcLastMonth = no data stored
+- basv PrFuelSumHcLastMonth = no data stored
+- basv PrFuelSumHcThisMonth = no data stored
+- basv PrFuelSumHcThisMonth = no data stored
+- basv PrFuelSumHwc = no data stored
+- basv PrFuelSumHwc = no data stored
+- basv PrFuelSumHwcLastMonth = no data stored
+- basv PrFuelSumHwcLastMonth = no data stored
+- basv PrFuelSumHwcThisMonth = no data stored
+- basv PrFuelSumHwcThisMonth = no data stored
+- basv PumpAdditionalTime = no data stored
+- basv PumpAdditionalTime = no data stored
+- basv SFMode = no data stored
+- basv SFMode = no data stored
+- basv SolarYieldTotal = no data stored
+- basv SolarYieldTotal = no data stored
+- basv SystemFlowTemp =  (empty for f115b52406020000004b00 / 0800004b00ffffff7f)
+- basv TariffTimer_Friday = no data stored
+- basv TariffTimer_Friday = no data stored
+- basv TariffTimer_Monday = no data stored
+- basv TariffTimer_Monday = no data stored
+- basv TariffTimer_Saturday = no data stored
+- basv TariffTimer_Saturday = no data stored
+- basv TariffTimer_Sunday = no data stored
+- basv TariffTimer_Sunday = no data stored
+- basv TariffTimer_Thursday = no data stored
+- basv TariffTimer_Thursday = no data stored
+- basv TariffTimer_Tuesday = no data stored
+- basv TariffTimer_Tuesday = no data stored
+- basv TariffTimer_Wednesday = no data stored
+- basv TariffTimer_Wednesday = no data stored
+- basv Time = 10:54:32
+- basv Time = no data stored
+- basv VentilationDay = no data stored
+- basv VentilationDay = no data stored
+- basv VentilationNight = no data stored
+- basv VentilationNight = no data stored
+- basv VentilationTimer_Friday = no data stored
+- basv VentilationTimer_Friday = no data stored
+- basv VentilationTimer_Monday = no data stored
+- basv VentilationTimer_Monday = no data stored
+- basv VentilationTimer_Saturday = no data stored
+- basv VentilationTimer_Saturday = no data stored
+- basv VentilationTimer_Sunday = no data stored
+- basv VentilationTimer_Sunday = no data stored
+- basv VentilationTimer_Thursday = no data stored
+- basv VentilationTimer_Thursday = no data stored
+- basv VentilationTimer_Tuesday = no data stored
+- basv VentilationTimer_Tuesday = no data stored
+- basv VentilationTimer_Wednesday = no data stored
+- basv VentilationTimer_Wednesday = no data stored
+- basv WaterPressure = 1.7
+- basv YieldTotal = 21748
+- basv YieldTotal = no data stored
+- basv Z1ActualRoomTempDesired = 5
+- basv Z1ActualRoomTempDesired = no data stored
+- basv Z1BankHolidayEndPeriod = no data stored
+- basv Z1BankHolidayEndPeriod = no data stored
+- basv Z1BankHolidayStartPeriod = no data stored
+- basv Z1BankHolidayStartPeriod = no data stored
+- basv Z1CoolingTemp = 24
+- basv Z1CoolingTemp = no data stored
+- basv Z1CoolingTimer_Friday = no data stored
+- basv Z1CoolingTimer_Friday = no data stored
+- basv Z1CoolingTimer_Monday = no data stored
+- basv Z1CoolingTimer_Monday = no data stored
+- basv Z1CoolingTimer_Saturday = no data stored
+- basv Z1CoolingTimer_Saturday = no data stored
+- basv Z1CoolingTimer_Sunday = no data stored
+- basv Z1CoolingTimer_Sunday = no data stored
+- basv Z1CoolingTimer_Thursday = no data stored
+- basv Z1CoolingTimer_Thursday = no data stored
+- basv Z1CoolingTimer_Tuesday = no data stored
+- basv Z1CoolingTimer_Tuesday = no data stored
+- basv Z1CoolingTimer_Wednesday = no data stored
+- basv Z1CoolingTimer_Wednesday = no data stored
+- 'basv Z1DayTemp =  (ERR: invalid position for 3115b52406020003000700 / 00)'
+- basv Z1DayTemp = no data stored
+- basv Z1HolidayEndPeriod = 02.01.2026
+- basv Z1HolidayEndPeriod = no data stored
+- basv Z1HolidayStartPeriod = 30.12.2025
+- basv Z1HolidayStartPeriod = no data stored
+- basv Z1HolidayTemp = 21
+- basv Z1HolidayTemp = no data stored
+- 'basv Z1Name1 = Zone '
+- basv Z1Name1 = no data stored
+- 'basv Z1Name2 =  (ERR: invalid position for f115b52406020003001800 / 06030318003100)'
+- basv Z1Name2 = no data stored
+- basv Z1NightTemp = 22
+- basv Z1NightTemp = no data stored
+- basv Z1OpMode = off
+- basv Z1OpMode = no data stored
+- basv Z1OpModeCooling = no data stored
+- basv Z1OpModeCooling = no data stored
+- basv Z1QuickVetoTemp = 22.5
+- basv Z1QuickVetoTemp = no data stored
+- basv Z1RoomTemp = 22.25
+- basv Z1RoomZoneMapping = VRC700
+- basv Z1RoomZoneMapping = no data stored
+- basv Z1SFMode = auto
+- basv Z1SFMode = no data stored
+- basv Z1Shortname = no data stored
+- basv Z1Shortname = no data stored
+- basv Z1Timer_Friday = no data stored
+- basv Z1Timer_Friday = no data stored
+- basv Z1Timer_Monday = no data stored
+- basv Z1Timer_Monday = no data stored
+- basv Z1Timer_Saturday = no data stored
+- basv Z1Timer_Saturday = no data stored
+- basv Z1Timer_Sunday = no data stored
+- basv Z1Timer_Sunday = no data stored
+- basv Z1Timer_Thursday = no data stored
+- basv Z1Timer_Thursday = no data stored
+- basv Z1Timer_Tuesday = no data stored
+- basv Z1Timer_Tuesday = no data stored
+- basv Z1Timer_Wednesday = no data stored
+- basv Z1Timer_Wednesday = no data stored
+- basv Z1ValveStatus = no data stored
+- basv Z1ValveStatus = no data stored
+- basv Z2ActualRoomTempDesired = no data stored
+- basv Z2ActualRoomTempDesired = no data stored
+- basv Z2BankHolidayEndPeriod = no data stored
+- basv Z2BankHolidayEndPeriod = no data stored
+- basv Z2BankHolidayStartPeriod = no data stored
+- basv Z2BankHolidayStartPeriod = no data stored
+- basv Z2CoolingTemp = no data stored
+- basv Z2CoolingTemp = no data stored
+- basv Z2CoolingTimer_Friday = no data stored
+- basv Z2CoolingTimer_Friday = no data stored
+- basv Z2CoolingTimer_Monday = no data stored
+- basv Z2CoolingTimer_Monday = no data stored
+- basv Z2CoolingTimer_Saturday = no data stored
+- basv Z2CoolingTimer_Saturday = no data stored
+- basv Z2CoolingTimer_Sunday = no data stored
+- basv Z2CoolingTimer_Sunday = no data stored
+- basv Z2CoolingTimer_Thursday = no data stored
+- basv Z2CoolingTimer_Thursday = no data stored
+- basv Z2CoolingTimer_Tuesday = no data stored
+- basv Z2CoolingTimer_Tuesday = no data stored
+- basv Z2CoolingTimer_Wednesday = no data stored
+- basv Z2CoolingTimer_Wednesday = no data stored
+- basv Z2DayTemp = no data stored
+- basv Z2DayTemp = no data stored
+- basv Z2HolidayEndPeriod = no data stored
+- basv Z2HolidayEndPeriod = no data stored
+- basv Z2HolidayStartPeriod = no data stored
+- basv Z2HolidayStartPeriod = no data stored
+- basv Z2HolidayTemp = no data stored
+- basv Z2HolidayTemp = no data stored
+- basv Z2Name1 = no data stored
+- basv Z2Name1 = no data stored
+- basv Z2Name2 = no data stored
+- basv Z2Name2 = no data stored
+- basv Z2NightTemp = no data stored
+- basv Z2NightTemp = no data stored
+- basv Z2OpMode = no data stored
+- basv Z2OpMode = no data stored
+- basv Z2OpModeCooling = no data stored
+- basv Z2OpModeCooling = no data stored
+- basv Z2QuickVetoTemp = no data stored
+- basv Z2QuickVetoTemp = no data stored
+- basv Z2RoomTemp =  (empty for 3115b52406020003010f00 / 0800030f00ffffff7f)
+- basv Z2RoomZoneMapping = none
+- basv Z2RoomZoneMapping = no data stored
+- basv Z2SFMode = no data stored
+- basv Z2SFMode = no data stored
+- basv Z2Shortname = no data stored
+- basv Z2Shortname = no data stored
+- basv Z2Timer_Friday = no data stored
+- basv Z2Timer_Friday = no data stored
+- basv Z2Timer_Monday = no data stored
+- basv Z2Timer_Monday = no data stored
+- basv Z2Timer_Saturday = no data stored
+- basv Z2Timer_Saturday = no data stored
+- basv Z2Timer_Sunday = no data stored
+- basv Z2Timer_Sunday = no data stored
+- basv Z2Timer_Thursday = no data stored
+- basv Z2Timer_Thursday = no data stored
+- basv Z2Timer_Tuesday = no data stored
+- basv Z2Timer_Tuesday = no data stored
+- basv Z2Timer_Wednesday = no data stored
+- basv Z2Timer_Wednesday = no data stored
+- basv Z2ValveStatus = no data stored
+- basv Z2ValveStatus = no data stored
+- basv Z3ActualRoomTempDesired = no data stored
+- basv Z3ActualRoomTempDesired = no data stored
+- basv Z3BankHolidayEndPeriod = no data stored
+- basv Z3BankHolidayEndPeriod = no data stored
+- basv Z3BankHolidayStartPeriod = no data stored
+- basv Z3BankHolidayStartPeriod = no data stored
+- basv Z3CoolingTemp = no data stored
+- basv Z3CoolingTemp = no data stored
+- basv Z3CoolingTimer_Friday = no data stored
+- basv Z3CoolingTimer_Friday = no data stored
+- basv Z3CoolingTimer_Monday = no data stored
+- basv Z3CoolingTimer_Monday = no data stored
+- basv Z3CoolingTimer_Saturday = no data stored
+- basv Z3CoolingTimer_Saturday = no data stored
+- basv Z3CoolingTimer_Sunday = no data stored
+- basv Z3CoolingTimer_Sunday = no data stored
+- basv Z3CoolingTimer_Thursday = no data stored
+- basv Z3CoolingTimer_Thursday = no data stored
+- basv Z3CoolingTimer_Tuesday = no data stored
+- basv Z3CoolingTimer_Tuesday = no data stored
+- basv Z3CoolingTimer_Wednesday = no data stored
+- basv Z3CoolingTimer_Wednesday = no data stored
+- basv Z3DayTemp = no data stored
+- basv Z3DayTemp = no data stored
+- basv Z3HolidayEndPeriod = no data stored
+- basv Z3HolidayEndPeriod = no data stored
+- basv Z3HolidayStartPeriod = no data stored
+- basv Z3HolidayStartPeriod = no data stored
+- basv Z3HolidayTemp = no data stored
+- basv Z3HolidayTemp = no data stored
+- basv Z3Name1 = no data stored
+- basv Z3Name1 = no data stored
+- basv Z3Name2 = no data stored
+- basv Z3Name2 = no data stored
+- basv Z3NightTemp = no data stored
+- basv Z3NightTemp = no data stored
+- basv Z3OpMode = no data stored
+- basv Z3OpMode = no data stored
+- basv Z3OpModeCooling = no data stored
+- basv Z3OpModeCooling = no data stored
+- basv Z3QuickVetoTemp = no data stored
+- basv Z3QuickVetoTemp = no data stored
+- basv Z3RoomTemp = no data stored
+- basv Z3RoomZoneMapping = none
+- basv Z3RoomZoneMapping = no data stored
+- basv Z3SFMode = no data stored
+- basv Z3SFMode = no data stored
+- basv Z3Shortname = no data stored
+- basv Z3Shortname = no data stored
+- basv Z3Timer_Friday = no data stored
+- basv Z3Timer_Friday = no data stored
+- basv Z3Timer_Monday = no data stored
+- basv Z3Timer_Monday = no data stored
+- basv Z3Timer_Saturday = no data stored
+- basv Z3Timer_Saturday = no data stored
+- basv Z3Timer_Sunday = no data stored
+- basv Z3Timer_Sunday = no data stored
+- basv Z3Timer_Thursday = no data stored
+- basv Z3Timer_Thursday = no data stored
+- basv Z3Timer_Tuesday = no data stored
+- basv Z3Timer_Tuesday = no data stored
+- basv Z3Timer_Wednesday = no data stored
+- basv Z3Timer_Wednesday = no data stored
+- basv Z3ValveStatus = no data stored
+- basv Z3ValveStatus = no data stored
+- Broadcast Datetime = no data stored
+- Broadcast Error = no data stored
+- Broadcast HwcStatus = no data stored
+- Broadcast Id = no data stored
+- Broadcast IdAnswer = no data stored
+- Broadcast IdQuery = no data stored
+- Broadcast Load = no data stored
+- Broadcast Outsidetemp = 21.500
+- Broadcast Queryexistence =  (empty for 31fe07fe00 / )
+- Broadcast Signoflife = no data stored
+- Broadcast Vdatetime = 11:16:44;26.08.2026
+- Broadcast Vdatetime = no data stored
+- 'ctlv2 Hc1DewPointTemp =  (ERR: invalid position for 3115b52406020002002300 / 00)'
+- 'ctlv2 Hc1FlowTempCalc =  (ERR: invalid position for 3115b52406020002002000 / 050102200002)'
+- 'ctlv2 Hc1Humidity =  (ERR: invalid position for 3115b52406020002002200 / 00)'
+- 'ctlv2 Hc1MixerPosition =  (ERR: invalid position for 3115b52406020002002100 / 00)'
+- 'ctlv2 Hc1PumpHours =  (ERR: invalid position for 3115b52406020002002400 / 00)'
+- 'ctlv2 Hc1PumpStarts =  (ERR: invalid position for 3115b52406020002002500 / 00)'
+- 'ctlv2 Hc2DewPointTemp =  (ERR: invalid position for 3115b52406020002012300 / 00)'
+- 'ctlv2 Hc2FlowTempCalc =  (ERR: invalid position for 3115b52406020002012000 / 050002200000)'
+- 'ctlv2 Hc2Humidity =  (ERR: invalid position for 3115b52406020002012200 / 00)'
+- 'ctlv2 Hc2MixerPosition =  (ERR: invalid position for 3115b52406020002012100 / 00)'
+- 'ctlv2 Hc2PumpHours =  (ERR: invalid position for 3115b52406020002012400 / 00)'
+- 'ctlv2 Hc2PumpStarts =  (ERR: invalid position for 3115b52406020002012500 / 00)'
+- ctlv2 ManualCoolingEndDate = 01.01.2019
+- ctlv2 ManualCoolingEndDate = no data stored
+- ctlv2 ManualCoolingStartDate = 01.01.2019
+- ctlv2 ManualCoolingStartDate = no data stored
+- ctlv2 z1RoomHumidity = 52
+- General Valuerange = no data stored
+- hmu BuildingCircuitFlow = 0
+- hmu Clearerrorhistory = no data stored
+- hmu CompressorBlocktime = no data stored
+- hmu CompressorHc = no data stored (message not available due to condition)
+- hmu CompressorHwc = no data stored (message not available due to condition)
+- hmu CoolElecConsTotal = 0.0
+- hmu CoolEnvYieldDay = 0.0
+- hmu CoolEnvYieldMonth = 0.0
+- hmu CoolEnvYieldTotal = 0.0
+- hmu CopCooling = 1.0
+- hmu CopCoolingMonth = 1.0
+- hmu CopHc = 3.6
+- hmu CopHcMonth = 1.0
+- hmu CopHwc = 3.6
+- hmu CopHwcMonth = 4.6
+- hmu CurrentCompressorUtil = 0.00
+- hmu CurrentConsumedPower = 0.0
+- hmu Currenterror = -;-;-;-;-
+- hmu CurrentYieldPower = 0.0
+- hmu DateTime = nosignal;-:-:-;-.-.-;-
+- hmu EnergyIntegral = no data stored
+- hmu Errorhistory = no data stored
+- hmu FlowPressure = no data stored (message not available due to condition)
+- hmu FlowTemp = 53.56
+- hmu PowerConsumptionHmu = 1.561014652
+- hmu RunDataAirInletTemp = 23.3857
+- hmu RunDataBuildingCPumpPower = 100
+- hmu RunDataCompressorInletTemp = 19.3162
+- hmu RunDataCompressorOutletTemp = 20
+- hmu RunDataCompressorSpeed = 64.0033
+- hmu RunDataEEVOutletTemp = 19.3448
+- hmu RunDataEEVPositionAbs = 250
+- hmu RunDataFan1Speed = 0.0
+- hmu RunDataFan2Speed = 0.0
+- hmu RunDataHighPressure = 13.283
+- hmu RunDataStatuscode = hwc_compressor_active
+- hmu RunStats4PortValveHours = 73
+- hmu RunStats4PortValveSwitches = 1093
+- hmu RunStatsBuildingCPumpStarts = 1721
+- hmu RunStatsBuildingPumpHours = 10930
+- hmu RunStatsCompressorHours = 8454
+- hmu RunStatsCompressorStarts = 4925
+- hmu RunStatsFan1Hours = 8631
+- hmu RunStatsFan1Starts = 6044
+- hmu RunStatsFan2Hours = 0
+- hmu RunStatsFan2Starts = 0
+- hmu RunStatsHcHours = 9934
+- hmu RunStatsHMUHours = 27563
+- hmu RunStatsHwcHours = 812
+- hmu SetMode = water;-;-;160;1;1;1;1;0;0
+- hmu SetMode = no data stored
+- 'hmu SourceTempInput =  (ERR: invalid position for 3108b51a0405ff3222 / 02ff01)'
+- hmu Status01 = 54.0;52.5;-;-;-;hwc
+- hmu Status02 = no data stored
+- hmu Status16 = no data stored
+- hmu Status = no data stored
+- hmu StatusCirPump = on
+- hmu SupplyTempWeighted = 20.00
+- hmu TotalEnergyUsage = 7824
+- hmu YieldCoolDay = 0.0
+- hmu YieldCooling = 0.0
+- hmu YieldCoolingMonth = 0.0
+- hmu YieldHc = 18767
+- hmu YieldHcDay = 0.0
+- hmu YieldHcMonth = 0.0
+- hmu YieldHwc = 2967
+- hmu YieldHwcDay = 1.7
+- hmu YieldHwcMonth = 56.6
+- Memory Eeprom = no data stored
+- Memory Eeprom = no data stored
+- Memory Ram = no data stored
+- Memory Ram = no data stored
+- Scan Id = no data stored
+- scan.08  = Vaillant;HMU00;0901;5103
+- scan.15  = Vaillant;BASV2;0507;1704
+- Scan.15 Id = 21;22;25;0020262148;0082;006876;N9
+- scan.76  = Vaillant;VWZIO;0902;5103
+- Scan.76 Id = 21;23;21;0010022084;3100;005613;N0
+- scan.f6  = Vaillant;NETX2;4040;5703
+- Scan.f6 Id = 21;22;30;0020260962;0938;053360;N1
+- vwzio EnableTestHwcTemp = no data stored
+- vwzio EnableTestOutdoorTemp = no data stored
+- vwzio EnableTestThreeWayValve = no data stored
+- vwzio TestHwcTemp = no data stored
+- vwzio TestOutdoorTemp = no data stored
+- vwzio TestThreeWayValve = no data stored
+- ''
+before_registers:
+- circuit: Broadcast
+  name: Datetime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Error
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: Broadcast
+  name: HwcStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Id
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: IdAnswer
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: IdQuery
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Load
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Outsidetemp
+  fields:
+  - value
+  values:
+  - '21.500'
+  writable: false
+  has_data: true
+- circuit: Broadcast
+  name: Queryexistence
+  fields:
+  - value
+  values:
+  - (empty for 31fe07fe00 / )
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Signoflife
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Vdatetime
+  fields:
+  - value
+  values:
+  - 11:16:44;26.08.2026
+  writable: false
+  has_data: true
+- circuit: Broadcast
+  name: Vdatetime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: WaterPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: General
+  name: Valuerange
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Eeprom
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Eeprom
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Ram
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Ram
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Scan
+  name: Id
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Scan.15
+  name: Id
+  fields:
+  - value
+  values:
+  - 21;22;25;0020262148;0082;006876;N9
+  writable: false
+  has_data: true
+- circuit: Scan.76
+  name: Id
+  fields:
+  - value
+  values:
+  - 21;23;21;0010022084;3100;005613;N0
+  writable: false
+  has_data: true
+- circuit: Scan.f6
+  name: Id
+  fields:
+  - value
+  values:
+  - 21;22;30;0020260962;0938;053360;N1
+  writable: false
+  has_data: true
+- circuit: basv
+  name: AdaptHeatCurve
+  fields:
+  - value
+  values:
+  - 'no'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: AdaptHeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: CcTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: CcTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: CcTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: CcTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: CcTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: CcTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: CcTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: CcTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: CcTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: CcTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: CcTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: CcTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: CcTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: CcTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Clearerrorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: ContinuosHeating
+  fields:
+  - value
+  values:
+  - '-26'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: ContinuosHeating
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - -;-;-;-;-
+  writable: false
+  has_data: true
+- circuit: basv
+  name: CylinderChargeHyst
+  fields:
+  - value
+  values:
+  - '5'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: CylinderChargeHyst
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: CylinderChargeOffset
+  fields:
+  - value
+  values:
+  - '25'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: CylinderChargeOffset
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Date
+  fields:
+  - value
+  values:
+  - 26.08.2026
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Date
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: DisplayedOutsideTemp
+  fields:
+  - value
+  values:
+  - '21.4492'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: FrostOverRideTime
+  fields:
+  - value
+  values:
+  - '4'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: FrostOverRideTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: GlobalSystemOff
+  fields:
+  - value
+  values:
+  - 'no'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: GlobalSystemOff
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc1ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc1AutoOffMode
+  fields:
+  - value
+  values:
+  - eco
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc1AutoOffMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc1CircuitType
+  fields:
+  - value
+  values:
+  - mixer
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc1ExcessTemp
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc1ExcessTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc1FlowTemp
+  fields:
+  - value
+  values:
+  - '53'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc1HeatCurve
+  fields:
+  - value
+  values:
+  - '0.7'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc1HeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc1HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc1MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '60'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc1MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc1MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - '17'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc1MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc1MixerMovement
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc1PumpStatus
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc1PumpStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc1RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - thermostat
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc1RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc1Status
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc1Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc1SummerTempLimit
+  fields:
+  - value
+  values:
+  - '22'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc1SummerTempLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc2ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc2AutoOffMode
+  fields:
+  - value
+  values:
+  - eco
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc2AutoOffMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc2CircuitType
+  fields:
+  - value
+  values:
+  - inactive
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc2ExcessTemp
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc2ExcessTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc2FlowTemp
+  fields:
+  - value
+  values:
+  - (empty for 3115b52406020002010800 / 0800020800ffffff7f)
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc2HeatCurve
+  fields:
+  - value
+  values:
+  - '0.6'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc2HeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc2HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc2MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '55'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc2MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc2MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - '15'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc2MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc2MixerMovement
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc2PumpStatus
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc2PumpStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc2RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'off'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc2RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc2Status
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc2Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc2SummerTempLimit
+  fields:
+  - value
+  values:
+  - '21'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc2SummerTempLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc3ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc3AutoOffMode
+  fields:
+  - value
+  values:
+  - eco
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc3AutoOffMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc3CircuitType
+  fields:
+  - value
+  values:
+  - inactive
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc3ExcessTemp
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc3ExcessTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc3FlowTemp
+  fields:
+  - value
+  values:
+  - (empty for 3115b52406020002020800 / 0800020800ffffff7f)
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc3HeatCurve
+  fields:
+  - value
+  values:
+  - '0.6'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc3HeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc3HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc3MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '55'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc3MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc3MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - '15'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc3MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc3MixerMovement
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc3PumpStatus
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc3PumpStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc3RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'off'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc3RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc3Status
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc3Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc3SummerTempLimit
+  fields:
+  - value
+  values:
+  - '21'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc3SummerTempLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HcStorageTempBottom
+  fields:
+  - value
+  values:
+  - (empty for f115b5240602000000a000 / 080000a000ffffff7f)
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HcStorageTempTop
+  fields:
+  - value
+  values:
+  - (empty for f115b52406020000009f00 / 0800009f00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcBankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcBankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcBankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcBankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcFlowTemp
+  fields:
+  - value
+  values:
+  - '93'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: HwcHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 02.01.2026
+  writable: false
+  has_data: true
+- circuit: basv
+  name: HwcHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 30.12.2025
+  writable: false
+  has_data: true
+- circuit: basv
+  name: HwcHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcLockTime
+  fields:
+  - value
+  values:
+  - '60'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: HwcLockTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcMaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '80'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: HwcMaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcOpMode
+  fields:
+  - value
+  values:
+  - auto
+  writable: false
+  has_data: true
+- circuit: basv
+  name: HwcOpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcParallelLoading
+  fields:
+  - value
+  values:
+  - 'off'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: HwcParallelLoading
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcSFMode
+  fields:
+  - value
+  values:
+  - load
+  writable: false
+  has_data: true
+- circuit: basv
+  name: HwcSFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcStorageTemp
+  fields:
+  - value
+  values:
+  - '46'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: HwcStorageTempBottom
+  fields:
+  - value
+  values:
+  - (empty for f115b52406020000009e00 / 0800009e00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcStorageTempTop
+  fields:
+  - value
+  values:
+  - (empty for f115b52406020000009d00 / 0800009d00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcTempDesired
+  fields:
+  - value
+  values:
+  - '68'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: HwcTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HydraulicScheme
+  fields:
+  - value
+  values:
+  - '8'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: HydraulicScheme
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Installer1
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Installer1
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Installer2
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Installer2
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: basv
+  name: KeyCodeforConfigMenu
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: basv
+  name: KeyCodeforConfigMenu
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: basv
+  name: MaintenanceDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: MaintenanceDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: MaintenanceDue
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: ManualCooling
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: ManualCooling
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: MaxCylinderChargeTime
+  fields:
+  - value
+  values:
+  - '120'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: MaxCylinderChargeTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: MaxRoomHumidity
+  fields:
+  - value
+  values:
+  - '40'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: MaxRoomHumidity
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: MultiRelaySetting
+  fields:
+  - value
+  values:
+  - '4'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: MultiRelaySetting
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: NoiseReductionTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: NoiseReductionTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: NoiseReductionTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: NoiseReductionTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: NoiseReductionTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: NoiseReductionTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: NoiseReductionTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: NoiseReductionTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: NoiseReductionTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: NoiseReductionTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: NoiseReductionTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: NoiseReductionTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: NoiseReductionTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: NoiseReductionTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: OpModeCooling
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: OpModeCooling
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: OpModeEffect
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: OpModeEffect
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: OpModeVentilation
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: OpModeVentilation
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: OutsideTempAvg
+  fields:
+  - value
+  values:
+  - '17.6992'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: OutsideTempAvg
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PhoneNumber1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PhoneNumber1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PhoneNumber2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PhoneNumber2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrEnergySum
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020000005c00 / 00)'
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrEnergySum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrEnergySumHc
+  fields:
+  - value
+  values:
+  - '7192'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: PrEnergySumHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrEnergySumHcLastMonth
+  fields:
+  - value
+  values:
+  - '7'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: PrEnergySumHcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrEnergySumHcThisMonth
+  fields:
+  - value
+  values:
+  - '6'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: PrEnergySumHcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrEnergySumHwc
+  fields:
+  - value
+  values:
+  - '1279'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: PrEnergySumHwc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrEnergySumHwcLastMonth
+  fields:
+  - value
+  values:
+  - '28'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: PrEnergySumHwcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrEnergySumHwcThisMonth
+  fields:
+  - value
+  values:
+  - '23'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: PrEnergySumHwcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrFuelSum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrFuelSum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrFuelSumHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrFuelSumHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrFuelSumHcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrFuelSumHcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrFuelSumHcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrFuelSumHcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrFuelSumHwc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrFuelSumHwc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrFuelSumHwcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrFuelSumHwcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrFuelSumHwcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrFuelSumHwcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PumpAdditionalTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PumpAdditionalTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: SolarYieldTotal
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: SolarYieldTotal
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: SystemFlowTemp
+  fields:
+  - value
+  values:
+  - (empty for f115b52406020000004b00 / 0800004b00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: basv
+  name: TariffTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: TariffTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: TariffTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: TariffTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: TariffTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: TariffTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: TariffTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: TariffTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: TariffTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: TariffTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: TariffTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: TariffTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: TariffTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: TariffTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Time
+  fields:
+  - value
+  values:
+  - '10:54:32'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Time
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: VentilationDay
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: VentilationDay
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: VentilationNight
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: VentilationNight
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: VentilationTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: VentilationTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: VentilationTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: VentilationTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: VentilationTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: VentilationTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: VentilationTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: VentilationTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: VentilationTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: VentilationTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: VentilationTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: VentilationTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: VentilationTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: VentilationTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: WaterPressure
+  fields:
+  - value
+  values:
+  - '1.7'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: YieldTotal
+  fields:
+  - value
+  values:
+  - '21748'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: YieldTotal
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - '5'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Z1ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1CoolingTemp
+  fields:
+  - value
+  values:
+  - '24'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Z1CoolingTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1CoolingTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1CoolingTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1CoolingTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1CoolingTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1CoolingTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1CoolingTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1CoolingTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1CoolingTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1CoolingTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1CoolingTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1CoolingTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1CoolingTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1CoolingTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1CoolingTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1DayTemp
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020003000700 / 00)'
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 02.01.2026
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Z1HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 30.12.2025
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Z1HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1HolidayTemp
+  fields:
+  - value
+  values:
+  - '21'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Z1HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1Name1
+  fields:
+  - value
+  values:
+  - Zone
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Z1Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1Name2
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for f115b52406020003001800 / 06030318003100)'
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1NightTemp
+  fields:
+  - value
+  values:
+  - '22'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Z1NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1OpMode
+  fields:
+  - value
+  values:
+  - 'off'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Z1OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1OpModeCooling
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1OpModeCooling
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1QuickVetoTemp
+  fields:
+  - value
+  values:
+  - '22.5'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Z1QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1RoomTemp
+  fields:
+  - value
+  values:
+  - '22.25'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Z1RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Z1RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1SFMode
+  fields:
+  - value
+  values:
+  - auto
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Z1SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2CoolingTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2CoolingTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2CoolingTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2CoolingTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2CoolingTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2CoolingTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2CoolingTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2CoolingTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2CoolingTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2CoolingTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2CoolingTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2CoolingTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2CoolingTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2CoolingTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2CoolingTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2CoolingTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2OpModeCooling
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2OpModeCooling
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2RoomTemp
+  fields:
+  - value
+  values:
+  - (empty for 3115b52406020003010f00 / 0800030f00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Z2RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3CoolingTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3CoolingTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3CoolingTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3CoolingTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3CoolingTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3CoolingTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3CoolingTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3CoolingTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3CoolingTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3CoolingTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3CoolingTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3CoolingTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3CoolingTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3CoolingTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3CoolingTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3CoolingTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3OpModeCooling
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3OpModeCooling
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3RoomTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Z3RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: AdaptHeatCurve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: CcTimer_Config
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: CcTimer_Timeframes
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: ContinuousHeating
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: CylinderChargeHyst
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: CylinderChargeOffset
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Date
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: DisplayedOutsideTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: FrostOverRideTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1AutoOffMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1CircuitType
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1CoolingEnabled
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1CoolingFlowTempMin
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1DewPointMonitoring
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1DewPointOffset
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1DewPointTemp
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002300 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1ExcessTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1FlowTempCalc
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002000 / 050102200002)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1HeatCurve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1Humidity
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002200 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MixerMovement
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MixerPosition
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002100 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1PumpHours
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002400 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1PumpStarts
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002500 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1PumpStatus
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1RoomTempModulation
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1Status
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1SummerTempLimit
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2AutoOffMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2CircuitType
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2DewPointTemp
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012300 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2ExcessTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2FlowTempCalc
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012000 / 050002200000)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2HeatCurve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2Humidity
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012200 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MixerMovement
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MixerPosition
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012100 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2PumpHours
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012400 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2PumpStarts
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012500 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2PumpStatus
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2Status
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2SummerTempLimit
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3AutoOffMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3CircuitType
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3ExcessTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3HeatCurve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MixerMovement
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3PumpStatus
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3Status
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3SummerTempLimit
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HcStorageTempBottom
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: ctlv2
+  name: HcStorageTempTop
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: ctlv2
+  name: HwcFlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcLockTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcMaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcOpMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcParallelLoading
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcSFMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcSfMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcStorageTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcStorageTempBottom
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcStorageTempTop
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HydraulicScheme
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: ManualCoolingEndDate
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: ManualCoolingEndDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: ManualCoolingStartDate
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: ManualCoolingStartDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: MaxCylinderChargeTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: MaxRoomHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: MultiRelaySetting
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: OutsideTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: OutsideTempAvg
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySum
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHcLastMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHcThisMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHwcLastMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHwcThisMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: SystemFlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: WaterPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingManualTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingOpMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingSetbackTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1DayTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1HolidayTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1NightTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1OpMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoDuration
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoEndDate
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoEndTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1RoomTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1SFMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z2RoomTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: z1RoomHumidity
+  fields:
+  - value
+  values:
+  - '52'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: BuildingCircuitFlow
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: BuildingCircuitPumpSpeed
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Clearerrorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: CompressorBlocktime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: CompressorHc
+  fields:
+  - value
+  values:
+  - no data stored (message not available due to condition)
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: CompressorHc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHwc
+  fields:
+  - value
+  values:
+  - no data stored (message not available due to condition)
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: CompressorHwc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHwc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CoolElecConsTotal
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CoolEnvYieldDay
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CoolEnvYieldMonth
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CoolEnvYieldTotal
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CopCooling
+  fields:
+  - value
+  values:
+  - '1.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CopCoolingMonth
+  fields:
+  - value
+  values:
+  - '1.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CopHc
+  fields:
+  - value
+  values:
+  - '3.6'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CopHcMonth
+  fields:
+  - value
+  values:
+  - '1.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CopHwc
+  fields:
+  - value
+  values:
+  - '3.6'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CopHwcMonth
+  fields:
+  - value
+  values:
+  - '4.6'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CurrentCompressorUtil
+  fields:
+  - value
+  values:
+  - '0.00'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CurrentConsumedPower
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CurrentYieldPower
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - -;-;-;-;-
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: DateTime
+  fields:
+  - value
+  values:
+  - nosignal;-:-:-;-.-.-;-
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: EnergyIntegral
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: FlowPressure
+  fields:
+  - value
+  values:
+  - no data stored (message not available due to condition)
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: FlowTemp
+  fields:
+  - value
+  values:
+  - '53.56'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: FlowTemperature
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: HoursCool
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: PowerConsumptionHmu
+  fields:
+  - value
+  values:
+  - '1.561014652'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataAirInletTemp
+  fields:
+  - value
+  values:
+  - '23.3857'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataBuildingCPumpPower
+  fields:
+  - value
+  values:
+  - '100'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataCompressorInletTemp
+  fields:
+  - value
+  values:
+  - '19.3162'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataCompressorOutletTemp
+  fields:
+  - value
+  values:
+  - '20'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataCompressorSpeed
+  fields:
+  - value
+  values:
+  - '64.0033'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataEEVOutletTemp
+  fields:
+  - value
+  values:
+  - '19.3448'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataEEVPositionAbs
+  fields:
+  - value
+  values:
+  - '250'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataFan1Speed
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataFan2Speed
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataHighPressure
+  fields:
+  - value
+  values:
+  - '13.283'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataLowPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunDataStatuscode
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStats4PortValveHours
+  fields:
+  - value
+  values:
+  - '73'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStats4PortValveSwitches
+  fields:
+  - value
+  values:
+  - '1093'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsBuildingCPumpStarts
+  fields:
+  - value
+  values:
+  - '1721'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsBuildingPumpHours
+  fields:
+  - value
+  values:
+  - '10930'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsCompressorHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunStatsCompressorHc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHours
+  fields:
+  - value
+  values:
+  - '8454'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsCompressorHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunStatsCompressorHwc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHwc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorStarts
+  fields:
+  - value
+  values:
+  - '4925'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsFan1Hours
+  fields:
+  - value
+  values:
+  - '8631'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsFan1Starts
+  fields:
+  - value
+  values:
+  - '6044'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsFan2Hours
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsFan2Starts
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsHMUHours
+  fields:
+  - value
+  values:
+  - '27563'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsHcHours
+  fields:
+  - value
+  values:
+  - '9934'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsHwcHours
+  fields:
+  - value
+  values:
+  - '812'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: SetMode
+  fields:
+  - value
+  values:
+  - water;-;-;160;1;1;1;1;0;0
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: SetMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: SourceTempInput
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: SourceTempOutput
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatElectricEnergySum
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatElectricEnergySumCool
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatElectricEnergySumHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatElectricEnergySumHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatEnvironmentEnergySum
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatEnvironmentEnergySumCool
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatEnvironmentEnergySumHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatEnvironmentEnergySumHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: Status01
+  fields:
+  - value
+  values:
+  - 54.0;52.5;-;-;-;hwc
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: Status01.pumpstate
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.temp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.temp_1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.temp_2
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: Status01.temp_3
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: Status01.temp_4
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: Status02
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: Status16
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: StatusCirPump
+  fields:
+  - value
+  values:
+  - 'on'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: SupplyTempWeighted
+  fields:
+  - value
+  values:
+  - '20.00'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: TotalEnergyUsage
+  fields:
+  - value
+  values:
+  - '7824'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldCoolDay
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldCooling
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldCoolingMonth
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldHc
+  fields:
+  - value
+  values:
+  - '18767'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldHcDay
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldHcMonth
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldHwc
+  fields:
+  - value
+  values:
+  - '2967'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldHwcDay
+  fields:
+  - value
+  values:
+  - '1.7'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldHwcMonth
+  fields:
+  - value
+  values:
+  - '56.6'
+  writable: false
+  has_data: true
+- circuit: v32
+  name: BypassPosition
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: ExhaustAirHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: ExhaustAirTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: MaxAirHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: MinAirHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: OutsideAirTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: SupplyAirTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: VentilationLevelDay
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: VentilationLevelNight
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldToday
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldTotal
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldYear
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Clearerrorhistory
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Mc1Operation
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Mc2Operation
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Mc3Operation
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: SensorData1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: SensorData2
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: SetActorState
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vwz
+  name: TestHwcTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: vwz
+  name: TestOutdoorTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: vwz
+  name: TestThreeWayValve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: vwzio
+  name: EnableTestHwcTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: EnableTestOutdoorTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: EnableTestThreeWayValve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: TestHwcTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: TestOutdoorTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: TestThreeWayValve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+grab:
+- '[grab] grab started'
+- '1008b510090003ffffa0ff070001 / 0101 = 1: hmu SetMode'
+- '10feb516080045171126080326 = 1: Broadcast Vdatetime'
+- '10feb51603017315 = 1: Broadcast Outsidetemp'
+- 1008b5110100 / 096603116b180900004c = 1
+- 1076b5040100 / 0a03471711260803266618 = 1
+- 1076b5110101 / 096f694c18ff5e0000ff = 1
+- 10feb505025c00 = 1
+- 7108b5110107 / 0a250d00c1803300000000 = 3
+- f176b5160114 / 09000000404000000000 = 1
+- 'f108b5110101 / 096c690080ffff0400ff = 2: hmu Status01'
+- 'f108b5160114 / 09025308c64400000000 = 1: hmu PowerConsumptionHmu'
+- 1008b507020900 / 02e405 = 1
+- 1076b512030f0002 / 07f20200790311ff = 1
+- 1076b51009000000ffffff010000 / 0101 = 1
+- f108b509055402005b0d / 0802015b0d8301c644 = 1
+- f115b52406020003001b00 / 0601031b000000 = 2
+- 'f115b52406020003000600 / 06030306000000 = 1: basv Z1OpMode'
+- 'f115b52406020002000700 / 080102070000000000 = 1: basv Hc1ActualFlowTempDesired'
+- '3115b52406020002020b00 / 0802020b0000000000 = 1: basv Hc3ExcessTemp'
+- '3115b52406020002021200 / 080202120000007041 = 1: basv Hc3MinFlowTempDesired'
+- 'f115b52406020003001400 / 08010314000000a040 = 1: basv Z1ActualRoomTempDesired'
+- 'f115b52406020002001e00 / 0601021e000000 = 1: basv Hc1PumpStatus'
+- '3115b52406020002002200 / 00 = 1: ctlv2 Hc1Humidity'
+- '3115b52406020002012200 / 00 = 1: ctlv2 Hc2Humidity'
+- '[grab stop] grab stopped'
+labeled_telegrams:
+- msgid: b510
+  master: '10'
+  slave: 08
+  sub: 090003ffffa0ff070001
+  resp: '0101'
+  count: '1'
+  label: hmu SetMode
+- msgid: b516
+  master: '10'
+  slave: fe
+  sub: 080045171126080326
+  resp: null
+  count: '1'
+  label: Broadcast Vdatetime
+- msgid: b516
+  master: '10'
+  slave: fe
+  sub: '03017315'
+  resp: null
+  count: '1'
+  label: Broadcast Outsidetemp
+- msgid: b511
+  master: f1
+  slave: 08
+  sub: '0101'
+  resp: 096c690080ffff0400ff
+  count: '2'
+  label: hmu Status01
+- msgid: b516
+  master: f1
+  slave: 08
+  sub: '0114'
+  resp: 09025308c64400000000
+  count: '1'
+  label: hmu PowerConsumptionHmu
+- msgid: b524
+  master: f1
+  slave: '15'
+  sub: '06020003000600'
+  resp: '06030306000000'
+  count: '1'
+  label: basv Z1OpMode
+- msgid: b524
+  master: f1
+  slave: '15'
+  sub: '06020002000700'
+  resp: 080102070000000000
+  count: '1'
+  label: basv Hc1ActualFlowTempDesired
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020002020b00
+  resp: 0802020b0000000000
+  count: '1'
+  label: basv Hc3ExcessTemp
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020002021200'
+  resp: 080202120000007041
+  count: '1'
+  label: basv Hc3MinFlowTempDesired
+- msgid: b524
+  master: f1
+  slave: '15'
+  sub: '06020003001400'
+  resp: 08010314000000a040
+  count: '1'
+  label: basv Z1ActualRoomTempDesired
+- msgid: b524
+  master: f1
+  slave: '15'
+  sub: 06020002001e00
+  resp: 0601021e000000
+  count: '1'
+  label: basv Hc1PumpStatus
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020002002200'
+  resp: '00'
+  count: '1'
+  label: ctlv2 Hc1Humidity
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020002012200'
+  resp: '00'
+  count: '1'
+  label: ctlv2 Hc2Humidity
+unknown_telegrams:
+- msgid: b511
+  master: '10'
+  slave: 08
+  sub: '0100'
+  resp: 096603116b180900004c
+  count: '1'
+  label: null
+- msgid: b504
+  master: '10'
+  slave: '76'
+  sub: '0100'
+  resp: 0a03471711260803266618
+  count: '1'
+  label: null
+- msgid: b511
+  master: '10'
+  slave: '76'
+  sub: '0101'
+  resp: 096f694c18ff5e0000ff
+  count: '1'
+  label: null
+- msgid: b505
+  master: '10'
+  slave: fe
+  sub: 025c00
+  resp: null
+  count: '1'
+  label: null
+- msgid: b511
+  master: '71'
+  slave: 08
+  sub: '0107'
+  resp: 0a250d00c1803300000000
+  count: '3'
+  label: null
+- msgid: b516
+  master: f1
+  slave: '76'
+  sub: '0114'
+  resp: 09000000404000000000
+  count: '1'
+  label: null
+- msgid: b507
+  master: '10'
+  slave: 08
+  sub: 020900
+  resp: 02e405
+  count: '1'
+  label: null
+- msgid: b512
+  master: '10'
+  slave: '76'
+  sub: 030f0002
+  resp: 07f20200790311ff
+  count: '1'
+  label: null
+- msgid: b510
+  master: '10'
+  slave: '76'
+  sub: 09000000ffffff010000
+  resp: '0101'
+  count: '1'
+  label: null
+- msgid: b509
+  master: f1
+  slave: 08
+  sub: 055402005b0d
+  resp: 0802015b0d8301c644
+  count: '1'
+  label: null
+- msgid: b524
+  master: f1
+  slave: '15'
+  sub: 06020003001b00
+  resp: 0601031b000000
+  count: '2'
+  label: null
+after_registers:
+- circuit: Broadcast
+  name: Datetime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Error
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: Broadcast
+  name: HwcStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Id
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: IdAnswer
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: IdQuery
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Load
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Outsidetemp
+  fields:
+  - value
+  values:
+  - '21.449'
+  writable: false
+  has_data: true
+- circuit: Broadcast
+  name: Queryexistence
+  fields:
+  - value
+  values:
+  - (empty for 31fe07fe00 / )
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Signoflife
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Vdatetime
+  fields:
+  - value
+  values:
+  - 11:17:45;26.08.2026
+  writable: false
+  has_data: true
+- circuit: Broadcast
+  name: Vdatetime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: WaterPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: General
+  name: Valuerange
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Eeprom
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Eeprom
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Ram
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Ram
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Scan
+  name: Id
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Scan.15
+  name: Id
+  fields:
+  - value
+  values:
+  - 21;22;25;0020262148;0082;006876;N9
+  writable: false
+  has_data: true
+- circuit: Scan.76
+  name: Id
+  fields:
+  - value
+  values:
+  - 21;23;21;0010022084;3100;005613;N0
+  writable: false
+  has_data: true
+- circuit: Scan.f6
+  name: Id
+  fields:
+  - value
+  values:
+  - 21;22;30;0020260962;0938;053360;N1
+  writable: false
+  has_data: true
+- circuit: basv
+  name: AdaptHeatCurve
+  fields:
+  - value
+  values:
+  - 'no'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: AdaptHeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: CcTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: CcTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: CcTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: CcTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: CcTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: CcTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: CcTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: CcTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: CcTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: CcTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: CcTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: CcTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: CcTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: CcTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Clearerrorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: ContinuosHeating
+  fields:
+  - value
+  values:
+  - '-26'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: ContinuosHeating
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - -;-;-;-;-
+  writable: false
+  has_data: true
+- circuit: basv
+  name: CylinderChargeHyst
+  fields:
+  - value
+  values:
+  - '5'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: CylinderChargeHyst
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: CylinderChargeOffset
+  fields:
+  - value
+  values:
+  - '25'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: CylinderChargeOffset
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Date
+  fields:
+  - value
+  values:
+  - 26.08.2026
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Date
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: DisplayedOutsideTemp
+  fields:
+  - value
+  values:
+  - '21.4492'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: FrostOverRideTime
+  fields:
+  - value
+  values:
+  - '4'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: FrostOverRideTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: GlobalSystemOff
+  fields:
+  - value
+  values:
+  - 'no'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: GlobalSystemOff
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc1ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc1AutoOffMode
+  fields:
+  - value
+  values:
+  - eco
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc1AutoOffMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc1CircuitType
+  fields:
+  - value
+  values:
+  - mixer
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc1ExcessTemp
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc1ExcessTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc1FlowTemp
+  fields:
+  - value
+  values:
+  - '53'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc1HeatCurve
+  fields:
+  - value
+  values:
+  - '0.7'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc1HeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc1HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc1MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '60'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc1MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc1MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - '17'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc1MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc1MixerMovement
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc1PumpStatus
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc1PumpStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc1RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - thermostat
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc1RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc1Status
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc1Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc1SummerTempLimit
+  fields:
+  - value
+  values:
+  - '22'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc1SummerTempLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc2ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc2AutoOffMode
+  fields:
+  - value
+  values:
+  - eco
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc2AutoOffMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc2CircuitType
+  fields:
+  - value
+  values:
+  - inactive
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc2ExcessTemp
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc2ExcessTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc2FlowTemp
+  fields:
+  - value
+  values:
+  - (empty for 3115b52406020002010800 / 0800020800ffffff7f)
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc2HeatCurve
+  fields:
+  - value
+  values:
+  - '0.6'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc2HeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc2HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc2MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '55'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc2MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc2MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - '15'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc2MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc2MixerMovement
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc2PumpStatus
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc2PumpStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc2RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'off'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc2RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc2Status
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc2Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc2SummerTempLimit
+  fields:
+  - value
+  values:
+  - '21'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc2SummerTempLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc3ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc3AutoOffMode
+  fields:
+  - value
+  values:
+  - eco
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc3AutoOffMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc3CircuitType
+  fields:
+  - value
+  values:
+  - inactive
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc3ExcessTemp
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc3ExcessTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc3FlowTemp
+  fields:
+  - value
+  values:
+  - (empty for 3115b52406020002020800 / 0800020800ffffff7f)
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc3HeatCurve
+  fields:
+  - value
+  values:
+  - '0.6'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc3HeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc3HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc3MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '55'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc3MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc3MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - '15'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc3MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc3MixerMovement
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc3PumpStatus
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc3PumpStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc3RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'off'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc3RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc3Status
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc3Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc3SummerTempLimit
+  fields:
+  - value
+  values:
+  - '21'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc3SummerTempLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HcStorageTempBottom
+  fields:
+  - value
+  values:
+  - (empty for f115b5240602000000a000 / 080000a000ffffff7f)
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HcStorageTempTop
+  fields:
+  - value
+  values:
+  - (empty for f115b52406020000009f00 / 0800009f00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcBankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcBankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcBankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcBankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcFlowTemp
+  fields:
+  - value
+  values:
+  - '93'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: HwcHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 02.01.2026
+  writable: false
+  has_data: true
+- circuit: basv
+  name: HwcHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 30.12.2025
+  writable: false
+  has_data: true
+- circuit: basv
+  name: HwcHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcLockTime
+  fields:
+  - value
+  values:
+  - '60'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: HwcLockTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcMaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '80'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: HwcMaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcOpMode
+  fields:
+  - value
+  values:
+  - auto
+  writable: false
+  has_data: true
+- circuit: basv
+  name: HwcOpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcParallelLoading
+  fields:
+  - value
+  values:
+  - 'off'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: HwcParallelLoading
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcSFMode
+  fields:
+  - value
+  values:
+  - load
+  writable: false
+  has_data: true
+- circuit: basv
+  name: HwcSFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcStorageTemp
+  fields:
+  - value
+  values:
+  - '46'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: HwcStorageTempBottom
+  fields:
+  - value
+  values:
+  - (empty for f115b52406020000009e00 / 0800009e00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcStorageTempTop
+  fields:
+  - value
+  values:
+  - (empty for f115b52406020000009d00 / 0800009d00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcTempDesired
+  fields:
+  - value
+  values:
+  - '68'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: HwcTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HydraulicScheme
+  fields:
+  - value
+  values:
+  - '8'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: HydraulicScheme
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Installer1
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Installer1
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Installer2
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Installer2
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: basv
+  name: KeyCodeforConfigMenu
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: basv
+  name: KeyCodeforConfigMenu
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: basv
+  name: MaintenanceDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: MaintenanceDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: MaintenanceDue
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: ManualCooling
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: ManualCooling
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: MaxCylinderChargeTime
+  fields:
+  - value
+  values:
+  - '120'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: MaxCylinderChargeTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: MaxRoomHumidity
+  fields:
+  - value
+  values:
+  - '40'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: MaxRoomHumidity
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: MultiRelaySetting
+  fields:
+  - value
+  values:
+  - '4'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: MultiRelaySetting
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: NoiseReductionTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: NoiseReductionTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: NoiseReductionTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: NoiseReductionTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: NoiseReductionTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: NoiseReductionTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: NoiseReductionTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: NoiseReductionTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: NoiseReductionTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: NoiseReductionTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: NoiseReductionTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: NoiseReductionTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: NoiseReductionTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: NoiseReductionTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: OpModeCooling
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: OpModeCooling
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: OpModeEffect
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: OpModeEffect
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: OpModeVentilation
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: OpModeVentilation
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: OutsideTempAvg
+  fields:
+  - value
+  values:
+  - '17.6992'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: OutsideTempAvg
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PhoneNumber1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PhoneNumber1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PhoneNumber2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PhoneNumber2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrEnergySum
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020000005c00 / 00)'
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrEnergySum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrEnergySumHc
+  fields:
+  - value
+  values:
+  - '7192'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: PrEnergySumHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrEnergySumHcLastMonth
+  fields:
+  - value
+  values:
+  - '7'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: PrEnergySumHcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrEnergySumHcThisMonth
+  fields:
+  - value
+  values:
+  - '6'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: PrEnergySumHcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrEnergySumHwc
+  fields:
+  - value
+  values:
+  - '1279'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: PrEnergySumHwc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrEnergySumHwcLastMonth
+  fields:
+  - value
+  values:
+  - '28'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: PrEnergySumHwcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrEnergySumHwcThisMonth
+  fields:
+  - value
+  values:
+  - '23'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: PrEnergySumHwcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrFuelSum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrFuelSum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrFuelSumHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrFuelSumHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrFuelSumHcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrFuelSumHcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrFuelSumHcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrFuelSumHcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrFuelSumHwc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrFuelSumHwc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrFuelSumHwcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrFuelSumHwcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrFuelSumHwcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrFuelSumHwcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PumpAdditionalTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PumpAdditionalTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: SolarYieldTotal
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: SolarYieldTotal
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: SystemFlowTemp
+  fields:
+  - value
+  values:
+  - (empty for f115b52406020000004b00 / 0800004b00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: basv
+  name: TariffTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: TariffTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: TariffTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: TariffTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: TariffTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: TariffTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: TariffTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: TariffTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: TariffTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: TariffTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: TariffTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: TariffTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: TariffTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: TariffTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Time
+  fields:
+  - value
+  values:
+  - '10:54:32'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Time
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: VentilationDay
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: VentilationDay
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: VentilationNight
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: VentilationNight
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: VentilationTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: VentilationTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: VentilationTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: VentilationTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: VentilationTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: VentilationTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: VentilationTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: VentilationTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: VentilationTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: VentilationTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: VentilationTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: VentilationTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: VentilationTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: VentilationTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: WaterPressure
+  fields:
+  - value
+  values:
+  - '1.7'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: YieldTotal
+  fields:
+  - value
+  values:
+  - '21748'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: YieldTotal
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - '5'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Z1ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1CoolingTemp
+  fields:
+  - value
+  values:
+  - '24'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Z1CoolingTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1CoolingTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1CoolingTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1CoolingTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1CoolingTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1CoolingTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1CoolingTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1CoolingTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1CoolingTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1CoolingTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1CoolingTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1CoolingTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1CoolingTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1CoolingTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1CoolingTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1DayTemp
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020003000700 / 00)'
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 02.01.2026
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Z1HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 30.12.2025
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Z1HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1HolidayTemp
+  fields:
+  - value
+  values:
+  - '21'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Z1HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1Name1
+  fields:
+  - value
+  values:
+  - Zone
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Z1Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1Name2
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for f115b52406020003001800 / 06030318003100)'
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1NightTemp
+  fields:
+  - value
+  values:
+  - '22'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Z1NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1OpMode
+  fields:
+  - value
+  values:
+  - 'off'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Z1OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1OpModeCooling
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1OpModeCooling
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1QuickVetoTemp
+  fields:
+  - value
+  values:
+  - '22.5'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Z1QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1RoomTemp
+  fields:
+  - value
+  values:
+  - '22.25'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Z1RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Z1RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1SFMode
+  fields:
+  - value
+  values:
+  - auto
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Z1SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2CoolingTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2CoolingTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2CoolingTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2CoolingTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2CoolingTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2CoolingTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2CoolingTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2CoolingTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2CoolingTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2CoolingTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2CoolingTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2CoolingTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2CoolingTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2CoolingTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2CoolingTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2CoolingTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2OpModeCooling
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2OpModeCooling
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2RoomTemp
+  fields:
+  - value
+  values:
+  - (empty for 3115b52406020003010f00 / 0800030f00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Z2RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3CoolingTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3CoolingTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3CoolingTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3CoolingTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3CoolingTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3CoolingTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3CoolingTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3CoolingTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3CoolingTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3CoolingTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3CoolingTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3CoolingTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3CoolingTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3CoolingTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3CoolingTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3CoolingTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3OpModeCooling
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3OpModeCooling
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3RoomTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Z3RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: AdaptHeatCurve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: CcTimer_Config
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: CcTimer_Timeframes
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: ContinuousHeating
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: CylinderChargeHyst
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: CylinderChargeOffset
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Date
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: DisplayedOutsideTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: FrostOverRideTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1AutoOffMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1CircuitType
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1CoolingEnabled
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1CoolingFlowTempMin
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1DewPointMonitoring
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1DewPointOffset
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1DewPointTemp
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002300 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1ExcessTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1FlowTempCalc
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002000 / 050102200002)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1HeatCurve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1Humidity
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002200 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MixerMovement
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MixerPosition
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002100 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1PumpHours
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002400 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1PumpStarts
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002500 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1PumpStatus
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1RoomTempModulation
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1Status
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1SummerTempLimit
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2AutoOffMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2CircuitType
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2DewPointTemp
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012300 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2ExcessTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2FlowTempCalc
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012000 / 050002200000)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2HeatCurve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2Humidity
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012200 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MixerMovement
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MixerPosition
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012100 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2PumpHours
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012400 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2PumpStarts
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012500 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2PumpStatus
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2Status
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2SummerTempLimit
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3AutoOffMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3CircuitType
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3ExcessTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3HeatCurve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MixerMovement
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3PumpStatus
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3Status
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3SummerTempLimit
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HcStorageTempBottom
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: ctlv2
+  name: HcStorageTempTop
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: ctlv2
+  name: HwcFlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcLockTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcMaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcOpMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcParallelLoading
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcSFMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcSfMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcStorageTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcStorageTempBottom
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcStorageTempTop
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HydraulicScheme
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: ManualCoolingEndDate
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: ManualCoolingEndDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: ManualCoolingStartDate
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: ManualCoolingStartDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: MaxCylinderChargeTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: MaxRoomHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: MultiRelaySetting
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: OutsideTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: OutsideTempAvg
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySum
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHcLastMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHcThisMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHwcLastMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHwcThisMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: SystemFlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: WaterPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingManualTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingOpMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingSetbackTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1DayTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1HolidayTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1NightTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1OpMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoDuration
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoEndDate
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoEndTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1RoomTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1SFMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z2RoomTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: z1RoomHumidity
+  fields:
+  - value
+  values:
+  - '52'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: BuildingCircuitFlow
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: BuildingCircuitPumpSpeed
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Clearerrorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: CompressorBlocktime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: CompressorHc
+  fields:
+  - value
+  values:
+  - no data stored (message not available due to condition)
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: CompressorHc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHwc
+  fields:
+  - value
+  values:
+  - no data stored (message not available due to condition)
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: CompressorHwc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHwc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CoolElecConsTotal
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CoolEnvYieldDay
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CoolEnvYieldMonth
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CoolEnvYieldTotal
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CopCooling
+  fields:
+  - value
+  values:
+  - '1.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CopCoolingMonth
+  fields:
+  - value
+  values:
+  - '1.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CopHc
+  fields:
+  - value
+  values:
+  - '3.6'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CopHcMonth
+  fields:
+  - value
+  values:
+  - '1.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CopHwc
+  fields:
+  - value
+  values:
+  - '3.6'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CopHwcMonth
+  fields:
+  - value
+  values:
+  - '4.6'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CurrentCompressorUtil
+  fields:
+  - value
+  values:
+  - '0.00'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CurrentConsumedPower
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CurrentYieldPower
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - -;-;-;-;-
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: DateTime
+  fields:
+  - value
+  values:
+  - nosignal;-:-:-;-.-.-;-
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: EnergyIntegral
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: FlowPressure
+  fields:
+  - value
+  values:
+  - no data stored (message not available due to condition)
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: FlowTemp
+  fields:
+  - value
+  values:
+  - '53.56'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: FlowTemperature
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: HoursCool
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: PowerConsumptionHmu
+  fields:
+  - value
+  values:
+  - '1.584260106'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataAirInletTemp
+  fields:
+  - value
+  values:
+  - '23.3857'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataBuildingCPumpPower
+  fields:
+  - value
+  values:
+  - '100'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataCompressorInletTemp
+  fields:
+  - value
+  values:
+  - '19.3162'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataCompressorOutletTemp
+  fields:
+  - value
+  values:
+  - '20'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataCompressorSpeed
+  fields:
+  - value
+  values:
+  - '64.0033'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataEEVOutletTemp
+  fields:
+  - value
+  values:
+  - '19.3448'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataEEVPositionAbs
+  fields:
+  - value
+  values:
+  - '250'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataFan1Speed
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataFan2Speed
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataHighPressure
+  fields:
+  - value
+  values:
+  - '13.283'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataLowPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunDataStatuscode
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStats4PortValveHours
+  fields:
+  - value
+  values:
+  - '73'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStats4PortValveSwitches
+  fields:
+  - value
+  values:
+  - '1093'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsBuildingCPumpStarts
+  fields:
+  - value
+  values:
+  - '1721'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsBuildingPumpHours
+  fields:
+  - value
+  values:
+  - '10930'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsCompressorHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunStatsCompressorHc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHours
+  fields:
+  - value
+  values:
+  - '8454'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsCompressorHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunStatsCompressorHwc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHwc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorStarts
+  fields:
+  - value
+  values:
+  - '4925'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsFan1Hours
+  fields:
+  - value
+  values:
+  - '8631'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsFan1Starts
+  fields:
+  - value
+  values:
+  - '6044'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsFan2Hours
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsFan2Starts
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsHMUHours
+  fields:
+  - value
+  values:
+  - '27563'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsHcHours
+  fields:
+  - value
+  values:
+  - '9934'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsHwcHours
+  fields:
+  - value
+  values:
+  - '812'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: SetMode
+  fields:
+  - value
+  values:
+  - water;-;-;160;1;1;1;1;0;0
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: SetMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: SourceTempInput
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: SourceTempOutput
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatElectricEnergySum
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatElectricEnergySumCool
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatElectricEnergySumHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatElectricEnergySumHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatEnvironmentEnergySum
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatEnvironmentEnergySumCool
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatEnvironmentEnergySumHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatEnvironmentEnergySumHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: Status01
+  fields:
+  - value
+  values:
+  - 54.0;52.5;-;-;-;hwc
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: Status01.pumpstate
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.temp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.temp_1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.temp_2
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: Status01.temp_3
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: Status01.temp_4
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: Status02
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: Status16
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: StatusCirPump
+  fields:
+  - value
+  values:
+  - 'on'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: SupplyTempWeighted
+  fields:
+  - value
+  values:
+  - '20.00'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: TotalEnergyUsage
+  fields:
+  - value
+  values:
+  - '7824'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldCoolDay
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldCooling
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldCoolingMonth
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldHc
+  fields:
+  - value
+  values:
+  - '18767'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldHcDay
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldHcMonth
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldHwc
+  fields:
+  - value
+  values:
+  - '2967'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldHwcDay
+  fields:
+  - value
+  values:
+  - '1.7'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldHwcMonth
+  fields:
+  - value
+  values:
+  - '56.6'
+  writable: false
+  has_data: true
+- circuit: v32
+  name: BypassPosition
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: ExhaustAirHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: ExhaustAirTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: MaxAirHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: MinAirHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: OutsideAirTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: SupplyAirTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: VentilationLevelDay
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: VentilationLevelNight
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldToday
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldTotal
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldYear
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Clearerrorhistory
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Mc1Operation
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Mc2Operation
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Mc3Operation
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: SensorData1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: SensorData2
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: SetActorState
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vwz
+  name: TestHwcTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: vwz
+  name: TestOutdoorTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: vwz
+  name: TestThreeWayValve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: vwzio
+  name: EnableTestHwcTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: EnableTestOutdoorTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: EnableTestThreeWayValve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: TestHwcTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: TestOutdoorTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: TestThreeWayValve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+raw_find_lines_after:
+- basv AdaptHeatCurve = no
+- basv AdaptHeatCurve = no data stored
+- basv BankHolidayEndPeriod = no data stored
+- basv BankHolidayEndPeriod = no data stored
+- basv BankHolidayStartPeriod = no data stored
+- basv BankHolidayStartPeriod = no data stored
+- basv CcTimer_Friday = no data stored
+- basv CcTimer_Friday = no data stored
+- basv CcTimer_Monday = no data stored
+- basv CcTimer_Monday = no data stored
+- basv CcTimer_Saturday = no data stored
+- basv CcTimer_Saturday = no data stored
+- basv CcTimer_Sunday = no data stored
+- basv CcTimer_Sunday = no data stored
+- basv CcTimer_Thursday = no data stored
+- basv CcTimer_Thursday = no data stored
+- basv CcTimer_Tuesday = no data stored
+- basv CcTimer_Tuesday = no data stored
+- basv CcTimer_Wednesday = no data stored
+- basv CcTimer_Wednesday = no data stored
+- basv Clearerrorhistory = no data stored
+- basv ContinuosHeating = -26
+- basv ContinuosHeating = no data stored
+- basv Currenterror = -;-;-;-;-
+- basv CylinderChargeHyst = 5
+- basv CylinderChargeHyst = no data stored
+- basv CylinderChargeOffset = 25
+- basv CylinderChargeOffset = no data stored
+- basv Date = 26.08.2026
+- basv Date = no data stored
+- basv DisplayedOutsideTemp = 21.4492
+- basv Errorhistory = no data stored
+- basv FrostOverRideTime = 4
+- basv FrostOverRideTime = no data stored
+- basv GlobalSystemOff = no
+- basv GlobalSystemOff = no data stored
+- basv Hc1ActualFlowTempDesired = 0.0
+- basv Hc1AutoOffMode = eco
+- basv Hc1AutoOffMode = no data stored
+- basv Hc1CircuitType = mixer
+- basv Hc1ExcessTemp = 0.0
+- basv Hc1ExcessTemp = no data stored
+- basv Hc1FlowTemp = 53
+- basv Hc1HeatCurve = 0.7
+- basv Hc1HeatCurve = no data stored
+- basv Hc1HeatCurveAdaption = 0.0
+- basv Hc1MaxFlowTempDesired = 60
+- basv Hc1MaxFlowTempDesired = no data stored
+- basv Hc1MinFlowTempDesired = 17
+- basv Hc1MinFlowTempDesired = no data stored
+- basv Hc1MixerMovement = 0.0
+- basv Hc1PumpStatus = 0
+- basv Hc1PumpStatus = no data stored
+- basv Hc1RoomTempSwitchOn = thermostat
+- basv Hc1RoomTempSwitchOn = no data stored
+- basv Hc1Status = 0
+- basv Hc1Status = no data stored
+- basv Hc1SummerTempLimit = 22
+- basv Hc1SummerTempLimit = no data stored
+- basv Hc2ActualFlowTempDesired = 0.0
+- basv Hc2AutoOffMode = eco
+- basv Hc2AutoOffMode = no data stored
+- basv Hc2CircuitType = inactive
+- basv Hc2ExcessTemp = 0.0
+- basv Hc2ExcessTemp = no data stored
+- basv Hc2FlowTemp =  (empty for 3115b52406020002010800 / 0800020800ffffff7f)
+- basv Hc2HeatCurve = 0.6
+- basv Hc2HeatCurve = no data stored
+- basv Hc2HeatCurveAdaption = 0.0
+- basv Hc2MaxFlowTempDesired = 55
+- basv Hc2MaxFlowTempDesired = no data stored
+- basv Hc2MinFlowTempDesired = 15
+- basv Hc2MinFlowTempDesired = no data stored
+- basv Hc2MixerMovement = 0.0
+- basv Hc2PumpStatus = 0
+- basv Hc2PumpStatus = no data stored
+- basv Hc2RoomTempSwitchOn = off
+- basv Hc2RoomTempSwitchOn = no data stored
+- basv Hc2Status = 0
+- basv Hc2Status = no data stored
+- basv Hc2SummerTempLimit = 21
+- basv Hc2SummerTempLimit = no data stored
+- basv Hc3ActualFlowTempDesired = 0.0
+- basv Hc3AutoOffMode = eco
+- basv Hc3AutoOffMode = no data stored
+- basv Hc3CircuitType = inactive
+- basv Hc3ExcessTemp = 0.0
+- basv Hc3ExcessTemp = no data stored
+- basv Hc3FlowTemp =  (empty for 3115b52406020002020800 / 0800020800ffffff7f)
+- basv Hc3HeatCurve = 0.6
+- basv Hc3HeatCurve = no data stored
+- basv Hc3HeatCurveAdaption = 0.0
+- basv Hc3MaxFlowTempDesired = 55
+- basv Hc3MaxFlowTempDesired = no data stored
+- basv Hc3MinFlowTempDesired = 15
+- basv Hc3MinFlowTempDesired = no data stored
+- basv Hc3MixerMovement = 0.0
+- basv Hc3PumpStatus = 0
+- basv Hc3PumpStatus = no data stored
+- basv Hc3RoomTempSwitchOn = off
+- basv Hc3RoomTempSwitchOn = no data stored
+- basv Hc3Status = 0
+- basv Hc3Status = no data stored
+- basv Hc3SummerTempLimit = 21
+- basv Hc3SummerTempLimit = no data stored
+- basv HcStorageTempBottom =  (empty for f115b5240602000000a000 / 080000a000ffffff7f)
+- basv HcStorageTempTop =  (empty for f115b52406020000009f00 / 0800009f00ffffff7f)
+- basv HolidayEndPeriod = no data stored
+- basv HolidayEndPeriod = no data stored
+- basv HolidayStartPeriod = no data stored
+- basv HolidayStartPeriod = no data stored
+- basv HolidayTemp = no data stored
+- basv HolidayTemp = no data stored
+- basv HwcBankHolidayEndPeriod = no data stored
+- basv HwcBankHolidayEndPeriod = no data stored
+- basv HwcBankHolidayStartPeriod = no data stored
+- basv HwcBankHolidayStartPeriod = no data stored
+- basv HwcFlowTemp = 93
+- basv HwcHolidayEndPeriod = 02.01.2026
+- basv HwcHolidayEndPeriod = no data stored
+- basv HwcHolidayStartPeriod = 30.12.2025
+- basv HwcHolidayStartPeriod = no data stored
+- basv HwcLockTime = 60
+- basv HwcLockTime = no data stored
+- basv HwcMaxFlowTempDesired = 80
+- basv HwcMaxFlowTempDesired = no data stored
+- basv HwcOpMode = auto
+- basv HwcOpMode = no data stored
+- basv HwcParallelLoading = off
+- basv HwcParallelLoading = no data stored
+- basv HwcSFMode = load
+- basv HwcSFMode = no data stored
+- basv HwcStorageTemp = 46
+- basv HwcStorageTempBottom =  (empty for f115b52406020000009e00 / 0800009e00ffffff7f)
+- basv HwcStorageTempTop =  (empty for f115b52406020000009d00 / 0800009d00ffffff7f)
+- basv HwcTempDesired = 68
+- basv HwcTempDesired = no data stored
+- basv HwcTimer_Friday = no data stored
+- basv HwcTimer_Friday = no data stored
+- basv HwcTimer_Monday = no data stored
+- basv HwcTimer_Monday = no data stored
+- basv HwcTimer_Saturday = no data stored
+- basv HwcTimer_Saturday = no data stored
+- basv HwcTimer_Sunday = no data stored
+- basv HwcTimer_Sunday = no data stored
+- basv HwcTimer_Thursday = no data stored
+- basv HwcTimer_Thursday = no data stored
+- basv HwcTimer_Tuesday = no data stored
+- basv HwcTimer_Tuesday = no data stored
+- basv HwcTimer_Wednesday = no data stored
+- basv HwcTimer_Wednesday = no data stored
+- basv HydraulicScheme = 8
+- basv HydraulicScheme = no data stored
+- basv Installer1 = no data stored
+- basv Installer1 = no data stored
+- basv Installer2 = no data stored
+- basv Installer2 = no data stored
+- basv KeyCodeforConfigMenu = no data stored
+- basv KeyCodeforConfigMenu = no data stored
+- basv MaintenanceDate = no data stored
+- basv MaintenanceDate = no data stored
+- basv MaintenanceDue = no data stored
+- basv ManualCooling = no data stored
+- basv ManualCooling = no data stored
+- basv MaxCylinderChargeTime = 120
+- basv MaxCylinderChargeTime = no data stored
+- basv MaxRoomHumidity = 40
+- basv MaxRoomHumidity = no data stored
+- basv MultiRelaySetting = 4
+- basv MultiRelaySetting = no data stored
+- basv NoiseReductionTimer_Friday = no data stored
+- basv NoiseReductionTimer_Friday = no data stored
+- basv NoiseReductionTimer_Monday = no data stored
+- basv NoiseReductionTimer_Monday = no data stored
+- basv NoiseReductionTimer_Saturday = no data stored
+- basv NoiseReductionTimer_Saturday = no data stored
+- basv NoiseReductionTimer_Sunday = no data stored
+- basv NoiseReductionTimer_Sunday = no data stored
+- basv NoiseReductionTimer_Thursday = no data stored
+- basv NoiseReductionTimer_Thursday = no data stored
+- basv NoiseReductionTimer_Tuesday = no data stored
+- basv NoiseReductionTimer_Tuesday = no data stored
+- basv NoiseReductionTimer_Wednesday = no data stored
+- basv NoiseReductionTimer_Wednesday = no data stored
+- basv OpMode = no data stored
+- basv OpMode = no data stored
+- basv OpModeCooling = no data stored
+- basv OpModeCooling = no data stored
+- basv OpModeEffect = no data stored
+- basv OpModeEffect = no data stored
+- basv OpModeVentilation = no data stored
+- basv OpModeVentilation = no data stored
+- basv OutsideTempAvg = 17.6992
+- basv OutsideTempAvg = no data stored
+- basv PhoneNumber1 = no data stored
+- basv PhoneNumber1 = no data stored
+- basv PhoneNumber2 = no data stored
+- basv PhoneNumber2 = no data stored
+- 'basv PrEnergySum =  (ERR: invalid position for 3115b52406020000005c00 / 00)'
+- basv PrEnergySum = no data stored
+- basv PrEnergySumHc = 7192
+- basv PrEnergySumHc = no data stored
+- basv PrEnergySumHcLastMonth = 7
+- basv PrEnergySumHcLastMonth = no data stored
+- basv PrEnergySumHcThisMonth = 6
+- basv PrEnergySumHcThisMonth = no data stored
+- basv PrEnergySumHwc = 1279
+- basv PrEnergySumHwc = no data stored
+- basv PrEnergySumHwcLastMonth = 28
+- basv PrEnergySumHwcLastMonth = no data stored
+- basv PrEnergySumHwcThisMonth = 23
+- basv PrEnergySumHwcThisMonth = no data stored
+- basv PrFuelSum = no data stored
+- basv PrFuelSum = no data stored
+- basv PrFuelSumHc = no data stored
+- basv PrFuelSumHc = no data stored
+- basv PrFuelSumHcLastMonth = no data stored
+- basv PrFuelSumHcLastMonth = no data stored
+- basv PrFuelSumHcThisMonth = no data stored
+- basv PrFuelSumHcThisMonth = no data stored
+- basv PrFuelSumHwc = no data stored
+- basv PrFuelSumHwc = no data stored
+- basv PrFuelSumHwcLastMonth = no data stored
+- basv PrFuelSumHwcLastMonth = no data stored
+- basv PrFuelSumHwcThisMonth = no data stored
+- basv PrFuelSumHwcThisMonth = no data stored
+- basv PumpAdditionalTime = no data stored
+- basv PumpAdditionalTime = no data stored
+- basv SFMode = no data stored
+- basv SFMode = no data stored
+- basv SolarYieldTotal = no data stored
+- basv SolarYieldTotal = no data stored
+- basv SystemFlowTemp =  (empty for f115b52406020000004b00 / 0800004b00ffffff7f)
+- basv TariffTimer_Friday = no data stored
+- basv TariffTimer_Friday = no data stored
+- basv TariffTimer_Monday = no data stored
+- basv TariffTimer_Monday = no data stored
+- basv TariffTimer_Saturday = no data stored
+- basv TariffTimer_Saturday = no data stored
+- basv TariffTimer_Sunday = no data stored
+- basv TariffTimer_Sunday = no data stored
+- basv TariffTimer_Thursday = no data stored
+- basv TariffTimer_Thursday = no data stored
+- basv TariffTimer_Tuesday = no data stored
+- basv TariffTimer_Tuesday = no data stored
+- basv TariffTimer_Wednesday = no data stored
+- basv TariffTimer_Wednesday = no data stored
+- basv Time = 10:54:32
+- basv Time = no data stored
+- basv VentilationDay = no data stored
+- basv VentilationDay = no data stored
+- basv VentilationNight = no data stored
+- basv VentilationNight = no data stored
+- basv VentilationTimer_Friday = no data stored
+- basv VentilationTimer_Friday = no data stored
+- basv VentilationTimer_Monday = no data stored
+- basv VentilationTimer_Monday = no data stored
+- basv VentilationTimer_Saturday = no data stored
+- basv VentilationTimer_Saturday = no data stored
+- basv VentilationTimer_Sunday = no data stored
+- basv VentilationTimer_Sunday = no data stored
+- basv VentilationTimer_Thursday = no data stored
+- basv VentilationTimer_Thursday = no data stored
+- basv VentilationTimer_Tuesday = no data stored
+- basv VentilationTimer_Tuesday = no data stored
+- basv VentilationTimer_Wednesday = no data stored
+- basv VentilationTimer_Wednesday = no data stored
+- basv WaterPressure = 1.7
+- basv YieldTotal = 21748
+- basv YieldTotal = no data stored
+- basv Z1ActualRoomTempDesired = 5
+- basv Z1ActualRoomTempDesired = no data stored
+- basv Z1BankHolidayEndPeriod = no data stored
+- basv Z1BankHolidayEndPeriod = no data stored
+- basv Z1BankHolidayStartPeriod = no data stored
+- basv Z1BankHolidayStartPeriod = no data stored
+- basv Z1CoolingTemp = 24
+- basv Z1CoolingTemp = no data stored
+- basv Z1CoolingTimer_Friday = no data stored
+- basv Z1CoolingTimer_Friday = no data stored
+- basv Z1CoolingTimer_Monday = no data stored
+- basv Z1CoolingTimer_Monday = no data stored
+- basv Z1CoolingTimer_Saturday = no data stored
+- basv Z1CoolingTimer_Saturday = no data stored
+- basv Z1CoolingTimer_Sunday = no data stored
+- basv Z1CoolingTimer_Sunday = no data stored
+- basv Z1CoolingTimer_Thursday = no data stored
+- basv Z1CoolingTimer_Thursday = no data stored
+- basv Z1CoolingTimer_Tuesday = no data stored
+- basv Z1CoolingTimer_Tuesday = no data stored
+- basv Z1CoolingTimer_Wednesday = no data stored
+- basv Z1CoolingTimer_Wednesday = no data stored
+- 'basv Z1DayTemp =  (ERR: invalid position for 3115b52406020003000700 / 00)'
+- basv Z1DayTemp = no data stored
+- basv Z1HolidayEndPeriod = 02.01.2026
+- basv Z1HolidayEndPeriod = no data stored
+- basv Z1HolidayStartPeriod = 30.12.2025
+- basv Z1HolidayStartPeriod = no data stored
+- basv Z1HolidayTemp = 21
+- basv Z1HolidayTemp = no data stored
+- 'basv Z1Name1 = Zone '
+- basv Z1Name1 = no data stored
+- 'basv Z1Name2 =  (ERR: invalid position for f115b52406020003001800 / 06030318003100)'
+- basv Z1Name2 = no data stored
+- basv Z1NightTemp = 22
+- basv Z1NightTemp = no data stored
+- basv Z1OpMode = off
+- basv Z1OpMode = no data stored
+- basv Z1OpModeCooling = no data stored
+- basv Z1OpModeCooling = no data stored
+- basv Z1QuickVetoTemp = 22.5
+- basv Z1QuickVetoTemp = no data stored
+- basv Z1RoomTemp = 22.25
+- basv Z1RoomZoneMapping = VRC700
+- basv Z1RoomZoneMapping = no data stored
+- basv Z1SFMode = auto
+- basv Z1SFMode = no data stored
+- basv Z1Shortname = no data stored
+- basv Z1Shortname = no data stored
+- basv Z1Timer_Friday = no data stored
+- basv Z1Timer_Friday = no data stored
+- basv Z1Timer_Monday = no data stored
+- basv Z1Timer_Monday = no data stored
+- basv Z1Timer_Saturday = no data stored
+- basv Z1Timer_Saturday = no data stored
+- basv Z1Timer_Sunday = no data stored
+- basv Z1Timer_Sunday = no data stored
+- basv Z1Timer_Thursday = no data stored
+- basv Z1Timer_Thursday = no data stored
+- basv Z1Timer_Tuesday = no data stored
+- basv Z1Timer_Tuesday = no data stored
+- basv Z1Timer_Wednesday = no data stored
+- basv Z1Timer_Wednesday = no data stored
+- basv Z1ValveStatus = no data stored
+- basv Z1ValveStatus = no data stored
+- basv Z2ActualRoomTempDesired = no data stored
+- basv Z2ActualRoomTempDesired = no data stored
+- basv Z2BankHolidayEndPeriod = no data stored
+- basv Z2BankHolidayEndPeriod = no data stored
+- basv Z2BankHolidayStartPeriod = no data stored
+- basv Z2BankHolidayStartPeriod = no data stored
+- basv Z2CoolingTemp = no data stored
+- basv Z2CoolingTemp = no data stored
+- basv Z2CoolingTimer_Friday = no data stored
+- basv Z2CoolingTimer_Friday = no data stored
+- basv Z2CoolingTimer_Monday = no data stored
+- basv Z2CoolingTimer_Monday = no data stored
+- basv Z2CoolingTimer_Saturday = no data stored
+- basv Z2CoolingTimer_Saturday = no data stored
+- basv Z2CoolingTimer_Sunday = no data stored
+- basv Z2CoolingTimer_Sunday = no data stored
+- basv Z2CoolingTimer_Thursday = no data stored
+- basv Z2CoolingTimer_Thursday = no data stored
+- basv Z2CoolingTimer_Tuesday = no data stored
+- basv Z2CoolingTimer_Tuesday = no data stored
+- basv Z2CoolingTimer_Wednesday = no data stored
+- basv Z2CoolingTimer_Wednesday = no data stored
+- basv Z2DayTemp = no data stored
+- basv Z2DayTemp = no data stored
+- basv Z2HolidayEndPeriod = no data stored
+- basv Z2HolidayEndPeriod = no data stored
+- basv Z2HolidayStartPeriod = no data stored
+- basv Z2HolidayStartPeriod = no data stored
+- basv Z2HolidayTemp = no data stored
+- basv Z2HolidayTemp = no data stored
+- basv Z2Name1 = no data stored
+- basv Z2Name1 = no data stored
+- basv Z2Name2 = no data stored
+- basv Z2Name2 = no data stored
+- basv Z2NightTemp = no data stored
+- basv Z2NightTemp = no data stored
+- basv Z2OpMode = no data stored
+- basv Z2OpMode = no data stored
+- basv Z2OpModeCooling = no data stored
+- basv Z2OpModeCooling = no data stored
+- basv Z2QuickVetoTemp = no data stored
+- basv Z2QuickVetoTemp = no data stored
+- basv Z2RoomTemp =  (empty for 3115b52406020003010f00 / 0800030f00ffffff7f)
+- basv Z2RoomZoneMapping = none
+- basv Z2RoomZoneMapping = no data stored
+- basv Z2SFMode = no data stored
+- basv Z2SFMode = no data stored
+- basv Z2Shortname = no data stored
+- basv Z2Shortname = no data stored
+- basv Z2Timer_Friday = no data stored
+- basv Z2Timer_Friday = no data stored
+- basv Z2Timer_Monday = no data stored
+- basv Z2Timer_Monday = no data stored
+- basv Z2Timer_Saturday = no data stored
+- basv Z2Timer_Saturday = no data stored
+- basv Z2Timer_Sunday = no data stored
+- basv Z2Timer_Sunday = no data stored
+- basv Z2Timer_Thursday = no data stored
+- basv Z2Timer_Thursday = no data stored
+- basv Z2Timer_Tuesday = no data stored
+- basv Z2Timer_Tuesday = no data stored
+- basv Z2Timer_Wednesday = no data stored
+- basv Z2Timer_Wednesday = no data stored
+- basv Z2ValveStatus = no data stored
+- basv Z2ValveStatus = no data stored
+- basv Z3ActualRoomTempDesired = no data stored
+- basv Z3ActualRoomTempDesired = no data stored
+- basv Z3BankHolidayEndPeriod = no data stored
+- basv Z3BankHolidayEndPeriod = no data stored
+- basv Z3BankHolidayStartPeriod = no data stored
+- basv Z3BankHolidayStartPeriod = no data stored
+- basv Z3CoolingTemp = no data stored
+- basv Z3CoolingTemp = no data stored
+- basv Z3CoolingTimer_Friday = no data stored
+- basv Z3CoolingTimer_Friday = no data stored
+- basv Z3CoolingTimer_Monday = no data stored
+- basv Z3CoolingTimer_Monday = no data stored
+- basv Z3CoolingTimer_Saturday = no data stored
+- basv Z3CoolingTimer_Saturday = no data stored
+- basv Z3CoolingTimer_Sunday = no data stored
+- basv Z3CoolingTimer_Sunday = no data stored
+- basv Z3CoolingTimer_Thursday = no data stored
+- basv Z3CoolingTimer_Thursday = no data stored
+- basv Z3CoolingTimer_Tuesday = no data stored
+- basv Z3CoolingTimer_Tuesday = no data stored
+- basv Z3CoolingTimer_Wednesday = no data stored
+- basv Z3CoolingTimer_Wednesday = no data stored
+- basv Z3DayTemp = no data stored
+- basv Z3DayTemp = no data stored
+- basv Z3HolidayEndPeriod = no data stored
+- basv Z3HolidayEndPeriod = no data stored
+- basv Z3HolidayStartPeriod = no data stored
+- basv Z3HolidayStartPeriod = no data stored
+- basv Z3HolidayTemp = no data stored
+- basv Z3HolidayTemp = no data stored
+- basv Z3Name1 = no data stored
+- basv Z3Name1 = no data stored
+- basv Z3Name2 = no data stored
+- basv Z3Name2 = no data stored
+- basv Z3NightTemp = no data stored
+- basv Z3NightTemp = no data stored
+- basv Z3OpMode = no data stored
+- basv Z3OpMode = no data stored
+- basv Z3OpModeCooling = no data stored
+- basv Z3OpModeCooling = no data stored
+- basv Z3QuickVetoTemp = no data stored
+- basv Z3QuickVetoTemp = no data stored
+- basv Z3RoomTemp = no data stored
+- basv Z3RoomZoneMapping = none
+- basv Z3RoomZoneMapping = no data stored
+- basv Z3SFMode = no data stored
+- basv Z3SFMode = no data stored
+- basv Z3Shortname = no data stored
+- basv Z3Shortname = no data stored
+- basv Z3Timer_Friday = no data stored
+- basv Z3Timer_Friday = no data stored
+- basv Z3Timer_Monday = no data stored
+- basv Z3Timer_Monday = no data stored
+- basv Z3Timer_Saturday = no data stored
+- basv Z3Timer_Saturday = no data stored
+- basv Z3Timer_Sunday = no data stored
+- basv Z3Timer_Sunday = no data stored
+- basv Z3Timer_Thursday = no data stored
+- basv Z3Timer_Thursday = no data stored
+- basv Z3Timer_Tuesday = no data stored
+- basv Z3Timer_Tuesday = no data stored
+- basv Z3Timer_Wednesday = no data stored
+- basv Z3Timer_Wednesday = no data stored
+- basv Z3ValveStatus = no data stored
+- basv Z3ValveStatus = no data stored
+- Broadcast Datetime = no data stored
+- Broadcast Error = no data stored
+- Broadcast HwcStatus = no data stored
+- Broadcast Id = no data stored
+- Broadcast IdAnswer = no data stored
+- Broadcast IdQuery = no data stored
+- Broadcast Load = no data stored
+- Broadcast Outsidetemp = 21.449
+- Broadcast Queryexistence =  (empty for 31fe07fe00 / )
+- Broadcast Signoflife = no data stored
+- Broadcast Vdatetime = 11:17:45;26.08.2026
+- Broadcast Vdatetime = no data stored
+- 'ctlv2 Hc1DewPointTemp =  (ERR: invalid position for 3115b52406020002002300 / 00)'
+- 'ctlv2 Hc1FlowTempCalc =  (ERR: invalid position for 3115b52406020002002000 / 050102200002)'
+- 'ctlv2 Hc1Humidity =  (ERR: invalid position for 3115b52406020002002200 / 00)'
+- 'ctlv2 Hc1MixerPosition =  (ERR: invalid position for 3115b52406020002002100 / 00)'
+- 'ctlv2 Hc1PumpHours =  (ERR: invalid position for 3115b52406020002002400 / 00)'
+- 'ctlv2 Hc1PumpStarts =  (ERR: invalid position for 3115b52406020002002500 / 00)'
+- 'ctlv2 Hc2DewPointTemp =  (ERR: invalid position for 3115b52406020002012300 / 00)'
+- 'ctlv2 Hc2FlowTempCalc =  (ERR: invalid position for 3115b52406020002012000 / 050002200000)'
+- 'ctlv2 Hc2Humidity =  (ERR: invalid position for 3115b52406020002012200 / 00)'
+- 'ctlv2 Hc2MixerPosition =  (ERR: invalid position for 3115b52406020002012100 / 00)'
+- 'ctlv2 Hc2PumpHours =  (ERR: invalid position for 3115b52406020002012400 / 00)'
+- 'ctlv2 Hc2PumpStarts =  (ERR: invalid position for 3115b52406020002012500 / 00)'
+- ctlv2 ManualCoolingEndDate = 01.01.2019
+- ctlv2 ManualCoolingEndDate = no data stored
+- ctlv2 ManualCoolingStartDate = 01.01.2019
+- ctlv2 ManualCoolingStartDate = no data stored
+- ctlv2 z1RoomHumidity = 52
+- General Valuerange = no data stored
+- hmu BuildingCircuitFlow = 0
+- hmu Clearerrorhistory = no data stored
+- hmu CompressorBlocktime = no data stored
+- hmu CompressorHc = no data stored (message not available due to condition)
+- hmu CompressorHwc = no data stored (message not available due to condition)
+- hmu CoolElecConsTotal = 0.0
+- hmu CoolEnvYieldDay = 0.0
+- hmu CoolEnvYieldMonth = 0.0
+- hmu CoolEnvYieldTotal = 0.0
+- hmu CopCooling = 1.0
+- hmu CopCoolingMonth = 1.0
+- hmu CopHc = 3.6
+- hmu CopHcMonth = 1.0
+- hmu CopHwc = 3.6
+- hmu CopHwcMonth = 4.6
+- hmu CurrentCompressorUtil = 0.00
+- hmu CurrentConsumedPower = 0.0
+- hmu Currenterror = -;-;-;-;-
+- hmu CurrentYieldPower = 0.0
+- hmu DateTime = nosignal;-:-:-;-.-.-;-
+- hmu EnergyIntegral = no data stored
+- hmu Errorhistory = no data stored
+- hmu FlowPressure = no data stored (message not available due to condition)
+- hmu FlowTemp = 53.56
+- hmu PowerConsumptionHmu = 1.584260106
+- hmu RunDataAirInletTemp = 23.3857
+- hmu RunDataBuildingCPumpPower = 100
+- hmu RunDataCompressorInletTemp = 19.3162
+- hmu RunDataCompressorOutletTemp = 20
+- hmu RunDataCompressorSpeed = 64.0033
+- hmu RunDataEEVOutletTemp = 19.3448
+- hmu RunDataEEVPositionAbs = 250
+- hmu RunDataFan1Speed = 0.0
+- hmu RunDataFan2Speed = 0.0
+- hmu RunDataHighPressure = 13.283
+- hmu RunDataStatuscode = hwc_compressor_active
+- hmu RunStats4PortValveHours = 73
+- hmu RunStats4PortValveSwitches = 1093
+- hmu RunStatsBuildingCPumpStarts = 1721
+- hmu RunStatsBuildingPumpHours = 10930
+- hmu RunStatsCompressorHours = 8454
+- hmu RunStatsCompressorStarts = 4925
+- hmu RunStatsFan1Hours = 8631
+- hmu RunStatsFan1Starts = 6044
+- hmu RunStatsFan2Hours = 0
+- hmu RunStatsFan2Starts = 0
+- hmu RunStatsHcHours = 9934
+- hmu RunStatsHMUHours = 27563
+- hmu RunStatsHwcHours = 812
+- hmu SetMode = water;-;-;160;1;1;1;1;0;0
+- hmu SetMode = no data stored
+- 'hmu SourceTempInput =  (ERR: invalid position for 3108b51a0405ff3222 / 02ff01)'
+- hmu Status01 = 54.0;52.5;-;-;-;hwc
+- hmu Status02 = no data stored
+- hmu Status16 = no data stored
+- hmu Status = no data stored
+- hmu StatusCirPump = on
+- hmu SupplyTempWeighted = 20.00
+- hmu TotalEnergyUsage = 7824
+- hmu YieldCoolDay = 0.0
+- hmu YieldCooling = 0.0
+- hmu YieldCoolingMonth = 0.0
+- hmu YieldHc = 18767
+- hmu YieldHcDay = 0.0
+- hmu YieldHcMonth = 0.0
+- hmu YieldHwc = 2967
+- hmu YieldHwcDay = 1.7
+- hmu YieldHwcMonth = 56.6
+- Memory Eeprom = no data stored
+- Memory Eeprom = no data stored
+- Memory Ram = no data stored
+- Memory Ram = no data stored
+- Scan Id = no data stored
+- scan.08  = Vaillant;HMU00;0901;5103
+- scan.15  = Vaillant;BASV2;0507;1704
+- Scan.15 Id = 21;22;25;0020262148;0082;006876;N9
+- scan.76  = Vaillant;VWZIO;0902;5103
+- Scan.76 Id = 21;23;21;0010022084;3100;005613;N0
+- scan.f6  = Vaillant;NETX2;4040;5703
+- Scan.f6 Id = 21;22;30;0020260962;0938;053360;N1
+- vwzio EnableTestHwcTemp = no data stored
+- vwzio EnableTestOutdoorTemp = no data stored
+- vwzio EnableTestThreeWayValve = no data stored
+- vwzio TestHwcTemp = no data stored
+- vwzio TestOutdoorTemp = no data stored
+- vwzio TestThreeWayValve = no data stored
+- ''

--- a/tests/fixtures/community/arotherm_basv_boost_on_discovery.yaml
+++ b/tests/fixtures/community/arotherm_basv_boost_on_discovery.yaml
@@ -1,0 +1,15023 @@
+# Discovery dump for vaillant_ebus
+# Review this file for sensitive information before sharing
+metadata:
+  timestamp: '2026-08-26T11:16:49.626111'
+  ebusd_version: null
+  register_count: 743
+  grab_duration: 10
+  dump_version: 3
+raw_find_lines:
+- basv AdaptHeatCurve = no
+- basv AdaptHeatCurve = no data stored
+- basv BankHolidayEndPeriod = no data stored
+- basv BankHolidayEndPeriod = no data stored
+- basv BankHolidayStartPeriod = no data stored
+- basv BankHolidayStartPeriod = no data stored
+- basv CcTimer_Friday = no data stored
+- basv CcTimer_Friday = no data stored
+- basv CcTimer_Monday = no data stored
+- basv CcTimer_Monday = no data stored
+- basv CcTimer_Saturday = no data stored
+- basv CcTimer_Saturday = no data stored
+- basv CcTimer_Sunday = no data stored
+- basv CcTimer_Sunday = no data stored
+- basv CcTimer_Thursday = no data stored
+- basv CcTimer_Thursday = no data stored
+- basv CcTimer_Tuesday = no data stored
+- basv CcTimer_Tuesday = no data stored
+- basv CcTimer_Wednesday = no data stored
+- basv CcTimer_Wednesday = no data stored
+- basv Clearerrorhistory = no data stored
+- basv ContinuosHeating = -26
+- basv ContinuosHeating = no data stored
+- basv Currenterror = -;-;-;-;-
+- basv CylinderChargeHyst = 5
+- basv CylinderChargeHyst = no data stored
+- basv CylinderChargeOffset = 25
+- basv CylinderChargeOffset = no data stored
+- basv Date = 26.08.2026
+- basv Date = no data stored
+- basv DisplayedOutsideTemp = 21.4492
+- basv Errorhistory = no data stored
+- basv FrostOverRideTime = 4
+- basv FrostOverRideTime = no data stored
+- basv GlobalSystemOff = no
+- basv GlobalSystemOff = no data stored
+- basv Hc1ActualFlowTempDesired = 0.0
+- basv Hc1AutoOffMode = eco
+- basv Hc1AutoOffMode = no data stored
+- basv Hc1CircuitType = mixer
+- basv Hc1ExcessTemp = 0.0
+- basv Hc1ExcessTemp = no data stored
+- basv Hc1FlowTemp = 53
+- basv Hc1HeatCurve = 0.7
+- basv Hc1HeatCurve = no data stored
+- basv Hc1HeatCurveAdaption = 0.0
+- basv Hc1MaxFlowTempDesired = 60
+- basv Hc1MaxFlowTempDesired = no data stored
+- basv Hc1MinFlowTempDesired = 17
+- basv Hc1MinFlowTempDesired = no data stored
+- basv Hc1MixerMovement = 0.0
+- basv Hc1PumpStatus = 0
+- basv Hc1PumpStatus = no data stored
+- basv Hc1RoomTempSwitchOn = thermostat
+- basv Hc1RoomTempSwitchOn = no data stored
+- basv Hc1Status = 0
+- basv Hc1Status = no data stored
+- basv Hc1SummerTempLimit = 22
+- basv Hc1SummerTempLimit = no data stored
+- basv Hc2ActualFlowTempDesired = 0.0
+- basv Hc2AutoOffMode = eco
+- basv Hc2AutoOffMode = no data stored
+- basv Hc2CircuitType = inactive
+- basv Hc2ExcessTemp = 0.0
+- basv Hc2ExcessTemp = no data stored
+- basv Hc2FlowTemp =  (empty for 3115b52406020002010800 / 0800020800ffffff7f)
+- basv Hc2HeatCurve = 0.6
+- basv Hc2HeatCurve = no data stored
+- basv Hc2HeatCurveAdaption = 0.0
+- basv Hc2MaxFlowTempDesired = 55
+- basv Hc2MaxFlowTempDesired = no data stored
+- basv Hc2MinFlowTempDesired = 15
+- basv Hc2MinFlowTempDesired = no data stored
+- basv Hc2MixerMovement = 0.0
+- basv Hc2PumpStatus = 0
+- basv Hc2PumpStatus = no data stored
+- basv Hc2RoomTempSwitchOn = off
+- basv Hc2RoomTempSwitchOn = no data stored
+- basv Hc2Status = 0
+- basv Hc2Status = no data stored
+- basv Hc2SummerTempLimit = 21
+- basv Hc2SummerTempLimit = no data stored
+- basv Hc3ActualFlowTempDesired = 0.0
+- basv Hc3AutoOffMode = eco
+- basv Hc3AutoOffMode = no data stored
+- basv Hc3CircuitType = inactive
+- basv Hc3ExcessTemp = 0.0
+- basv Hc3ExcessTemp = no data stored
+- basv Hc3FlowTemp =  (empty for 3115b52406020002020800 / 0800020800ffffff7f)
+- basv Hc3HeatCurve = 0.6
+- basv Hc3HeatCurve = no data stored
+- basv Hc3HeatCurveAdaption = 0.0
+- basv Hc3MaxFlowTempDesired = 55
+- basv Hc3MaxFlowTempDesired = no data stored
+- basv Hc3MinFlowTempDesired = 15
+- basv Hc3MinFlowTempDesired = no data stored
+- basv Hc3MixerMovement = 0.0
+- basv Hc3PumpStatus = 0
+- basv Hc3PumpStatus = no data stored
+- basv Hc3RoomTempSwitchOn = off
+- basv Hc3RoomTempSwitchOn = no data stored
+- basv Hc3Status = 0
+- basv Hc3Status = no data stored
+- basv Hc3SummerTempLimit = 21
+- basv Hc3SummerTempLimit = no data stored
+- basv HcStorageTempBottom =  (empty for f115b5240602000000a000 / 080000a000ffffff7f)
+- basv HcStorageTempTop =  (empty for f115b52406020000009f00 / 0800009f00ffffff7f)
+- basv HolidayEndPeriod = no data stored
+- basv HolidayEndPeriod = no data stored
+- basv HolidayStartPeriod = no data stored
+- basv HolidayStartPeriod = no data stored
+- basv HolidayTemp = no data stored
+- basv HolidayTemp = no data stored
+- basv HwcBankHolidayEndPeriod = no data stored
+- basv HwcBankHolidayEndPeriod = no data stored
+- basv HwcBankHolidayStartPeriod = no data stored
+- basv HwcBankHolidayStartPeriod = no data stored
+- basv HwcFlowTemp = 93
+- basv HwcHolidayEndPeriod = 02.01.2026
+- basv HwcHolidayEndPeriod = no data stored
+- basv HwcHolidayStartPeriod = 30.12.2025
+- basv HwcHolidayStartPeriod = no data stored
+- basv HwcLockTime = 60
+- basv HwcLockTime = no data stored
+- basv HwcMaxFlowTempDesired = 80
+- basv HwcMaxFlowTempDesired = no data stored
+- basv HwcOpMode = auto
+- basv HwcOpMode = no data stored
+- basv HwcParallelLoading = off
+- basv HwcParallelLoading = no data stored
+- basv HwcSFMode = load
+- basv HwcSFMode = no data stored
+- basv HwcStorageTemp = 46
+- basv HwcStorageTempBottom =  (empty for f115b52406020000009e00 / 0800009e00ffffff7f)
+- basv HwcStorageTempTop =  (empty for f115b52406020000009d00 / 0800009d00ffffff7f)
+- basv HwcTempDesired = 68
+- basv HwcTempDesired = no data stored
+- basv HwcTimer_Friday = no data stored
+- basv HwcTimer_Friday = no data stored
+- basv HwcTimer_Monday = no data stored
+- basv HwcTimer_Monday = no data stored
+- basv HwcTimer_Saturday = no data stored
+- basv HwcTimer_Saturday = no data stored
+- basv HwcTimer_Sunday = no data stored
+- basv HwcTimer_Sunday = no data stored
+- basv HwcTimer_Thursday = no data stored
+- basv HwcTimer_Thursday = no data stored
+- basv HwcTimer_Tuesday = no data stored
+- basv HwcTimer_Tuesday = no data stored
+- basv HwcTimer_Wednesday = no data stored
+- basv HwcTimer_Wednesday = no data stored
+- basv HydraulicScheme = 8
+- basv HydraulicScheme = no data stored
+- basv Installer1 = no data stored
+- basv Installer1 = no data stored
+- basv Installer2 = no data stored
+- basv Installer2 = no data stored
+- basv KeyCodeforConfigMenu = no data stored
+- basv KeyCodeforConfigMenu = no data stored
+- basv MaintenanceDate = no data stored
+- basv MaintenanceDate = no data stored
+- basv MaintenanceDue = no data stored
+- basv ManualCooling = no data stored
+- basv ManualCooling = no data stored
+- basv MaxCylinderChargeTime = 120
+- basv MaxCylinderChargeTime = no data stored
+- basv MaxRoomHumidity = 40
+- basv MaxRoomHumidity = no data stored
+- basv MultiRelaySetting = 4
+- basv MultiRelaySetting = no data stored
+- basv NoiseReductionTimer_Friday = no data stored
+- basv NoiseReductionTimer_Friday = no data stored
+- basv NoiseReductionTimer_Monday = no data stored
+- basv NoiseReductionTimer_Monday = no data stored
+- basv NoiseReductionTimer_Saturday = no data stored
+- basv NoiseReductionTimer_Saturday = no data stored
+- basv NoiseReductionTimer_Sunday = no data stored
+- basv NoiseReductionTimer_Sunday = no data stored
+- basv NoiseReductionTimer_Thursday = no data stored
+- basv NoiseReductionTimer_Thursday = no data stored
+- basv NoiseReductionTimer_Tuesday = no data stored
+- basv NoiseReductionTimer_Tuesday = no data stored
+- basv NoiseReductionTimer_Wednesday = no data stored
+- basv NoiseReductionTimer_Wednesday = no data stored
+- basv OpMode = no data stored
+- basv OpMode = no data stored
+- basv OpModeCooling = no data stored
+- basv OpModeCooling = no data stored
+- basv OpModeEffect = no data stored
+- basv OpModeEffect = no data stored
+- basv OpModeVentilation = no data stored
+- basv OpModeVentilation = no data stored
+- basv OutsideTempAvg = 17.6992
+- basv OutsideTempAvg = no data stored
+- basv PhoneNumber1 = no data stored
+- basv PhoneNumber1 = no data stored
+- basv PhoneNumber2 = no data stored
+- basv PhoneNumber2 = no data stored
+- 'basv PrEnergySum =  (ERR: invalid position for 3115b52406020000005c00 / 00)'
+- basv PrEnergySum = no data stored
+- basv PrEnergySumHc = 7192
+- basv PrEnergySumHc = no data stored
+- basv PrEnergySumHcLastMonth = 7
+- basv PrEnergySumHcLastMonth = no data stored
+- basv PrEnergySumHcThisMonth = 6
+- basv PrEnergySumHcThisMonth = no data stored
+- basv PrEnergySumHwc = 1279
+- basv PrEnergySumHwc = no data stored
+- basv PrEnergySumHwcLastMonth = 28
+- basv PrEnergySumHwcLastMonth = no data stored
+- basv PrEnergySumHwcThisMonth = 23
+- basv PrEnergySumHwcThisMonth = no data stored
+- basv PrFuelSum = no data stored
+- basv PrFuelSum = no data stored
+- basv PrFuelSumHc = no data stored
+- basv PrFuelSumHc = no data stored
+- basv PrFuelSumHcLastMonth = no data stored
+- basv PrFuelSumHcLastMonth = no data stored
+- basv PrFuelSumHcThisMonth = no data stored
+- basv PrFuelSumHcThisMonth = no data stored
+- basv PrFuelSumHwc = no data stored
+- basv PrFuelSumHwc = no data stored
+- basv PrFuelSumHwcLastMonth = no data stored
+- basv PrFuelSumHwcLastMonth = no data stored
+- basv PrFuelSumHwcThisMonth = no data stored
+- basv PrFuelSumHwcThisMonth = no data stored
+- basv PumpAdditionalTime = no data stored
+- basv PumpAdditionalTime = no data stored
+- basv SFMode = no data stored
+- basv SFMode = no data stored
+- basv SolarYieldTotal = no data stored
+- basv SolarYieldTotal = no data stored
+- basv SystemFlowTemp =  (empty for f115b52406020000004b00 / 0800004b00ffffff7f)
+- basv TariffTimer_Friday = no data stored
+- basv TariffTimer_Friday = no data stored
+- basv TariffTimer_Monday = no data stored
+- basv TariffTimer_Monday = no data stored
+- basv TariffTimer_Saturday = no data stored
+- basv TariffTimer_Saturday = no data stored
+- basv TariffTimer_Sunday = no data stored
+- basv TariffTimer_Sunday = no data stored
+- basv TariffTimer_Thursday = no data stored
+- basv TariffTimer_Thursday = no data stored
+- basv TariffTimer_Tuesday = no data stored
+- basv TariffTimer_Tuesday = no data stored
+- basv TariffTimer_Wednesday = no data stored
+- basv TariffTimer_Wednesday = no data stored
+- basv Time = 10:54:32
+- basv Time = no data stored
+- basv VentilationDay = no data stored
+- basv VentilationDay = no data stored
+- basv VentilationNight = no data stored
+- basv VentilationNight = no data stored
+- basv VentilationTimer_Friday = no data stored
+- basv VentilationTimer_Friday = no data stored
+- basv VentilationTimer_Monday = no data stored
+- basv VentilationTimer_Monday = no data stored
+- basv VentilationTimer_Saturday = no data stored
+- basv VentilationTimer_Saturday = no data stored
+- basv VentilationTimer_Sunday = no data stored
+- basv VentilationTimer_Sunday = no data stored
+- basv VentilationTimer_Thursday = no data stored
+- basv VentilationTimer_Thursday = no data stored
+- basv VentilationTimer_Tuesday = no data stored
+- basv VentilationTimer_Tuesday = no data stored
+- basv VentilationTimer_Wednesday = no data stored
+- basv VentilationTimer_Wednesday = no data stored
+- basv WaterPressure = 1.7
+- basv YieldTotal = 21748
+- basv YieldTotal = no data stored
+- basv Z1ActualRoomTempDesired = 5
+- basv Z1ActualRoomTempDesired = no data stored
+- basv Z1BankHolidayEndPeriod = no data stored
+- basv Z1BankHolidayEndPeriod = no data stored
+- basv Z1BankHolidayStartPeriod = no data stored
+- basv Z1BankHolidayStartPeriod = no data stored
+- basv Z1CoolingTemp = 24
+- basv Z1CoolingTemp = no data stored
+- basv Z1CoolingTimer_Friday = no data stored
+- basv Z1CoolingTimer_Friday = no data stored
+- basv Z1CoolingTimer_Monday = no data stored
+- basv Z1CoolingTimer_Monday = no data stored
+- basv Z1CoolingTimer_Saturday = no data stored
+- basv Z1CoolingTimer_Saturday = no data stored
+- basv Z1CoolingTimer_Sunday = no data stored
+- basv Z1CoolingTimer_Sunday = no data stored
+- basv Z1CoolingTimer_Thursday = no data stored
+- basv Z1CoolingTimer_Thursday = no data stored
+- basv Z1CoolingTimer_Tuesday = no data stored
+- basv Z1CoolingTimer_Tuesday = no data stored
+- basv Z1CoolingTimer_Wednesday = no data stored
+- basv Z1CoolingTimer_Wednesday = no data stored
+- 'basv Z1DayTemp =  (ERR: invalid position for 3115b52406020003000700 / 00)'
+- basv Z1DayTemp = no data stored
+- basv Z1HolidayEndPeriod = 02.01.2026
+- basv Z1HolidayEndPeriod = no data stored
+- basv Z1HolidayStartPeriod = 30.12.2025
+- basv Z1HolidayStartPeriod = no data stored
+- basv Z1HolidayTemp = 21
+- basv Z1HolidayTemp = no data stored
+- 'basv Z1Name1 = Zone '
+- basv Z1Name1 = no data stored
+- 'basv Z1Name2 =  (ERR: invalid position for f115b52406020003001800 / 06030318003100)'
+- basv Z1Name2 = no data stored
+- basv Z1NightTemp = 22
+- basv Z1NightTemp = no data stored
+- basv Z1OpMode = off
+- basv Z1OpMode = no data stored
+- basv Z1OpModeCooling = no data stored
+- basv Z1OpModeCooling = no data stored
+- basv Z1QuickVetoTemp = 22.5
+- basv Z1QuickVetoTemp = no data stored
+- basv Z1RoomTemp = 22.25
+- basv Z1RoomZoneMapping = VRC700
+- basv Z1RoomZoneMapping = no data stored
+- basv Z1SFMode = auto
+- basv Z1SFMode = no data stored
+- basv Z1Shortname = no data stored
+- basv Z1Shortname = no data stored
+- basv Z1Timer_Friday = no data stored
+- basv Z1Timer_Friday = no data stored
+- basv Z1Timer_Monday = no data stored
+- basv Z1Timer_Monday = no data stored
+- basv Z1Timer_Saturday = no data stored
+- basv Z1Timer_Saturday = no data stored
+- basv Z1Timer_Sunday = no data stored
+- basv Z1Timer_Sunday = no data stored
+- basv Z1Timer_Thursday = no data stored
+- basv Z1Timer_Thursday = no data stored
+- basv Z1Timer_Tuesday = no data stored
+- basv Z1Timer_Tuesday = no data stored
+- basv Z1Timer_Wednesday = no data stored
+- basv Z1Timer_Wednesday = no data stored
+- basv Z1ValveStatus = no data stored
+- basv Z1ValveStatus = no data stored
+- basv Z2ActualRoomTempDesired = no data stored
+- basv Z2ActualRoomTempDesired = no data stored
+- basv Z2BankHolidayEndPeriod = no data stored
+- basv Z2BankHolidayEndPeriod = no data stored
+- basv Z2BankHolidayStartPeriod = no data stored
+- basv Z2BankHolidayStartPeriod = no data stored
+- basv Z2CoolingTemp = no data stored
+- basv Z2CoolingTemp = no data stored
+- basv Z2CoolingTimer_Friday = no data stored
+- basv Z2CoolingTimer_Friday = no data stored
+- basv Z2CoolingTimer_Monday = no data stored
+- basv Z2CoolingTimer_Monday = no data stored
+- basv Z2CoolingTimer_Saturday = no data stored
+- basv Z2CoolingTimer_Saturday = no data stored
+- basv Z2CoolingTimer_Sunday = no data stored
+- basv Z2CoolingTimer_Sunday = no data stored
+- basv Z2CoolingTimer_Thursday = no data stored
+- basv Z2CoolingTimer_Thursday = no data stored
+- basv Z2CoolingTimer_Tuesday = no data stored
+- basv Z2CoolingTimer_Tuesday = no data stored
+- basv Z2CoolingTimer_Wednesday = no data stored
+- basv Z2CoolingTimer_Wednesday = no data stored
+- basv Z2DayTemp = no data stored
+- basv Z2DayTemp = no data stored
+- basv Z2HolidayEndPeriod = no data stored
+- basv Z2HolidayEndPeriod = no data stored
+- basv Z2HolidayStartPeriod = no data stored
+- basv Z2HolidayStartPeriod = no data stored
+- basv Z2HolidayTemp = no data stored
+- basv Z2HolidayTemp = no data stored
+- basv Z2Name1 = no data stored
+- basv Z2Name1 = no data stored
+- basv Z2Name2 = no data stored
+- basv Z2Name2 = no data stored
+- basv Z2NightTemp = no data stored
+- basv Z2NightTemp = no data stored
+- basv Z2OpMode = no data stored
+- basv Z2OpMode = no data stored
+- basv Z2OpModeCooling = no data stored
+- basv Z2OpModeCooling = no data stored
+- basv Z2QuickVetoTemp = no data stored
+- basv Z2QuickVetoTemp = no data stored
+- basv Z2RoomTemp =  (empty for 3115b52406020003010f00 / 0800030f00ffffff7f)
+- basv Z2RoomZoneMapping = none
+- basv Z2RoomZoneMapping = no data stored
+- basv Z2SFMode = no data stored
+- basv Z2SFMode = no data stored
+- basv Z2Shortname = no data stored
+- basv Z2Shortname = no data stored
+- basv Z2Timer_Friday = no data stored
+- basv Z2Timer_Friday = no data stored
+- basv Z2Timer_Monday = no data stored
+- basv Z2Timer_Monday = no data stored
+- basv Z2Timer_Saturday = no data stored
+- basv Z2Timer_Saturday = no data stored
+- basv Z2Timer_Sunday = no data stored
+- basv Z2Timer_Sunday = no data stored
+- basv Z2Timer_Thursday = no data stored
+- basv Z2Timer_Thursday = no data stored
+- basv Z2Timer_Tuesday = no data stored
+- basv Z2Timer_Tuesday = no data stored
+- basv Z2Timer_Wednesday = no data stored
+- basv Z2Timer_Wednesday = no data stored
+- basv Z2ValveStatus = no data stored
+- basv Z2ValveStatus = no data stored
+- basv Z3ActualRoomTempDesired = no data stored
+- basv Z3ActualRoomTempDesired = no data stored
+- basv Z3BankHolidayEndPeriod = no data stored
+- basv Z3BankHolidayEndPeriod = no data stored
+- basv Z3BankHolidayStartPeriod = no data stored
+- basv Z3BankHolidayStartPeriod = no data stored
+- basv Z3CoolingTemp = no data stored
+- basv Z3CoolingTemp = no data stored
+- basv Z3CoolingTimer_Friday = no data stored
+- basv Z3CoolingTimer_Friday = no data stored
+- basv Z3CoolingTimer_Monday = no data stored
+- basv Z3CoolingTimer_Monday = no data stored
+- basv Z3CoolingTimer_Saturday = no data stored
+- basv Z3CoolingTimer_Saturday = no data stored
+- basv Z3CoolingTimer_Sunday = no data stored
+- basv Z3CoolingTimer_Sunday = no data stored
+- basv Z3CoolingTimer_Thursday = no data stored
+- basv Z3CoolingTimer_Thursday = no data stored
+- basv Z3CoolingTimer_Tuesday = no data stored
+- basv Z3CoolingTimer_Tuesday = no data stored
+- basv Z3CoolingTimer_Wednesday = no data stored
+- basv Z3CoolingTimer_Wednesday = no data stored
+- basv Z3DayTemp = no data stored
+- basv Z3DayTemp = no data stored
+- basv Z3HolidayEndPeriod = no data stored
+- basv Z3HolidayEndPeriod = no data stored
+- basv Z3HolidayStartPeriod = no data stored
+- basv Z3HolidayStartPeriod = no data stored
+- basv Z3HolidayTemp = no data stored
+- basv Z3HolidayTemp = no data stored
+- basv Z3Name1 = no data stored
+- basv Z3Name1 = no data stored
+- basv Z3Name2 = no data stored
+- basv Z3Name2 = no data stored
+- basv Z3NightTemp = no data stored
+- basv Z3NightTemp = no data stored
+- basv Z3OpMode = no data stored
+- basv Z3OpMode = no data stored
+- basv Z3OpModeCooling = no data stored
+- basv Z3OpModeCooling = no data stored
+- basv Z3QuickVetoTemp = no data stored
+- basv Z3QuickVetoTemp = no data stored
+- basv Z3RoomTemp = no data stored
+- basv Z3RoomZoneMapping = none
+- basv Z3RoomZoneMapping = no data stored
+- basv Z3SFMode = no data stored
+- basv Z3SFMode = no data stored
+- basv Z3Shortname = no data stored
+- basv Z3Shortname = no data stored
+- basv Z3Timer_Friday = no data stored
+- basv Z3Timer_Friday = no data stored
+- basv Z3Timer_Monday = no data stored
+- basv Z3Timer_Monday = no data stored
+- basv Z3Timer_Saturday = no data stored
+- basv Z3Timer_Saturday = no data stored
+- basv Z3Timer_Sunday = no data stored
+- basv Z3Timer_Sunday = no data stored
+- basv Z3Timer_Thursday = no data stored
+- basv Z3Timer_Thursday = no data stored
+- basv Z3Timer_Tuesday = no data stored
+- basv Z3Timer_Tuesday = no data stored
+- basv Z3Timer_Wednesday = no data stored
+- basv Z3Timer_Wednesday = no data stored
+- basv Z3ValveStatus = no data stored
+- basv Z3ValveStatus = no data stored
+- Broadcast Datetime = no data stored
+- Broadcast Error = no data stored
+- Broadcast HwcStatus = no data stored
+- Broadcast Id = no data stored
+- Broadcast IdAnswer = no data stored
+- Broadcast IdQuery = no data stored
+- Broadcast Load = no data stored
+- Broadcast Outsidetemp = 21.449
+- Broadcast Queryexistence =  (empty for 31fe07fe00 / )
+- Broadcast Signoflife = no data stored
+- Broadcast Vdatetime = 11:15:44;26.08.2026
+- Broadcast Vdatetime = no data stored
+- 'ctlv2 Hc1DewPointTemp =  (ERR: invalid position for 3115b52406020002002300 / 00)'
+- 'ctlv2 Hc1FlowTempCalc =  (ERR: invalid position for 3115b52406020002002000 / 050102200002)'
+- 'ctlv2 Hc1Humidity =  (ERR: invalid position for 3115b52406020002002200 / 00)'
+- 'ctlv2 Hc1MixerPosition =  (ERR: invalid position for 3115b52406020002002100 / 00)'
+- 'ctlv2 Hc1PumpHours =  (ERR: invalid position for 3115b52406020002002400 / 00)'
+- 'ctlv2 Hc1PumpStarts =  (ERR: invalid position for 3115b52406020002002500 / 00)'
+- 'ctlv2 Hc2DewPointTemp =  (ERR: invalid position for 3115b52406020002012300 / 00)'
+- 'ctlv2 Hc2FlowTempCalc =  (ERR: invalid position for 3115b52406020002012000 / 050002200000)'
+- 'ctlv2 Hc2Humidity =  (ERR: invalid position for 3115b52406020002012200 / 00)'
+- 'ctlv2 Hc2MixerPosition =  (ERR: invalid position for 3115b52406020002012100 / 00)'
+- 'ctlv2 Hc2PumpHours =  (ERR: invalid position for 3115b52406020002012400 / 00)'
+- 'ctlv2 Hc2PumpStarts =  (ERR: invalid position for 3115b52406020002012500 / 00)'
+- ctlv2 ManualCoolingEndDate = 01.01.2019
+- ctlv2 ManualCoolingEndDate = no data stored
+- ctlv2 ManualCoolingStartDate = 01.01.2019
+- ctlv2 ManualCoolingStartDate = no data stored
+- ctlv2 z1RoomHumidity = 52
+- General Valuerange = no data stored
+- hmu BuildingCircuitFlow = 0
+- hmu Clearerrorhistory = no data stored
+- hmu CompressorBlocktime = no data stored
+- hmu CompressorHc = no data stored (message not available due to condition)
+- hmu CompressorHwc = no data stored (message not available due to condition)
+- hmu CoolElecConsTotal = 0.0
+- hmu CoolEnvYieldDay = 0.0
+- hmu CoolEnvYieldMonth = 0.0
+- hmu CoolEnvYieldTotal = 0.0
+- hmu CopCooling = 1.0
+- hmu CopCoolingMonth = 1.0
+- hmu CopHc = 3.6
+- hmu CopHcMonth = 1.0
+- hmu CopHwc = 3.6
+- hmu CopHwcMonth = 4.6
+- hmu CurrentCompressorUtil = 0.00
+- hmu CurrentConsumedPower = 0.0
+- hmu Currenterror = -;-;-;-;-
+- hmu CurrentYieldPower = 0.0
+- hmu DateTime = nosignal;-:-:-;-.-.-;-
+- hmu EnergyIntegral = no data stored
+- hmu Errorhistory = no data stored
+- hmu FlowPressure = no data stored (message not available due to condition)
+- hmu FlowTemp = 53.56
+- hmu PowerConsumptionHmu = 1.558503509
+- hmu RunDataAirInletTemp = 24.7758
+- hmu RunDataBuildingCPumpPower = 100
+- hmu RunDataCompressorInletTemp = 19.3162
+- hmu RunDataCompressorOutletTemp = 20
+- hmu RunDataCompressorSpeed = 64.0033
+- hmu RunDataEEVOutletTemp = 19.3448
+- hmu RunDataEEVPositionAbs = 250
+- hmu RunDataFan1Speed = 0.0
+- hmu RunDataFan2Speed = 0.0
+- hmu RunDataHighPressure = 13.283
+- hmu RunDataStatuscode = hwc_compressor_active
+- hmu RunStats4PortValveHours = 73
+- hmu RunStats4PortValveSwitches = 1093
+- hmu RunStatsBuildingCPumpStarts = 1721
+- hmu RunStatsBuildingPumpHours = 10930
+- hmu RunStatsCompressorHours = 8454
+- hmu RunStatsCompressorStarts = 4925
+- hmu RunStatsFan1Hours = 8631
+- hmu RunStatsFan1Starts = 6044
+- hmu RunStatsFan2Hours = 0
+- hmu RunStatsFan2Starts = 0
+- hmu RunStatsHcHours = 9934
+- hmu RunStatsHMUHours = 27563
+- hmu RunStatsHwcHours = 812
+- hmu SetMode = water;-;-;160;1;1;1;1;0;0
+- hmu SetMode = no data stored
+- 'hmu SourceTempInput =  (ERR: invalid position for 3108b51a0405ff3222 / 02ff01)'
+- hmu Status01 = 53.5;52.0;-;-;-;hwc
+- hmu Status02 = no data stored
+- hmu Status16 = no data stored
+- hmu Status = no data stored
+- hmu StatusCirPump = on
+- hmu SupplyTempWeighted = 20.00
+- hmu TotalEnergyUsage = 7824
+- hmu YieldCoolDay = 0.0
+- hmu YieldCooling = 0.0
+- hmu YieldCoolingMonth = 0.0
+- hmu YieldHc = 18767
+- hmu YieldHcDay = 0.0
+- hmu YieldHcMonth = 0.0
+- hmu YieldHwc = 2967
+- hmu YieldHwcDay = 1.7
+- hmu YieldHwcMonth = 56.6
+- Memory Eeprom = no data stored
+- Memory Eeprom = no data stored
+- Memory Ram = no data stored
+- Memory Ram = no data stored
+- Scan Id = no data stored
+- scan.08  = Vaillant;HMU00;0901;5103
+- scan.15  = Vaillant;BASV2;0507;1704
+- Scan.15 Id = 21;22;25;0020262148;0082;006876;N9
+- scan.76  = Vaillant;VWZIO;0902;5103
+- Scan.76 Id = 21;23;21;0010022084;3100;005613;N0
+- scan.f6  = Vaillant;NETX2;4040;5703
+- Scan.f6 Id = 21;22;30;0020260962;0938;053360;N1
+- vwzio EnableTestHwcTemp = no data stored
+- vwzio EnableTestOutdoorTemp = no data stored
+- vwzio EnableTestThreeWayValve = no data stored
+- vwzio TestHwcTemp = no data stored
+- vwzio TestOutdoorTemp = no data stored
+- vwzio TestThreeWayValve = no data stored
+- ''
+before_registers:
+- circuit: Broadcast
+  name: Datetime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Error
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: Broadcast
+  name: HwcStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Id
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: IdAnswer
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: IdQuery
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Load
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Outsidetemp
+  fields:
+  - value
+  values:
+  - '21.449'
+  writable: false
+  has_data: true
+- circuit: Broadcast
+  name: Queryexistence
+  fields:
+  - value
+  values:
+  - (empty for 31fe07fe00 / )
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Signoflife
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Vdatetime
+  fields:
+  - value
+  values:
+  - 11:15:44;26.08.2026
+  writable: false
+  has_data: true
+- circuit: Broadcast
+  name: Vdatetime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: WaterPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: General
+  name: Valuerange
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Eeprom
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Eeprom
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Ram
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Ram
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Scan
+  name: Id
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Scan.15
+  name: Id
+  fields:
+  - value
+  values:
+  - 21;22;25;0020262148;0082;006876;N9
+  writable: false
+  has_data: true
+- circuit: Scan.76
+  name: Id
+  fields:
+  - value
+  values:
+  - 21;23;21;0010022084;3100;005613;N0
+  writable: false
+  has_data: true
+- circuit: Scan.f6
+  name: Id
+  fields:
+  - value
+  values:
+  - 21;22;30;0020260962;0938;053360;N1
+  writable: false
+  has_data: true
+- circuit: basv
+  name: AdaptHeatCurve
+  fields:
+  - value
+  values:
+  - 'no'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: AdaptHeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: CcTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: CcTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: CcTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: CcTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: CcTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: CcTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: CcTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: CcTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: CcTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: CcTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: CcTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: CcTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: CcTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: CcTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Clearerrorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: ContinuosHeating
+  fields:
+  - value
+  values:
+  - '-26'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: ContinuosHeating
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - -;-;-;-;-
+  writable: false
+  has_data: true
+- circuit: basv
+  name: CylinderChargeHyst
+  fields:
+  - value
+  values:
+  - '5'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: CylinderChargeHyst
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: CylinderChargeOffset
+  fields:
+  - value
+  values:
+  - '25'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: CylinderChargeOffset
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Date
+  fields:
+  - value
+  values:
+  - 26.08.2026
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Date
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: DisplayedOutsideTemp
+  fields:
+  - value
+  values:
+  - '21.4492'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: FrostOverRideTime
+  fields:
+  - value
+  values:
+  - '4'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: FrostOverRideTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: GlobalSystemOff
+  fields:
+  - value
+  values:
+  - 'no'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: GlobalSystemOff
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc1ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc1AutoOffMode
+  fields:
+  - value
+  values:
+  - eco
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc1AutoOffMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc1CircuitType
+  fields:
+  - value
+  values:
+  - mixer
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc1ExcessTemp
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc1ExcessTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc1FlowTemp
+  fields:
+  - value
+  values:
+  - '53'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc1HeatCurve
+  fields:
+  - value
+  values:
+  - '0.7'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc1HeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc1HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc1MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '60'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc1MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc1MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - '17'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc1MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc1MixerMovement
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc1PumpStatus
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc1PumpStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc1RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - thermostat
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc1RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc1Status
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc1Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc1SummerTempLimit
+  fields:
+  - value
+  values:
+  - '22'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc1SummerTempLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc2ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc2AutoOffMode
+  fields:
+  - value
+  values:
+  - eco
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc2AutoOffMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc2CircuitType
+  fields:
+  - value
+  values:
+  - inactive
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc2ExcessTemp
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc2ExcessTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc2FlowTemp
+  fields:
+  - value
+  values:
+  - (empty for 3115b52406020002010800 / 0800020800ffffff7f)
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc2HeatCurve
+  fields:
+  - value
+  values:
+  - '0.6'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc2HeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc2HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc2MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '55'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc2MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc2MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - '15'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc2MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc2MixerMovement
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc2PumpStatus
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc2PumpStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc2RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'off'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc2RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc2Status
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc2Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc2SummerTempLimit
+  fields:
+  - value
+  values:
+  - '21'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc2SummerTempLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc3ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc3AutoOffMode
+  fields:
+  - value
+  values:
+  - eco
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc3AutoOffMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc3CircuitType
+  fields:
+  - value
+  values:
+  - inactive
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc3ExcessTemp
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc3ExcessTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc3FlowTemp
+  fields:
+  - value
+  values:
+  - (empty for 3115b52406020002020800 / 0800020800ffffff7f)
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc3HeatCurve
+  fields:
+  - value
+  values:
+  - '0.6'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc3HeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc3HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc3MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '55'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc3MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc3MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - '15'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc3MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc3MixerMovement
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc3PumpStatus
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc3PumpStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc3RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'off'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc3RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc3Status
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc3Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc3SummerTempLimit
+  fields:
+  - value
+  values:
+  - '21'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc3SummerTempLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HcStorageTempBottom
+  fields:
+  - value
+  values:
+  - (empty for f115b5240602000000a000 / 080000a000ffffff7f)
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HcStorageTempTop
+  fields:
+  - value
+  values:
+  - (empty for f115b52406020000009f00 / 0800009f00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcBankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcBankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcBankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcBankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcFlowTemp
+  fields:
+  - value
+  values:
+  - '93'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: HwcHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 02.01.2026
+  writable: false
+  has_data: true
+- circuit: basv
+  name: HwcHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 30.12.2025
+  writable: false
+  has_data: true
+- circuit: basv
+  name: HwcHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcLockTime
+  fields:
+  - value
+  values:
+  - '60'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: HwcLockTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcMaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '80'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: HwcMaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcOpMode
+  fields:
+  - value
+  values:
+  - auto
+  writable: false
+  has_data: true
+- circuit: basv
+  name: HwcOpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcParallelLoading
+  fields:
+  - value
+  values:
+  - 'off'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: HwcParallelLoading
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcSFMode
+  fields:
+  - value
+  values:
+  - load
+  writable: false
+  has_data: true
+- circuit: basv
+  name: HwcSFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcStorageTemp
+  fields:
+  - value
+  values:
+  - '46'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: HwcStorageTempBottom
+  fields:
+  - value
+  values:
+  - (empty for f115b52406020000009e00 / 0800009e00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcStorageTempTop
+  fields:
+  - value
+  values:
+  - (empty for f115b52406020000009d00 / 0800009d00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcTempDesired
+  fields:
+  - value
+  values:
+  - '68'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: HwcTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HydraulicScheme
+  fields:
+  - value
+  values:
+  - '8'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: HydraulicScheme
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Installer1
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Installer1
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Installer2
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Installer2
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: basv
+  name: KeyCodeforConfigMenu
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: basv
+  name: KeyCodeforConfigMenu
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: basv
+  name: MaintenanceDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: MaintenanceDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: MaintenanceDue
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: ManualCooling
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: ManualCooling
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: MaxCylinderChargeTime
+  fields:
+  - value
+  values:
+  - '120'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: MaxCylinderChargeTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: MaxRoomHumidity
+  fields:
+  - value
+  values:
+  - '40'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: MaxRoomHumidity
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: MultiRelaySetting
+  fields:
+  - value
+  values:
+  - '4'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: MultiRelaySetting
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: NoiseReductionTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: NoiseReductionTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: NoiseReductionTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: NoiseReductionTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: NoiseReductionTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: NoiseReductionTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: NoiseReductionTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: NoiseReductionTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: NoiseReductionTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: NoiseReductionTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: NoiseReductionTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: NoiseReductionTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: NoiseReductionTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: NoiseReductionTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: OpModeCooling
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: OpModeCooling
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: OpModeEffect
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: OpModeEffect
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: OpModeVentilation
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: OpModeVentilation
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: OutsideTempAvg
+  fields:
+  - value
+  values:
+  - '17.6992'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: OutsideTempAvg
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PhoneNumber1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PhoneNumber1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PhoneNumber2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PhoneNumber2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrEnergySum
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020000005c00 / 00)'
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrEnergySum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrEnergySumHc
+  fields:
+  - value
+  values:
+  - '7192'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: PrEnergySumHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrEnergySumHcLastMonth
+  fields:
+  - value
+  values:
+  - '7'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: PrEnergySumHcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrEnergySumHcThisMonth
+  fields:
+  - value
+  values:
+  - '6'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: PrEnergySumHcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrEnergySumHwc
+  fields:
+  - value
+  values:
+  - '1279'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: PrEnergySumHwc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrEnergySumHwcLastMonth
+  fields:
+  - value
+  values:
+  - '28'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: PrEnergySumHwcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrEnergySumHwcThisMonth
+  fields:
+  - value
+  values:
+  - '23'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: PrEnergySumHwcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrFuelSum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrFuelSum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrFuelSumHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrFuelSumHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrFuelSumHcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrFuelSumHcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrFuelSumHcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrFuelSumHcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrFuelSumHwc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrFuelSumHwc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrFuelSumHwcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrFuelSumHwcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrFuelSumHwcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrFuelSumHwcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PumpAdditionalTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PumpAdditionalTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: SolarYieldTotal
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: SolarYieldTotal
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: SystemFlowTemp
+  fields:
+  - value
+  values:
+  - (empty for f115b52406020000004b00 / 0800004b00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: basv
+  name: TariffTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: TariffTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: TariffTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: TariffTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: TariffTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: TariffTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: TariffTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: TariffTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: TariffTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: TariffTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: TariffTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: TariffTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: TariffTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: TariffTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Time
+  fields:
+  - value
+  values:
+  - '10:54:32'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Time
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: VentilationDay
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: VentilationDay
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: VentilationNight
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: VentilationNight
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: VentilationTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: VentilationTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: VentilationTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: VentilationTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: VentilationTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: VentilationTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: VentilationTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: VentilationTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: VentilationTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: VentilationTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: VentilationTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: VentilationTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: VentilationTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: VentilationTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: WaterPressure
+  fields:
+  - value
+  values:
+  - '1.7'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: YieldTotal
+  fields:
+  - value
+  values:
+  - '21748'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: YieldTotal
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - '5'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Z1ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1CoolingTemp
+  fields:
+  - value
+  values:
+  - '24'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Z1CoolingTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1CoolingTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1CoolingTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1CoolingTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1CoolingTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1CoolingTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1CoolingTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1CoolingTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1CoolingTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1CoolingTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1CoolingTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1CoolingTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1CoolingTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1CoolingTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1CoolingTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1DayTemp
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020003000700 / 00)'
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 02.01.2026
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Z1HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 30.12.2025
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Z1HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1HolidayTemp
+  fields:
+  - value
+  values:
+  - '21'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Z1HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1Name1
+  fields:
+  - value
+  values:
+  - Zone
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Z1Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1Name2
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for f115b52406020003001800 / 06030318003100)'
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1NightTemp
+  fields:
+  - value
+  values:
+  - '22'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Z1NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1OpMode
+  fields:
+  - value
+  values:
+  - 'off'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Z1OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1OpModeCooling
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1OpModeCooling
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1QuickVetoTemp
+  fields:
+  - value
+  values:
+  - '22.5'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Z1QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1RoomTemp
+  fields:
+  - value
+  values:
+  - '22.25'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Z1RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Z1RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1SFMode
+  fields:
+  - value
+  values:
+  - auto
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Z1SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2CoolingTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2CoolingTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2CoolingTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2CoolingTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2CoolingTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2CoolingTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2CoolingTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2CoolingTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2CoolingTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2CoolingTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2CoolingTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2CoolingTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2CoolingTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2CoolingTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2CoolingTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2CoolingTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2OpModeCooling
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2OpModeCooling
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2RoomTemp
+  fields:
+  - value
+  values:
+  - (empty for 3115b52406020003010f00 / 0800030f00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Z2RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3CoolingTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3CoolingTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3CoolingTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3CoolingTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3CoolingTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3CoolingTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3CoolingTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3CoolingTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3CoolingTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3CoolingTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3CoolingTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3CoolingTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3CoolingTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3CoolingTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3CoolingTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3CoolingTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3OpModeCooling
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3OpModeCooling
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3RoomTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Z3RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: AdaptHeatCurve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: CcTimer_Config
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: CcTimer_Timeframes
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: ContinuousHeating
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: CylinderChargeHyst
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: CylinderChargeOffset
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Date
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: DisplayedOutsideTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: FrostOverRideTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1AutoOffMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1CircuitType
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1CoolingEnabled
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1CoolingFlowTempMin
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1DewPointMonitoring
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1DewPointOffset
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1DewPointTemp
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002300 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1ExcessTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1FlowTempCalc
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002000 / 050102200002)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1HeatCurve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1Humidity
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002200 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MixerMovement
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MixerPosition
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002100 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1PumpHours
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002400 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1PumpStarts
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002500 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1PumpStatus
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1RoomTempModulation
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1Status
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1SummerTempLimit
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2AutoOffMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2CircuitType
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2DewPointTemp
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012300 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2ExcessTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2FlowTempCalc
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012000 / 050002200000)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2HeatCurve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2Humidity
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012200 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MixerMovement
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MixerPosition
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012100 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2PumpHours
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012400 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2PumpStarts
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012500 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2PumpStatus
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2Status
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2SummerTempLimit
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3AutoOffMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3CircuitType
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3ExcessTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3HeatCurve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MixerMovement
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3PumpStatus
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3Status
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3SummerTempLimit
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HcStorageTempBottom
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: ctlv2
+  name: HcStorageTempTop
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: ctlv2
+  name: HwcFlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcLockTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcMaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcOpMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcParallelLoading
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcSFMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcSfMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcStorageTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcStorageTempBottom
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcStorageTempTop
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HydraulicScheme
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: ManualCoolingEndDate
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: ManualCoolingEndDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: ManualCoolingStartDate
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: ManualCoolingStartDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: MaxCylinderChargeTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: MaxRoomHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: MultiRelaySetting
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: OutsideTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: OutsideTempAvg
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySum
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHcLastMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHcThisMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHwcLastMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHwcThisMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: SystemFlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: WaterPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingManualTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingOpMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingSetbackTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1DayTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1HolidayTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1NightTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1OpMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoDuration
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoEndDate
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoEndTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1RoomTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1SFMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z2RoomTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: z1RoomHumidity
+  fields:
+  - value
+  values:
+  - '52'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: BuildingCircuitFlow
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: BuildingCircuitPumpSpeed
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Clearerrorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: CompressorBlocktime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: CompressorHc
+  fields:
+  - value
+  values:
+  - no data stored (message not available due to condition)
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: CompressorHc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHwc
+  fields:
+  - value
+  values:
+  - no data stored (message not available due to condition)
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: CompressorHwc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHwc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CoolElecConsTotal
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CoolEnvYieldDay
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CoolEnvYieldMonth
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CoolEnvYieldTotal
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CopCooling
+  fields:
+  - value
+  values:
+  - '1.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CopCoolingMonth
+  fields:
+  - value
+  values:
+  - '1.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CopHc
+  fields:
+  - value
+  values:
+  - '3.6'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CopHcMonth
+  fields:
+  - value
+  values:
+  - '1.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CopHwc
+  fields:
+  - value
+  values:
+  - '3.6'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CopHwcMonth
+  fields:
+  - value
+  values:
+  - '4.6'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CurrentCompressorUtil
+  fields:
+  - value
+  values:
+  - '0.00'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CurrentConsumedPower
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CurrentYieldPower
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - -;-;-;-;-
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: DateTime
+  fields:
+  - value
+  values:
+  - nosignal;-:-:-;-.-.-;-
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: EnergyIntegral
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: FlowPressure
+  fields:
+  - value
+  values:
+  - no data stored (message not available due to condition)
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: FlowTemp
+  fields:
+  - value
+  values:
+  - '53.56'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: FlowTemperature
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: HoursCool
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: PowerConsumptionHmu
+  fields:
+  - value
+  values:
+  - '1.558503509'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataAirInletTemp
+  fields:
+  - value
+  values:
+  - '24.7758'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataBuildingCPumpPower
+  fields:
+  - value
+  values:
+  - '100'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataCompressorInletTemp
+  fields:
+  - value
+  values:
+  - '19.3162'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataCompressorOutletTemp
+  fields:
+  - value
+  values:
+  - '20'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataCompressorSpeed
+  fields:
+  - value
+  values:
+  - '64.0033'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataEEVOutletTemp
+  fields:
+  - value
+  values:
+  - '19.3448'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataEEVPositionAbs
+  fields:
+  - value
+  values:
+  - '250'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataFan1Speed
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataFan2Speed
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataHighPressure
+  fields:
+  - value
+  values:
+  - '13.283'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataLowPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunDataStatuscode
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStats4PortValveHours
+  fields:
+  - value
+  values:
+  - '73'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStats4PortValveSwitches
+  fields:
+  - value
+  values:
+  - '1093'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsBuildingCPumpStarts
+  fields:
+  - value
+  values:
+  - '1721'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsBuildingPumpHours
+  fields:
+  - value
+  values:
+  - '10930'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsCompressorHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunStatsCompressorHc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHours
+  fields:
+  - value
+  values:
+  - '8454'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsCompressorHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunStatsCompressorHwc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHwc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorStarts
+  fields:
+  - value
+  values:
+  - '4925'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsFan1Hours
+  fields:
+  - value
+  values:
+  - '8631'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsFan1Starts
+  fields:
+  - value
+  values:
+  - '6044'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsFan2Hours
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsFan2Starts
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsHMUHours
+  fields:
+  - value
+  values:
+  - '27563'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsHcHours
+  fields:
+  - value
+  values:
+  - '9934'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsHwcHours
+  fields:
+  - value
+  values:
+  - '812'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: SetMode
+  fields:
+  - value
+  values:
+  - water;-;-;160;1;1;1;1;0;0
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: SetMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: SourceTempInput
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: SourceTempOutput
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatElectricEnergySum
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatElectricEnergySumCool
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatElectricEnergySumHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatElectricEnergySumHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatEnvironmentEnergySum
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatEnvironmentEnergySumCool
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatEnvironmentEnergySumHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatEnvironmentEnergySumHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: Status01
+  fields:
+  - value
+  values:
+  - 53.5;52.0;-;-;-;hwc
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: Status01.pumpstate
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.temp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.temp_1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.temp_2
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: Status01.temp_3
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: Status01.temp_4
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: Status02
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: Status16
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: StatusCirPump
+  fields:
+  - value
+  values:
+  - 'on'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: SupplyTempWeighted
+  fields:
+  - value
+  values:
+  - '20.00'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: TotalEnergyUsage
+  fields:
+  - value
+  values:
+  - '7824'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldCoolDay
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldCooling
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldCoolingMonth
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldHc
+  fields:
+  - value
+  values:
+  - '18767'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldHcDay
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldHcMonth
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldHwc
+  fields:
+  - value
+  values:
+  - '2967'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldHwcDay
+  fields:
+  - value
+  values:
+  - '1.7'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldHwcMonth
+  fields:
+  - value
+  values:
+  - '56.6'
+  writable: false
+  has_data: true
+- circuit: v32
+  name: BypassPosition
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: ExhaustAirHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: ExhaustAirTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: MaxAirHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: MinAirHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: OutsideAirTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: SupplyAirTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: VentilationLevelDay
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: VentilationLevelNight
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldToday
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldTotal
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldYear
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Clearerrorhistory
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Mc1Operation
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Mc2Operation
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Mc3Operation
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: SensorData1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: SensorData2
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: SetActorState
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vwz
+  name: TestHwcTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: vwz
+  name: TestOutdoorTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: vwz
+  name: TestThreeWayValve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: vwzio
+  name: EnableTestHwcTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: EnableTestOutdoorTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: EnableTestThreeWayValve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: TestHwcTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: TestOutdoorTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: TestThreeWayValve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+grab:
+- '[grab] grab continued'
+- 'f108070400 / 0ab5484d55303009015103 = 13: scan.08'
+- '3108b516081001ffff02051a35 / 0b01000702051a3500000000 = 1: hmu CoolEnvYieldDay'
+- 3108b516081001ffff02051935 / 0b0100070205193500000000 = 1
+- '3108b516081000ffff02050000 / 0b00000702051a3500000000 = 2: hmu CoolEnvYieldTotal'
+- '3108b516081002ffff02051a35 / 0b0200070205013500000000 = 1: hmu CoolEnvYieldMonth'
+- 3108b516081002ffff02051935 / 0b0200070205013500000000 = 1
+- '3108b516081000ffff03050000 / 0b00000603051a3500000000 = 2: hmu CoolElecConsTotal'
+- 'f115070400 / 0ab5424153563205071704 = 7: scan.15'
+- 'f115b5090127 / 094e39ffffffffffffff = 27: Scan.15 Id'
+- 'f176070400 / 0ab556575a494f09025103 = 14: scan.76'
+- 'f176b5090127 / 094e303c3c3c3c3c3c3c = 27: Scan.76 Id'
+- '31f6070400 / 0ab54e4554583240405703 = 1: scan.f6'
+- '31f6b5090127 / 094e31ffffffffffffff = 3: Scan.f6 Id'
+- '31fe07fe00 = 1: Broadcast Queryexistence'
+- '1008b510090003ffffa0ff070001 / 0101 = 52204: hmu SetMode'
+- '1008b512020064 / 00 = 1774: hmu StatusCirPump'
+- '10feb516080044151126080326 = 8811: Broadcast Vdatetime'
+- '10feb51603017315 = 8860: Broadcast Outsidetemp'
+- 1008b507010a / 036e7c06 = 146
+- 1008b5110100 / 095b03116b180900004c = 8694
+- '1008b5110101 / 0937370080ffff0000ff = 8: hmu Status01'
+- 1008b5160111 / 09020309100934090a09 = 6
+- 1076b5040100 / 0a03461511260803268018 = 8682
+- 1076b5110101 / 096e685918ff5d0000ff = 52184
+- 1076b5160111 / 09020304100434040a04 = 6
+- 10feb505025c00 = 8877
+- 10feb508020900 = 891
+- 10feb510020601 = 1785
+- '3115b5090124 / 09003231323232353030 = 1: Scan.15 Id'
+- '3176b5090124 / 09003231323332313030 = 1: Scan.76 Id'
+- '31f6b5090124 / 09003231323233303030 = 1: Scan.f6 Id'
+- 7108b5110107 / 0a250c00c1803300000000 = 149142
+- f108b5090124 / 09003231323331363030 = 6
+- f108b5090125 / 09313030323136313831 = 6
+- f108b5090126 / 09363130303035353038 = 6
+- f108b5090127 / 094e313c3c3c3c3c3c3c = 5
+- f108b5110100 / 095603116b180900004c = 1801
+- 'f108b5110101 / 0937370080ffff0000ff = 1: hmu Status01'
+- 'f108b5160114 / 09000000d04000000000 = 1: hmu PowerConsumptionHmu'
+- f108b5310102 / 0428004a01 = 6
+- f176b5160114 / 09000000404000000000 = 8530
+- f176b5310102 / 0457001c02 = 6
+- '3108b5040100 / 0a00ffffffffffffff0080 = 1: hmu DateTime'
+- '1008b5110101 / 096c680080ffff0400ff = 64158: hmu Status01'
+- 'f108b5160114 / 09021dd0c24400000000 = 8484: hmu PowerConsumptionHmu'
+- 1008b507020900 / 02e205 = 8835
+- 1008b5120204ff / 00 = 1768
+- 1008b513020528 / 0101 = 1776
+- 7108b509022802 / 0c020009015f0100484d553031 = 1750
+- 'f108b503020001 / 0affffffffffffffffffff = 1: hmu Currenterror'
+- f108b503020002 / 0affffffffffffffffffff = 8704
+- f108b503020003 / 0a8600ffffffffffffffff = 3497
+- f108b503020004 / 0affffffffffffffffffff = 8679
+- f108b503020005 / 00 = 8849
+- f108b509022802 / 0c020009015f0100484d553031 = 6
+- f108b511021801 / 09000f050700fc100000 = 144
+- f108b511021802 / 0900d3ba000045020000 = 145
+- f108b511021803 / 09000000000000000000 = 146
+- f115b503020002 / 0affffffffffffffffffff = 8692
+- f115b531020301 / 00 = 1775
+- f176b503020001 / 0affffffffffffffffffff = 8666
+- f176b509022802 / 0c020009025f010056575a3031 = 6
+- f176b511021801 / 0900ee1e00007c010000 = 144
+- f176b511021802 / 0900460b000055000000 = 142
+- f176b511021803 / 0101 = 147
+- 'f108b503020001 / 0affffffffffffffffffff = 8722: hmu Currenterror'
+- 'f115b503020001 / 0affffffffffffffffffff = 8640: basv Currenterror'
+- 1076b512030f0001 / 07bc0200ba0111ff = 50956
+- 1076b512030f0002 / 07eb0200720311ff = 1244
+- 7108b51a03040032 / 0e0007c0cfc07b3c00b01b20000000 = 34
+- 7108b51a03040033 / 0e000000008a000000000000000000 = 36
+- 7108b51a03040034 / 0e00cf2000c0022101001800061800 = 32
+- 7108b51a03040035 / 0e0000000000000100b00100001000 = 36
+- 7108b51a03040036 / 0e0000000000000000000000000000 = 34
+- 7108b51a03040132 / 0e0107c0cfc07b3c00b01b20000000 = 35
+- 7108b51a03040133 / 0e010000008a000000000000000000 = 34
+- 7108b51a03040134 / 0e01cf2000c0022101001800061800 = 34
+- 7108b51a03040135 / 0e0100000000000100b00100001000 = 33
+- 7108b51a03040136 / 0e0100000000000000000000000000 = 33
+- 7108b51a03040232 / 0e0207c0cfc07b3c00b01b20000000 = 31
+- 7108b51a03040233 / 0e020000008a000000000000000000 = 34
+- 7108b51a03040234 / 0e02cf2000c0022101001800061800 = 34
+- 7108b51a03040235 / 0e0200000000000100b00100001000 = 36
+- 7108b51a03040236 / 0e0200000000000000000000000000 = 33
+- 7108b51a03040332 / 0e0307c0cfc07b3c00b01b20000000 = 35
+- 7108b51a03040333 / 0e030000008a000000000000000000 = 33
+- 7108b51a03040334 / 0e03cf2000c0022101001800061800 = 33
+- 7108b51a03040335 / 0e0300000000000100b00100001000 = 32
+- 7108b51a03040336 / 0e0300000000000000000000000000 = 33
+- 7108b51a03040432 / 0e0407c0cfc07b3c00b01b20000000 = 36
+- 7108b51a03040433 / 0e040000008a000000000000000000 = 32
+- 7108b51a03040434 / 0e04cf2000c0022101001800061800 = 33
+- 7108b51a03040435 / 0e0400000000000100b00100001000 = 34
+- 7108b51a03040436 / 0e0400000000000000000000000000 = 32
+- 7108b51a03040532 / 0e0507c0cfc07b3c00b01b20000000 = 34
+- 7108b51a03040533 / 0e050000008a000000000000000000 = 34
+- 7108b51a03040534 / 0e05cf2000c0022101001800061800 = 34
+- 7108b51a03040535 / 0e0500000000000100b00100001000 = 33
+- 7108b51a03040536 / 0e0500000000000000000000000000 = 33
+- 7108b51a03040632 / 0e0607c0cfc07b3c00b01b20000000 = 33
+- 7108b51a03040633 / 0e060000008a000000000000000000 = 33
+- 7108b51a03040634 / 0e06cf2000c0022101001800061800 = 36
+- 7108b51a03040635 / 0e0600000000000100b00100001000 = 35
+- 7108b51a03040636 / 0e0600000000000000000000000000 = 33
+- 7108b51a03040732 / 0e0707c0cfc07b3c00b01b20000000 = 36
+- 7108b51a03040733 / 0e070000008a000000000000000000 = 33
+- 7108b51a03040734 / 0e07cf2000c0022101001800061800 = 33
+- 7108b51a03040735 / 0e0700000000000100b00100001000 = 36
+- 7108b51a03040736 / 0e0700000000000000000000000000 = 36
+- 7108b51a03040832 / 0e0807c0cfc07b3c00b01b20000000 = 33
+- 7108b51a03040833 / 0e080000008a000000000000000000 = 37
+- 7108b51a03040834 / 0e08cf2000c0022101001800061800 = 34
+- 7108b51a03040835 / 0e0800000000000100b00100001000 = 32
+- 7108b51a03040836 / 0e0800000000000000000000000000 = 33
+- 7108b51a03040932 / 0e0907c0cfc07b3c00b01b20000000 = 35
+- 7108b51a03040933 / 0e090000008a000000000000000000 = 32
+- 7108b51a03040934 / 0e09cf2000c0022101001800061800 = 34
+- 7108b51a03040935 / 0e0900000000000100b00100001000 = 33
+- 7108b51a03040936 / 0e0900000000000000000000000000 = 33
+- 7108b51a03040a32 / 0e0a07c0cfc07b3c00b01b20000000 = 32
+- 7108b51a03040a33 / 0e0a0000008a000000000000000000 = 37
+- 7108b51a03040a34 / 0e0acf2000c0022101001800061800 = 33
+- 7108b51a03040a35 / 0e0a00000000000100b00100001000 = 35
+- 7108b51a03040a36 / 0e0a00000000000000000000000000 = 33
+- 7108b51a03040b32 / 0e0b07c0cfc07b3c00b01b20000000 = 35
+- 7108b51a03040b33 / 0e0b0000008a000000000000000000 = 32
+- 7108b51a03040b34 / 0e0bcf2000c0022101001800061800 = 37
+- 7108b51a03040b35 / 0e0b00000000000100b00100001000 = 34
+- 7108b51a03040b36 / 0e0b00000000000000000000000000 = 35
+- 7108b51a03040c32 / 0e0c07c0cfc07b3c00b01b20000000 = 31
+- 7108b51a03040c33 / 0e0c0000008a000000000000000000 = 32
+- 7108b51a03040c34 / 0e0ccf2000c0022101001800061800 = 32
+- 7108b51a03040c35 / 0e0c00000000000100b00100001000 = 35
+- 7108b51a03040c36 / 0e0c00000000000000000000000000 = 32
+- 7108b51a03040d32 / 0e0d07c0cfc07b3c00b01b20000000 = 36
+- 7108b51a03040d33 / 0e0d0000008a000000000000000000 = 32
+- 7108b51a03040d34 / 0e0dcf2000c0022101001800061800 = 33
+- 7108b51a03040d35 / 0e0d00000000000100b00100001000 = 32
+- 7108b51a03040d36 / 0e0d00000000000000000000000000 = 37
+- 7108b51a03040e32 / 0e0e07c0cfc07b3c00b01b20000000 = 33
+- 7108b51a03040e33 / 0e0e0000008a000000000000000000 = 37
+- 7108b51a03040e34 / 0e0ecf2000c0022101001800061800 = 31
+- 7108b51a03040e35 / 0e0e00000000000100b00100001000 = 34
+- 7108b51a03040e36 / 0e0e00000000000000000000000000 = 32
+- 7108b51a03040f32 / 0e0f07c0cfc07b3c00b01b20000000 = 34
+- 7108b51a03040f33 / 0e0f0000008a000000000000000000 = 32
+- 7108b51a03040f34 / 0e0fcf2000c0022101001800061800 = 35
+- 7108b51a03040f35 / 0e0f00000000000100b00100001000 = 32
+- 7108b51a03040f36 / 0e0f00000000000000000000000000 = 32
+- 7108b51a03041032 / 0e1007c0cfc07b3c00b01b20000000 = 34
+- 7108b51a03041033 / 0e100000008a000000000000000000 = 35
+- 7108b51a03041034 / 0e10cf2000c0022101001800061800 = 35
+- 7108b51a03041035 / 0e1000000000000100b00100001000 = 36
+- 7108b51a03041036 / 0e1000000000000000000000000000 = 33
+- 7108b51a03041132 / 0e1107c0cfc07b3c00b01b20000000 = 36
+- 7108b51a03041133 / 0e110000008a000000000000000000 = 31
+- 7108b51a03041134 / 0e11cf2000c0022101001800061800 = 35
+- 7108b51a03041135 / 0e1100000000000100b00100001000 = 35
+- 7108b51a03041136 / 0e1100000000000000000000000000 = 36
+- 7108b51a03041232 / 0e1207c0cfc07b3c00b01b20000000 = 30
+- 7108b51a03041233 / 0e120000008a000000000000000000 = 37
+- 7108b51a03041234 / 0e12cf2000c0022101001800061800 = 32
+- 7108b51a03041235 / 0e1200000000000100b00100001000 = 33
+- 7108b51a03041236 / 0e1200000000000000000000000000 = 36
+- 7108b51a03041332 / 0e1307c0cfc07b3c00b01b20000000 = 36
+- 7108b51a03041333 / 0e130000008a000000000000000000 = 34
+- 7108b51a03041334 / 0e13cf2000c0022101001800061800 = 36
+- 7108b51a03041335 / 0e1300000000000100b00100001000 = 32
+- 7108b51a03041336 / 0e1300000000000000000000000000 = 31
+- 7108b51a03041432 / 0e1407c0cfc07b3c00b01b20000000 = 33
+- 7108b51a03041433 / 0e140000008a000000000000000000 = 35
+- 7108b51a03041434 / 0e14cf2000c0022101001800061800 = 33
+- 7108b51a03041435 / 0e1400000000000100b00100001000 = 36
+- 7108b51a03041436 / 0e1400000000000000000000000000 = 32
+- 7108b51a03041532 / 0e1507c0cfc07b3c00b01b20000000 = 34
+- 7108b51a03041533 / 0e150000008a000000000000000000 = 33
+- 7108b51a03041534 / 0e15cf2000c0022101001800061800 = 35
+- 7108b51a03041535 / 0e1500000000000100b00100001000 = 34
+- 7108b51a03041536 / 0e1500000000000000000000000000 = 35
+- 7108b51a03041632 / 0e1607c0cfc07b3c00b01b20000000 = 33
+- 7108b51a03041633 / 0e160000008a000000000000000000 = 35
+- 7108b51a03041634 / 0e16cf2000c0022101001800061800 = 32
+- 7108b51a03041635 / 0e1600000000000100b00100001000 = 35
+- 7108b51a03041636 / 0e1600000000000000000000000000 = 34
+- 7108b51a03041732 / 0e1707c0cfc07b3c00b01b20000000 = 36
+- 7108b51a03041733 / 0e170000008a000000000000000000 = 32
+- 7108b51a03041734 / 0e17cf2000c0022101001800061800 = 33
+- 7108b51a03041735 / 0e1700000000000100b00100001000 = 31
+- 7108b51a03041736 / 0e1700000000000000000000000000 = 30
+- 7108b51a03041832 / 0e1807c0cfc07b3c00b01b20000000 = 33
+- 7108b51a03041833 / 0e180000008a000000000000000000 = 35
+- 7108b51a03041834 / 0e18cf2000c0022101001800061800 = 33
+- 7108b51a03041835 / 0e1800000000000100b00100001000 = 33
+- 7108b51a03041836 / 0e1800000000000000000000000000 = 31
+- 7108b51a03041932 / 0e1907c0cfc07b3c00b01b20000000 = 34
+- 7108b51a03041933 / 0e190000008a000000000000000000 = 32
+- 7108b51a03041934 / 0e19cf2000c0022101001800061800 = 35
+- 7108b51a03041935 / 0e1900000000000100b00100001000 = 33
+- 7108b51a03041936 / 0e1900000000000000000000000000 = 35
+- 7108b51a03041a32 / 0e1a07c0cfc07b3c00b01b20000000 = 32
+- '[grab stop] grab stopped'
+labeled_telegrams:
+- msgid: '0704'
+  master: f1
+  slave: 08
+  sub: '00'
+  resp: 0ab5484d55303009015103
+  count: '13'
+  label: scan.08
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081001ffff02051a35
+  resp: 0b01000702051a3500000000
+  count: '1'
+  label: hmu CoolEnvYieldDay
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081000ffff02050000
+  resp: 0b00000702051a3500000000
+  count: '2'
+  label: hmu CoolEnvYieldTotal
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081002ffff02051a35
+  resp: 0b0200070205013500000000
+  count: '1'
+  label: hmu CoolEnvYieldMonth
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081000ffff03050000
+  resp: 0b00000603051a3500000000
+  count: '2'
+  label: hmu CoolElecConsTotal
+- msgid: '0704'
+  master: f1
+  slave: '15'
+  sub: '00'
+  resp: 0ab5424153563205071704
+  count: '7'
+  label: scan.15
+- msgid: b509
+  master: f1
+  slave: '15'
+  sub: '0127'
+  resp: 094e39ffffffffffffff
+  count: '27'
+  label: Scan.15 Id
+- msgid: '0704'
+  master: f1
+  slave: '76'
+  sub: '00'
+  resp: 0ab556575a494f09025103
+  count: '14'
+  label: scan.76
+- msgid: b509
+  master: f1
+  slave: '76'
+  sub: '0127'
+  resp: 094e303c3c3c3c3c3c3c
+  count: '27'
+  label: Scan.76 Id
+- msgid: '0704'
+  master: '31'
+  slave: f6
+  sub: '00'
+  resp: 0ab54e4554583240405703
+  count: '1'
+  label: scan.f6
+- msgid: b509
+  master: '31'
+  slave: f6
+  sub: '0127'
+  resp: 094e31ffffffffffffff
+  count: '3'
+  label: Scan.f6 Id
+- msgid: 07fe
+  master: '31'
+  slave: fe
+  sub: '00'
+  resp: null
+  count: '1'
+  label: Broadcast Queryexistence
+- msgid: b510
+  master: '10'
+  slave: 08
+  sub: 090003ffffa0ff070001
+  resp: '0101'
+  count: '52204'
+  label: hmu SetMode
+- msgid: b512
+  master: '10'
+  slave: 08
+  sub: '020064'
+  resp: '00'
+  count: '1774'
+  label: hmu StatusCirPump
+- msgid: b516
+  master: '10'
+  slave: fe
+  sub: 080044151126080326
+  resp: null
+  count: '8811'
+  label: Broadcast Vdatetime
+- msgid: b516
+  master: '10'
+  slave: fe
+  sub: '03017315'
+  resp: null
+  count: '8860'
+  label: Broadcast Outsidetemp
+- msgid: b511
+  master: '10'
+  slave: 08
+  sub: '0101'
+  resp: 0937370080ffff0000ff
+  count: '8'
+  label: hmu Status01
+- msgid: b509
+  master: '31'
+  slave: '15'
+  sub: '0124'
+  resp: 09003231323232353030
+  count: '1'
+  label: Scan.15 Id
+- msgid: b509
+  master: '31'
+  slave: '76'
+  sub: '0124'
+  resp: 09003231323332313030
+  count: '1'
+  label: Scan.76 Id
+- msgid: b509
+  master: '31'
+  slave: f6
+  sub: '0124'
+  resp: 09003231323233303030
+  count: '1'
+  label: Scan.f6 Id
+- msgid: b511
+  master: f1
+  slave: 08
+  sub: '0101'
+  resp: 0937370080ffff0000ff
+  count: '1'
+  label: hmu Status01
+- msgid: b516
+  master: f1
+  slave: 08
+  sub: '0114'
+  resp: 09000000d04000000000
+  count: '1'
+  label: hmu PowerConsumptionHmu
+- msgid: b504
+  master: '31'
+  slave: 08
+  sub: '0100'
+  resp: 0a00ffffffffffffff0080
+  count: '1'
+  label: hmu DateTime
+- msgid: b511
+  master: '10'
+  slave: 08
+  sub: '0101'
+  resp: 096c680080ffff0400ff
+  count: '64158'
+  label: hmu Status01
+- msgid: b516
+  master: f1
+  slave: 08
+  sub: '0114'
+  resp: 09021dd0c24400000000
+  count: '8484'
+  label: hmu PowerConsumptionHmu
+- msgid: b503
+  master: f1
+  slave: 08
+  sub: '020001'
+  resp: 0affffffffffffffffffff
+  count: '1'
+  label: hmu Currenterror
+- msgid: b503
+  master: f1
+  slave: 08
+  sub: '020001'
+  resp: 0affffffffffffffffffff
+  count: '8722'
+  label: hmu Currenterror
+- msgid: b503
+  master: f1
+  slave: '15'
+  sub: '020001'
+  resp: 0affffffffffffffffffff
+  count: '8640'
+  label: basv Currenterror
+unknown_telegrams:
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081001ffff02051935
+  resp: 0b0100070205193500000000
+  count: '1'
+  label: null
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081002ffff02051935
+  resp: 0b0200070205013500000000
+  count: '1'
+  label: null
+- msgid: b507
+  master: '10'
+  slave: 08
+  sub: 010a
+  resp: 036e7c06
+  count: '146'
+  label: null
+- msgid: b511
+  master: '10'
+  slave: 08
+  sub: '0100'
+  resp: 095b03116b180900004c
+  count: '8694'
+  label: null
+- msgid: b516
+  master: '10'
+  slave: 08
+  sub: '0111'
+  resp: 09020309100934090a09
+  count: '6'
+  label: null
+- msgid: b504
+  master: '10'
+  slave: '76'
+  sub: '0100'
+  resp: 0a03461511260803268018
+  count: '8682'
+  label: null
+- msgid: b511
+  master: '10'
+  slave: '76'
+  sub: '0101'
+  resp: 096e685918ff5d0000ff
+  count: '52184'
+  label: null
+- msgid: b516
+  master: '10'
+  slave: '76'
+  sub: '0111'
+  resp: 09020304100434040a04
+  count: '6'
+  label: null
+- msgid: b505
+  master: '10'
+  slave: fe
+  sub: 025c00
+  resp: null
+  count: '8877'
+  label: null
+- msgid: b508
+  master: '10'
+  slave: fe
+  sub: 020900
+  resp: null
+  count: '891'
+  label: null
+- msgid: b510
+  master: '10'
+  slave: fe
+  sub: '020601'
+  resp: null
+  count: '1785'
+  label: null
+- msgid: b511
+  master: '71'
+  slave: 08
+  sub: '0107'
+  resp: 0a250c00c1803300000000
+  count: '149142'
+  label: null
+- msgid: b509
+  master: f1
+  slave: 08
+  sub: '0124'
+  resp: 09003231323331363030
+  count: '6'
+  label: null
+- msgid: b509
+  master: f1
+  slave: 08
+  sub: '0125'
+  resp: 09313030323136313831
+  count: '6'
+  label: null
+- msgid: b509
+  master: f1
+  slave: 08
+  sub: '0126'
+  resp: 09363130303035353038
+  count: '6'
+  label: null
+- msgid: b509
+  master: f1
+  slave: 08
+  sub: '0127'
+  resp: 094e313c3c3c3c3c3c3c
+  count: '5'
+  label: null
+- msgid: b511
+  master: f1
+  slave: 08
+  sub: '0100'
+  resp: 095603116b180900004c
+  count: '1801'
+  label: null
+- msgid: b531
+  master: f1
+  slave: 08
+  sub: '0102'
+  resp: 0428004a01
+  count: '6'
+  label: null
+- msgid: b516
+  master: f1
+  slave: '76'
+  sub: '0114'
+  resp: 09000000404000000000
+  count: '8530'
+  label: null
+- msgid: b531
+  master: f1
+  slave: '76'
+  sub: '0102'
+  resp: 0457001c02
+  count: '6'
+  label: null
+- msgid: b507
+  master: '10'
+  slave: 08
+  sub: 020900
+  resp: 02e205
+  count: '8835'
+  label: null
+- msgid: b512
+  master: '10'
+  slave: 08
+  sub: 0204ff
+  resp: '00'
+  count: '1768'
+  label: null
+- msgid: b513
+  master: '10'
+  slave: 08
+  sub: 020528
+  resp: '0101'
+  count: '1776'
+  label: null
+- msgid: b509
+  master: '71'
+  slave: 08
+  sub: 022802
+  resp: 0c020009015f0100484d553031
+  count: '1750'
+  label: null
+- msgid: b503
+  master: f1
+  slave: 08
+  sub: '020002'
+  resp: 0affffffffffffffffffff
+  count: '8704'
+  label: null
+- msgid: b503
+  master: f1
+  slave: 08
+  sub: '020003'
+  resp: 0a8600ffffffffffffffff
+  count: '3497'
+  label: null
+- msgid: b503
+  master: f1
+  slave: 08
+  sub: '020004'
+  resp: 0affffffffffffffffffff
+  count: '8679'
+  label: null
+- msgid: b503
+  master: f1
+  slave: 08
+  sub: '020005'
+  resp: '00'
+  count: '8849'
+  label: null
+- msgid: b509
+  master: f1
+  slave: 08
+  sub: 022802
+  resp: 0c020009015f0100484d553031
+  count: '6'
+  label: null
+- msgid: b511
+  master: f1
+  slave: 08
+  sub: 021801
+  resp: 09000f050700fc100000
+  count: '144'
+  label: null
+- msgid: b511
+  master: f1
+  slave: 08
+  sub: 021802
+  resp: 0900d3ba000045020000
+  count: '145'
+  label: null
+- msgid: b511
+  master: f1
+  slave: 08
+  sub: 021803
+  resp: 09000000000000000000
+  count: '146'
+  label: null
+- msgid: b503
+  master: f1
+  slave: '15'
+  sub: '020002'
+  resp: 0affffffffffffffffffff
+  count: '8692'
+  label: null
+- msgid: b531
+  master: f1
+  slave: '15'
+  sub: '020301'
+  resp: '00'
+  count: '1775'
+  label: null
+- msgid: b503
+  master: f1
+  slave: '76'
+  sub: '020001'
+  resp: 0affffffffffffffffffff
+  count: '8666'
+  label: null
+- msgid: b509
+  master: f1
+  slave: '76'
+  sub: 022802
+  resp: 0c020009025f010056575a3031
+  count: '6'
+  label: null
+- msgid: b511
+  master: f1
+  slave: '76'
+  sub: 021801
+  resp: 0900ee1e00007c010000
+  count: '144'
+  label: null
+- msgid: b511
+  master: f1
+  slave: '76'
+  sub: 021802
+  resp: 0900460b000055000000
+  count: '142'
+  label: null
+- msgid: b511
+  master: f1
+  slave: '76'
+  sub: 021803
+  resp: '0101'
+  count: '147'
+  label: null
+- msgid: b512
+  master: '10'
+  slave: '76'
+  sub: 030f0001
+  resp: 07bc0200ba0111ff
+  count: '50956'
+  label: null
+- msgid: b512
+  master: '10'
+  slave: '76'
+  sub: 030f0002
+  resp: 07eb0200720311ff
+  count: '1244'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03040032'
+  resp: 0e0007c0cfc07b3c00b01b20000000
+  count: '34'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03040033'
+  resp: 0e000000008a000000000000000000
+  count: '36'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03040034'
+  resp: 0e00cf2000c0022101001800061800
+  count: '32'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03040035'
+  resp: 0e0000000000000100b00100001000
+  count: '36'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03040036'
+  resp: 0e0000000000000000000000000000
+  count: '34'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03040132'
+  resp: 0e0107c0cfc07b3c00b01b20000000
+  count: '35'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03040133'
+  resp: 0e010000008a000000000000000000
+  count: '34'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03040134'
+  resp: 0e01cf2000c0022101001800061800
+  count: '34'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03040135'
+  resp: 0e0100000000000100b00100001000
+  count: '33'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03040136'
+  resp: 0e0100000000000000000000000000
+  count: '33'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03040232'
+  resp: 0e0207c0cfc07b3c00b01b20000000
+  count: '31'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03040233'
+  resp: 0e020000008a000000000000000000
+  count: '34'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03040234'
+  resp: 0e02cf2000c0022101001800061800
+  count: '34'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03040235'
+  resp: 0e0200000000000100b00100001000
+  count: '36'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03040236'
+  resp: 0e0200000000000000000000000000
+  count: '33'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03040332'
+  resp: 0e0307c0cfc07b3c00b01b20000000
+  count: '35'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03040333'
+  resp: 0e030000008a000000000000000000
+  count: '33'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03040334'
+  resp: 0e03cf2000c0022101001800061800
+  count: '33'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03040335'
+  resp: 0e0300000000000100b00100001000
+  count: '32'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03040336'
+  resp: 0e0300000000000000000000000000
+  count: '33'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03040432'
+  resp: 0e0407c0cfc07b3c00b01b20000000
+  count: '36'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03040433'
+  resp: 0e040000008a000000000000000000
+  count: '32'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03040434'
+  resp: 0e04cf2000c0022101001800061800
+  count: '33'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03040435'
+  resp: 0e0400000000000100b00100001000
+  count: '34'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03040436'
+  resp: 0e0400000000000000000000000000
+  count: '32'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03040532'
+  resp: 0e0507c0cfc07b3c00b01b20000000
+  count: '34'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03040533'
+  resp: 0e050000008a000000000000000000
+  count: '34'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03040534'
+  resp: 0e05cf2000c0022101001800061800
+  count: '34'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03040535'
+  resp: 0e0500000000000100b00100001000
+  count: '33'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03040536'
+  resp: 0e0500000000000000000000000000
+  count: '33'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03040632'
+  resp: 0e0607c0cfc07b3c00b01b20000000
+  count: '33'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03040633'
+  resp: 0e060000008a000000000000000000
+  count: '33'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03040634'
+  resp: 0e06cf2000c0022101001800061800
+  count: '36'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03040635'
+  resp: 0e0600000000000100b00100001000
+  count: '35'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03040636'
+  resp: 0e0600000000000000000000000000
+  count: '33'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03040732'
+  resp: 0e0707c0cfc07b3c00b01b20000000
+  count: '36'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03040733'
+  resp: 0e070000008a000000000000000000
+  count: '33'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03040734'
+  resp: 0e07cf2000c0022101001800061800
+  count: '33'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03040735'
+  resp: 0e0700000000000100b00100001000
+  count: '36'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03040736'
+  resp: 0e0700000000000000000000000000
+  count: '36'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03040832
+  resp: 0e0807c0cfc07b3c00b01b20000000
+  count: '33'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03040833
+  resp: 0e080000008a000000000000000000
+  count: '37'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03040834
+  resp: 0e08cf2000c0022101001800061800
+  count: '34'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03040835
+  resp: 0e0800000000000100b00100001000
+  count: '32'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03040836
+  resp: 0e0800000000000000000000000000
+  count: '33'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03040932
+  resp: 0e0907c0cfc07b3c00b01b20000000
+  count: '35'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03040933
+  resp: 0e090000008a000000000000000000
+  count: '32'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03040934
+  resp: 0e09cf2000c0022101001800061800
+  count: '34'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03040935
+  resp: 0e0900000000000100b00100001000
+  count: '33'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03040936
+  resp: 0e0900000000000000000000000000
+  count: '33'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03040a32
+  resp: 0e0a07c0cfc07b3c00b01b20000000
+  count: '32'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03040a33
+  resp: 0e0a0000008a000000000000000000
+  count: '37'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03040a34
+  resp: 0e0acf2000c0022101001800061800
+  count: '33'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03040a35
+  resp: 0e0a00000000000100b00100001000
+  count: '35'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03040a36
+  resp: 0e0a00000000000000000000000000
+  count: '33'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03040b32
+  resp: 0e0b07c0cfc07b3c00b01b20000000
+  count: '35'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03040b33
+  resp: 0e0b0000008a000000000000000000
+  count: '32'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03040b34
+  resp: 0e0bcf2000c0022101001800061800
+  count: '37'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03040b35
+  resp: 0e0b00000000000100b00100001000
+  count: '34'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03040b36
+  resp: 0e0b00000000000000000000000000
+  count: '35'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03040c32
+  resp: 0e0c07c0cfc07b3c00b01b20000000
+  count: '31'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03040c33
+  resp: 0e0c0000008a000000000000000000
+  count: '32'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03040c34
+  resp: 0e0ccf2000c0022101001800061800
+  count: '32'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03040c35
+  resp: 0e0c00000000000100b00100001000
+  count: '35'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03040c36
+  resp: 0e0c00000000000000000000000000
+  count: '32'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03040d32
+  resp: 0e0d07c0cfc07b3c00b01b20000000
+  count: '36'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03040d33
+  resp: 0e0d0000008a000000000000000000
+  count: '32'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03040d34
+  resp: 0e0dcf2000c0022101001800061800
+  count: '33'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03040d35
+  resp: 0e0d00000000000100b00100001000
+  count: '32'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03040d36
+  resp: 0e0d00000000000000000000000000
+  count: '37'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03040e32
+  resp: 0e0e07c0cfc07b3c00b01b20000000
+  count: '33'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03040e33
+  resp: 0e0e0000008a000000000000000000
+  count: '37'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03040e34
+  resp: 0e0ecf2000c0022101001800061800
+  count: '31'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03040e35
+  resp: 0e0e00000000000100b00100001000
+  count: '34'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03040e36
+  resp: 0e0e00000000000000000000000000
+  count: '32'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03040f32
+  resp: 0e0f07c0cfc07b3c00b01b20000000
+  count: '34'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03040f33
+  resp: 0e0f0000008a000000000000000000
+  count: '32'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03040f34
+  resp: 0e0fcf2000c0022101001800061800
+  count: '35'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03040f35
+  resp: 0e0f00000000000100b00100001000
+  count: '32'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03040f36
+  resp: 0e0f00000000000000000000000000
+  count: '32'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03041032'
+  resp: 0e1007c0cfc07b3c00b01b20000000
+  count: '34'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03041033'
+  resp: 0e100000008a000000000000000000
+  count: '35'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03041034'
+  resp: 0e10cf2000c0022101001800061800
+  count: '35'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03041035'
+  resp: 0e1000000000000100b00100001000
+  count: '36'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03041036'
+  resp: 0e1000000000000000000000000000
+  count: '33'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03041132'
+  resp: 0e1107c0cfc07b3c00b01b20000000
+  count: '36'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03041133'
+  resp: 0e110000008a000000000000000000
+  count: '31'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03041134'
+  resp: 0e11cf2000c0022101001800061800
+  count: '35'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03041135'
+  resp: 0e1100000000000100b00100001000
+  count: '35'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03041136'
+  resp: 0e1100000000000000000000000000
+  count: '36'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03041232'
+  resp: 0e1207c0cfc07b3c00b01b20000000
+  count: '30'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03041233'
+  resp: 0e120000008a000000000000000000
+  count: '37'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03041234'
+  resp: 0e12cf2000c0022101001800061800
+  count: '32'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03041235'
+  resp: 0e1200000000000100b00100001000
+  count: '33'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03041236'
+  resp: 0e1200000000000000000000000000
+  count: '36'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03041332'
+  resp: 0e1307c0cfc07b3c00b01b20000000
+  count: '36'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03041333'
+  resp: 0e130000008a000000000000000000
+  count: '34'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03041334'
+  resp: 0e13cf2000c0022101001800061800
+  count: '36'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03041335'
+  resp: 0e1300000000000100b00100001000
+  count: '32'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03041336'
+  resp: 0e1300000000000000000000000000
+  count: '31'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03041432'
+  resp: 0e1407c0cfc07b3c00b01b20000000
+  count: '33'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03041433'
+  resp: 0e140000008a000000000000000000
+  count: '35'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03041434'
+  resp: 0e14cf2000c0022101001800061800
+  count: '33'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03041435'
+  resp: 0e1400000000000100b00100001000
+  count: '36'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03041436'
+  resp: 0e1400000000000000000000000000
+  count: '32'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03041532'
+  resp: 0e1507c0cfc07b3c00b01b20000000
+  count: '34'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03041533'
+  resp: 0e150000008a000000000000000000
+  count: '33'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03041534'
+  resp: 0e15cf2000c0022101001800061800
+  count: '35'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03041535'
+  resp: 0e1500000000000100b00100001000
+  count: '34'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03041536'
+  resp: 0e1500000000000000000000000000
+  count: '35'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03041632'
+  resp: 0e1607c0cfc07b3c00b01b20000000
+  count: '33'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03041633'
+  resp: 0e160000008a000000000000000000
+  count: '35'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03041634'
+  resp: 0e16cf2000c0022101001800061800
+  count: '32'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03041635'
+  resp: 0e1600000000000100b00100001000
+  count: '35'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03041636'
+  resp: 0e1600000000000000000000000000
+  count: '34'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03041732'
+  resp: 0e1707c0cfc07b3c00b01b20000000
+  count: '36'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03041733'
+  resp: 0e170000008a000000000000000000
+  count: '32'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03041734'
+  resp: 0e17cf2000c0022101001800061800
+  count: '33'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03041735'
+  resp: 0e1700000000000100b00100001000
+  count: '31'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: '03041736'
+  resp: 0e1700000000000000000000000000
+  count: '30'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03041832
+  resp: 0e1807c0cfc07b3c00b01b20000000
+  count: '33'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03041833
+  resp: 0e180000008a000000000000000000
+  count: '35'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03041834
+  resp: 0e18cf2000c0022101001800061800
+  count: '33'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03041835
+  resp: 0e1800000000000100b00100001000
+  count: '33'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03041836
+  resp: 0e1800000000000000000000000000
+  count: '31'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03041932
+  resp: 0e1907c0cfc07b3c00b01b20000000
+  count: '34'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03041933
+  resp: 0e190000008a000000000000000000
+  count: '32'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03041934
+  resp: 0e19cf2000c0022101001800061800
+  count: '35'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03041935
+  resp: 0e1900000000000100b00100001000
+  count: '33'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03041936
+  resp: 0e1900000000000000000000000000
+  count: '35'
+  label: null
+- msgid: b51a
+  master: '71'
+  slave: 08
+  sub: 03041a32
+  resp: 0e1a07c0cfc07b3c00b01b20000000
+  count: '32'
+  label: null
+after_registers:
+- circuit: Broadcast
+  name: Datetime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Error
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: Broadcast
+  name: HwcStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Id
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: IdAnswer
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: IdQuery
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Load
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Outsidetemp
+  fields:
+  - value
+  values:
+  - '21.449'
+  writable: false
+  has_data: true
+- circuit: Broadcast
+  name: Queryexistence
+  fields:
+  - value
+  values:
+  - (empty for 31fe07fe00 / )
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Signoflife
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Vdatetime
+  fields:
+  - value
+  values:
+  - 11:15:44;26.08.2026
+  writable: false
+  has_data: true
+- circuit: Broadcast
+  name: Vdatetime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: WaterPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: General
+  name: Valuerange
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Eeprom
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Eeprom
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Ram
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Ram
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Scan
+  name: Id
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Scan.15
+  name: Id
+  fields:
+  - value
+  values:
+  - 21;22;25;0020262148;0082;006876;N9
+  writable: false
+  has_data: true
+- circuit: Scan.76
+  name: Id
+  fields:
+  - value
+  values:
+  - 21;23;21;0010022084;3100;005613;N0
+  writable: false
+  has_data: true
+- circuit: Scan.f6
+  name: Id
+  fields:
+  - value
+  values:
+  - 21;22;30;0020260962;0938;053360;N1
+  writable: false
+  has_data: true
+- circuit: basv
+  name: AdaptHeatCurve
+  fields:
+  - value
+  values:
+  - 'no'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: AdaptHeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: CcTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: CcTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: CcTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: CcTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: CcTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: CcTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: CcTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: CcTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: CcTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: CcTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: CcTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: CcTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: CcTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: CcTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Clearerrorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: ContinuosHeating
+  fields:
+  - value
+  values:
+  - '-26'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: ContinuosHeating
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - -;-;-;-;-
+  writable: false
+  has_data: true
+- circuit: basv
+  name: CylinderChargeHyst
+  fields:
+  - value
+  values:
+  - '5'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: CylinderChargeHyst
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: CylinderChargeOffset
+  fields:
+  - value
+  values:
+  - '25'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: CylinderChargeOffset
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Date
+  fields:
+  - value
+  values:
+  - 26.08.2026
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Date
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: DisplayedOutsideTemp
+  fields:
+  - value
+  values:
+  - '21.4492'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: FrostOverRideTime
+  fields:
+  - value
+  values:
+  - '4'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: FrostOverRideTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: GlobalSystemOff
+  fields:
+  - value
+  values:
+  - 'no'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: GlobalSystemOff
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc1ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc1AutoOffMode
+  fields:
+  - value
+  values:
+  - eco
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc1AutoOffMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc1CircuitType
+  fields:
+  - value
+  values:
+  - mixer
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc1ExcessTemp
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc1ExcessTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc1FlowTemp
+  fields:
+  - value
+  values:
+  - '53'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc1HeatCurve
+  fields:
+  - value
+  values:
+  - '0.7'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc1HeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc1HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc1MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '60'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc1MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc1MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - '17'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc1MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc1MixerMovement
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc1PumpStatus
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc1PumpStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc1RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - thermostat
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc1RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc1Status
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc1Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc1SummerTempLimit
+  fields:
+  - value
+  values:
+  - '22'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc1SummerTempLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc2ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc2AutoOffMode
+  fields:
+  - value
+  values:
+  - eco
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc2AutoOffMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc2CircuitType
+  fields:
+  - value
+  values:
+  - inactive
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc2ExcessTemp
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc2ExcessTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc2FlowTemp
+  fields:
+  - value
+  values:
+  - (empty for 3115b52406020002010800 / 0800020800ffffff7f)
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc2HeatCurve
+  fields:
+  - value
+  values:
+  - '0.6'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc2HeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc2HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc2MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '55'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc2MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc2MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - '15'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc2MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc2MixerMovement
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc2PumpStatus
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc2PumpStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc2RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'off'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc2RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc2Status
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc2Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc2SummerTempLimit
+  fields:
+  - value
+  values:
+  - '21'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc2SummerTempLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc3ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc3AutoOffMode
+  fields:
+  - value
+  values:
+  - eco
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc3AutoOffMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc3CircuitType
+  fields:
+  - value
+  values:
+  - inactive
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc3ExcessTemp
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc3ExcessTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc3FlowTemp
+  fields:
+  - value
+  values:
+  - (empty for 3115b52406020002020800 / 0800020800ffffff7f)
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc3HeatCurve
+  fields:
+  - value
+  values:
+  - '0.6'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc3HeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc3HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc3MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '55'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc3MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc3MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - '15'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc3MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc3MixerMovement
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc3PumpStatus
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc3PumpStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc3RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'off'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc3RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc3Status
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc3Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Hc3SummerTempLimit
+  fields:
+  - value
+  values:
+  - '21'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Hc3SummerTempLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HcStorageTempBottom
+  fields:
+  - value
+  values:
+  - (empty for f115b5240602000000a000 / 080000a000ffffff7f)
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HcStorageTempTop
+  fields:
+  - value
+  values:
+  - (empty for f115b52406020000009f00 / 0800009f00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcBankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcBankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcBankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcBankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcFlowTemp
+  fields:
+  - value
+  values:
+  - '93'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: HwcHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 02.01.2026
+  writable: false
+  has_data: true
+- circuit: basv
+  name: HwcHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 30.12.2025
+  writable: false
+  has_data: true
+- circuit: basv
+  name: HwcHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcLockTime
+  fields:
+  - value
+  values:
+  - '60'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: HwcLockTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcMaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '80'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: HwcMaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcOpMode
+  fields:
+  - value
+  values:
+  - auto
+  writable: false
+  has_data: true
+- circuit: basv
+  name: HwcOpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcParallelLoading
+  fields:
+  - value
+  values:
+  - 'off'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: HwcParallelLoading
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcSFMode
+  fields:
+  - value
+  values:
+  - load
+  writable: false
+  has_data: true
+- circuit: basv
+  name: HwcSFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcStorageTemp
+  fields:
+  - value
+  values:
+  - '46'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: HwcStorageTempBottom
+  fields:
+  - value
+  values:
+  - (empty for f115b52406020000009e00 / 0800009e00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcStorageTempTop
+  fields:
+  - value
+  values:
+  - (empty for f115b52406020000009d00 / 0800009d00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcTempDesired
+  fields:
+  - value
+  values:
+  - '68'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: HwcTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HwcTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: HydraulicScheme
+  fields:
+  - value
+  values:
+  - '8'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: HydraulicScheme
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Installer1
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Installer1
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Installer2
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Installer2
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: basv
+  name: KeyCodeforConfigMenu
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: basv
+  name: KeyCodeforConfigMenu
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: basv
+  name: MaintenanceDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: MaintenanceDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: MaintenanceDue
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: ManualCooling
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: ManualCooling
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: MaxCylinderChargeTime
+  fields:
+  - value
+  values:
+  - '120'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: MaxCylinderChargeTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: MaxRoomHumidity
+  fields:
+  - value
+  values:
+  - '40'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: MaxRoomHumidity
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: MultiRelaySetting
+  fields:
+  - value
+  values:
+  - '4'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: MultiRelaySetting
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: NoiseReductionTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: NoiseReductionTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: NoiseReductionTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: NoiseReductionTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: NoiseReductionTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: NoiseReductionTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: NoiseReductionTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: NoiseReductionTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: NoiseReductionTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: NoiseReductionTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: NoiseReductionTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: NoiseReductionTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: NoiseReductionTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: NoiseReductionTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: OpModeCooling
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: OpModeCooling
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: OpModeEffect
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: OpModeEffect
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: OpModeVentilation
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: OpModeVentilation
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: OutsideTempAvg
+  fields:
+  - value
+  values:
+  - '17.6992'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: OutsideTempAvg
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PhoneNumber1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PhoneNumber1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PhoneNumber2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PhoneNumber2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrEnergySum
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020000005c00 / 00)'
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrEnergySum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrEnergySumHc
+  fields:
+  - value
+  values:
+  - '7192'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: PrEnergySumHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrEnergySumHcLastMonth
+  fields:
+  - value
+  values:
+  - '7'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: PrEnergySumHcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrEnergySumHcThisMonth
+  fields:
+  - value
+  values:
+  - '6'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: PrEnergySumHcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrEnergySumHwc
+  fields:
+  - value
+  values:
+  - '1279'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: PrEnergySumHwc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrEnergySumHwcLastMonth
+  fields:
+  - value
+  values:
+  - '28'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: PrEnergySumHwcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrEnergySumHwcThisMonth
+  fields:
+  - value
+  values:
+  - '23'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: PrEnergySumHwcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrFuelSum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrFuelSum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrFuelSumHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrFuelSumHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrFuelSumHcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrFuelSumHcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrFuelSumHcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrFuelSumHcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrFuelSumHwc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrFuelSumHwc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrFuelSumHwcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrFuelSumHwcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrFuelSumHwcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PrFuelSumHwcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PumpAdditionalTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: PumpAdditionalTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: SolarYieldTotal
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: SolarYieldTotal
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: SystemFlowTemp
+  fields:
+  - value
+  values:
+  - (empty for f115b52406020000004b00 / 0800004b00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: basv
+  name: TariffTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: TariffTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: TariffTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: TariffTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: TariffTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: TariffTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: TariffTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: TariffTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: TariffTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: TariffTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: TariffTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: TariffTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: TariffTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: TariffTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Time
+  fields:
+  - value
+  values:
+  - '10:54:32'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Time
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: VentilationDay
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: VentilationDay
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: VentilationNight
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: VentilationNight
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: VentilationTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: VentilationTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: VentilationTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: VentilationTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: VentilationTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: VentilationTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: VentilationTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: VentilationTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: VentilationTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: VentilationTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: VentilationTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: VentilationTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: VentilationTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: VentilationTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: WaterPressure
+  fields:
+  - value
+  values:
+  - '1.7'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: YieldTotal
+  fields:
+  - value
+  values:
+  - '21748'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: YieldTotal
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - '5'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Z1ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1CoolingTemp
+  fields:
+  - value
+  values:
+  - '24'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Z1CoolingTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1CoolingTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1CoolingTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1CoolingTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1CoolingTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1CoolingTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1CoolingTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1CoolingTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1CoolingTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1CoolingTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1CoolingTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1CoolingTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1CoolingTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1CoolingTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1CoolingTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1DayTemp
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020003000700 / 00)'
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 02.01.2026
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Z1HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 30.12.2025
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Z1HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1HolidayTemp
+  fields:
+  - value
+  values:
+  - '21'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Z1HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1Name1
+  fields:
+  - value
+  values:
+  - Zone
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Z1Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1Name2
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for f115b52406020003001800 / 06030318003100)'
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1NightTemp
+  fields:
+  - value
+  values:
+  - '22'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Z1NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1OpMode
+  fields:
+  - value
+  values:
+  - 'off'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Z1OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1OpModeCooling
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1OpModeCooling
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1QuickVetoTemp
+  fields:
+  - value
+  values:
+  - '22.5'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Z1QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1RoomTemp
+  fields:
+  - value
+  values:
+  - '22.25'
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Z1RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Z1RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1SFMode
+  fields:
+  - value
+  values:
+  - auto
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Z1SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z1ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2CoolingTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2CoolingTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2CoolingTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2CoolingTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2CoolingTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2CoolingTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2CoolingTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2CoolingTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2CoolingTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2CoolingTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2CoolingTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2CoolingTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2CoolingTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2CoolingTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2CoolingTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2CoolingTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2OpModeCooling
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2OpModeCooling
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2RoomTemp
+  fields:
+  - value
+  values:
+  - (empty for 3115b52406020003010f00 / 0800030f00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Z2RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z2ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3CoolingTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3CoolingTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3CoolingTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3CoolingTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3CoolingTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3CoolingTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3CoolingTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3CoolingTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3CoolingTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3CoolingTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3CoolingTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3CoolingTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3CoolingTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3CoolingTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3CoolingTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3CoolingTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3OpModeCooling
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3OpModeCooling
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3RoomTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: true
+- circuit: basv
+  name: Z3RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: basv
+  name: Z3ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: AdaptHeatCurve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: CcTimer_Config
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: CcTimer_Timeframes
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: ContinuousHeating
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: CylinderChargeHyst
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: CylinderChargeOffset
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Date
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: DisplayedOutsideTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: FrostOverRideTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1AutoOffMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1CircuitType
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1CoolingEnabled
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1CoolingFlowTempMin
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1DewPointMonitoring
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1DewPointOffset
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1DewPointTemp
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002300 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1ExcessTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1FlowTempCalc
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002000 / 050102200002)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1HeatCurve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1Humidity
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002200 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MixerMovement
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MixerPosition
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002100 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1PumpHours
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002400 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1PumpStarts
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002500 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1PumpStatus
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1RoomTempModulation
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1Status
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1SummerTempLimit
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2AutoOffMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2CircuitType
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2DewPointTemp
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012300 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2ExcessTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2FlowTempCalc
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012000 / 050002200000)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2HeatCurve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2Humidity
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012200 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MixerMovement
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MixerPosition
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012100 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2PumpHours
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012400 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2PumpStarts
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012500 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2PumpStatus
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2Status
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2SummerTempLimit
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3AutoOffMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3CircuitType
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3ExcessTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3HeatCurve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MixerMovement
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3PumpStatus
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3Status
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3SummerTempLimit
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HcStorageTempBottom
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: ctlv2
+  name: HcStorageTempTop
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: ctlv2
+  name: HwcFlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcLockTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcMaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcOpMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcParallelLoading
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcSFMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcSfMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcStorageTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcStorageTempBottom
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcStorageTempTop
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HydraulicScheme
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: ManualCoolingEndDate
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: ManualCoolingEndDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: ManualCoolingStartDate
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: ManualCoolingStartDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: MaxCylinderChargeTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: MaxRoomHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: MultiRelaySetting
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: OutsideTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: OutsideTempAvg
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySum
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHcLastMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHcThisMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHwcLastMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHwcThisMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: SystemFlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: WaterPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingManualTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingOpMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingSetbackTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1DayTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1HolidayTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1NightTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1OpMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoDuration
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoEndDate
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoEndTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1RoomTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1SFMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z2RoomTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: z1RoomHumidity
+  fields:
+  - value
+  values:
+  - '52'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: BuildingCircuitFlow
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: BuildingCircuitPumpSpeed
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Clearerrorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: CompressorBlocktime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: CompressorHc
+  fields:
+  - value
+  values:
+  - no data stored (message not available due to condition)
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: CompressorHc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHwc
+  fields:
+  - value
+  values:
+  - no data stored (message not available due to condition)
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: CompressorHwc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHwc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CoolElecConsTotal
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CoolEnvYieldDay
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CoolEnvYieldMonth
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CoolEnvYieldTotal
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CopCooling
+  fields:
+  - value
+  values:
+  - '1.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CopCoolingMonth
+  fields:
+  - value
+  values:
+  - '1.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CopHc
+  fields:
+  - value
+  values:
+  - '3.6'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CopHcMonth
+  fields:
+  - value
+  values:
+  - '1.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CopHwc
+  fields:
+  - value
+  values:
+  - '3.6'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CopHwcMonth
+  fields:
+  - value
+  values:
+  - '4.6'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CurrentCompressorUtil
+  fields:
+  - value
+  values:
+  - '0.00'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CurrentConsumedPower
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CurrentYieldPower
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - -;-;-;-;-
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: DateTime
+  fields:
+  - value
+  values:
+  - nosignal;-:-:-;-.-.-;-
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: EnergyIntegral
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: FlowPressure
+  fields:
+  - value
+  values:
+  - no data stored (message not available due to condition)
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: FlowTemp
+  fields:
+  - value
+  values:
+  - '53.56'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: FlowTemperature
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: HoursCool
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: PowerConsumptionHmu
+  fields:
+  - value
+  values:
+  - '1.558503509'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataAirInletTemp
+  fields:
+  - value
+  values:
+  - '23.3857'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataBuildingCPumpPower
+  fields:
+  - value
+  values:
+  - '100'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataCompressorInletTemp
+  fields:
+  - value
+  values:
+  - '19.3162'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataCompressorOutletTemp
+  fields:
+  - value
+  values:
+  - '20'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataCompressorSpeed
+  fields:
+  - value
+  values:
+  - '64.0033'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataEEVOutletTemp
+  fields:
+  - value
+  values:
+  - '19.3448'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataEEVPositionAbs
+  fields:
+  - value
+  values:
+  - '250'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataFan1Speed
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataFan2Speed
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataHighPressure
+  fields:
+  - value
+  values:
+  - '13.283'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunDataLowPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunDataStatuscode
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStats4PortValveHours
+  fields:
+  - value
+  values:
+  - '73'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStats4PortValveSwitches
+  fields:
+  - value
+  values:
+  - '1093'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsBuildingCPumpStarts
+  fields:
+  - value
+  values:
+  - '1721'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsBuildingPumpHours
+  fields:
+  - value
+  values:
+  - '10930'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsCompressorHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunStatsCompressorHc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHours
+  fields:
+  - value
+  values:
+  - '8454'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsCompressorHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunStatsCompressorHwc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHwc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorStarts
+  fields:
+  - value
+  values:
+  - '4925'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsFan1Hours
+  fields:
+  - value
+  values:
+  - '8631'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsFan1Starts
+  fields:
+  - value
+  values:
+  - '6044'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsFan2Hours
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsFan2Starts
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsHMUHours
+  fields:
+  - value
+  values:
+  - '27563'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsHcHours
+  fields:
+  - value
+  values:
+  - '9934'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: RunStatsHwcHours
+  fields:
+  - value
+  values:
+  - '812'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: SetMode
+  fields:
+  - value
+  values:
+  - water;-;-;160;1;1;1;1;0;0
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: SetMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: SourceTempInput
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: SourceTempOutput
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatElectricEnergySum
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatElectricEnergySumCool
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatElectricEnergySumHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatElectricEnergySumHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatEnvironmentEnergySum
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatEnvironmentEnergySumCool
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatEnvironmentEnergySumHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatEnvironmentEnergySumHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: Status01
+  fields:
+  - value
+  values:
+  - 54.0;52.0;-;-;-;hwc
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: Status01.pumpstate
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.temp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.temp_1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.temp_2
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: Status01.temp_3
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: Status01.temp_4
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: Status02
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: Status16
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: StatusCirPump
+  fields:
+  - value
+  values:
+  - 'on'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: SupplyTempWeighted
+  fields:
+  - value
+  values:
+  - '20.00'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: TotalEnergyUsage
+  fields:
+  - value
+  values:
+  - '7824'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldCoolDay
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldCooling
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldCoolingMonth
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldHc
+  fields:
+  - value
+  values:
+  - '18767'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldHcDay
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldHcMonth
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldHwc
+  fields:
+  - value
+  values:
+  - '2967'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldHwcDay
+  fields:
+  - value
+  values:
+  - '1.7'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: YieldHwcMonth
+  fields:
+  - value
+  values:
+  - '56.6'
+  writable: false
+  has_data: true
+- circuit: v32
+  name: BypassPosition
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: ExhaustAirHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: ExhaustAirTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: MaxAirHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: MinAirHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: OutsideAirTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: SupplyAirTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: VentilationLevelDay
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: VentilationLevelNight
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldToday
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldTotal
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldYear
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Clearerrorhistory
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Mc1Operation
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Mc2Operation
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Mc3Operation
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: SensorData1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: SensorData2
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: SetActorState
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vwz
+  name: TestHwcTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: vwz
+  name: TestOutdoorTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: vwz
+  name: TestThreeWayValve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: vwzio
+  name: EnableTestHwcTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: EnableTestOutdoorTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: EnableTestThreeWayValve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: TestHwcTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: TestOutdoorTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: TestThreeWayValve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+raw_find_lines_after:
+- basv AdaptHeatCurve = no
+- basv AdaptHeatCurve = no data stored
+- basv BankHolidayEndPeriod = no data stored
+- basv BankHolidayEndPeriod = no data stored
+- basv BankHolidayStartPeriod = no data stored
+- basv BankHolidayStartPeriod = no data stored
+- basv CcTimer_Friday = no data stored
+- basv CcTimer_Friday = no data stored
+- basv CcTimer_Monday = no data stored
+- basv CcTimer_Monday = no data stored
+- basv CcTimer_Saturday = no data stored
+- basv CcTimer_Saturday = no data stored
+- basv CcTimer_Sunday = no data stored
+- basv CcTimer_Sunday = no data stored
+- basv CcTimer_Thursday = no data stored
+- basv CcTimer_Thursday = no data stored
+- basv CcTimer_Tuesday = no data stored
+- basv CcTimer_Tuesday = no data stored
+- basv CcTimer_Wednesday = no data stored
+- basv CcTimer_Wednesday = no data stored
+- basv Clearerrorhistory = no data stored
+- basv ContinuosHeating = -26
+- basv ContinuosHeating = no data stored
+- basv Currenterror = -;-;-;-;-
+- basv CylinderChargeHyst = 5
+- basv CylinderChargeHyst = no data stored
+- basv CylinderChargeOffset = 25
+- basv CylinderChargeOffset = no data stored
+- basv Date = 26.08.2026
+- basv Date = no data stored
+- basv DisplayedOutsideTemp = 21.4492
+- basv Errorhistory = no data stored
+- basv FrostOverRideTime = 4
+- basv FrostOverRideTime = no data stored
+- basv GlobalSystemOff = no
+- basv GlobalSystemOff = no data stored
+- basv Hc1ActualFlowTempDesired = 0.0
+- basv Hc1AutoOffMode = eco
+- basv Hc1AutoOffMode = no data stored
+- basv Hc1CircuitType = mixer
+- basv Hc1ExcessTemp = 0.0
+- basv Hc1ExcessTemp = no data stored
+- basv Hc1FlowTemp = 53
+- basv Hc1HeatCurve = 0.7
+- basv Hc1HeatCurve = no data stored
+- basv Hc1HeatCurveAdaption = 0.0
+- basv Hc1MaxFlowTempDesired = 60
+- basv Hc1MaxFlowTempDesired = no data stored
+- basv Hc1MinFlowTempDesired = 17
+- basv Hc1MinFlowTempDesired = no data stored
+- basv Hc1MixerMovement = 0.0
+- basv Hc1PumpStatus = 0
+- basv Hc1PumpStatus = no data stored
+- basv Hc1RoomTempSwitchOn = thermostat
+- basv Hc1RoomTempSwitchOn = no data stored
+- basv Hc1Status = 0
+- basv Hc1Status = no data stored
+- basv Hc1SummerTempLimit = 22
+- basv Hc1SummerTempLimit = no data stored
+- basv Hc2ActualFlowTempDesired = 0.0
+- basv Hc2AutoOffMode = eco
+- basv Hc2AutoOffMode = no data stored
+- basv Hc2CircuitType = inactive
+- basv Hc2ExcessTemp = 0.0
+- basv Hc2ExcessTemp = no data stored
+- basv Hc2FlowTemp =  (empty for 3115b52406020002010800 / 0800020800ffffff7f)
+- basv Hc2HeatCurve = 0.6
+- basv Hc2HeatCurve = no data stored
+- basv Hc2HeatCurveAdaption = 0.0
+- basv Hc2MaxFlowTempDesired = 55
+- basv Hc2MaxFlowTempDesired = no data stored
+- basv Hc2MinFlowTempDesired = 15
+- basv Hc2MinFlowTempDesired = no data stored
+- basv Hc2MixerMovement = 0.0
+- basv Hc2PumpStatus = 0
+- basv Hc2PumpStatus = no data stored
+- basv Hc2RoomTempSwitchOn = off
+- basv Hc2RoomTempSwitchOn = no data stored
+- basv Hc2Status = 0
+- basv Hc2Status = no data stored
+- basv Hc2SummerTempLimit = 21
+- basv Hc2SummerTempLimit = no data stored
+- basv Hc3ActualFlowTempDesired = 0.0
+- basv Hc3AutoOffMode = eco
+- basv Hc3AutoOffMode = no data stored
+- basv Hc3CircuitType = inactive
+- basv Hc3ExcessTemp = 0.0
+- basv Hc3ExcessTemp = no data stored
+- basv Hc3FlowTemp =  (empty for 3115b52406020002020800 / 0800020800ffffff7f)
+- basv Hc3HeatCurve = 0.6
+- basv Hc3HeatCurve = no data stored
+- basv Hc3HeatCurveAdaption = 0.0
+- basv Hc3MaxFlowTempDesired = 55
+- basv Hc3MaxFlowTempDesired = no data stored
+- basv Hc3MinFlowTempDesired = 15
+- basv Hc3MinFlowTempDesired = no data stored
+- basv Hc3MixerMovement = 0.0
+- basv Hc3PumpStatus = 0
+- basv Hc3PumpStatus = no data stored
+- basv Hc3RoomTempSwitchOn = off
+- basv Hc3RoomTempSwitchOn = no data stored
+- basv Hc3Status = 0
+- basv Hc3Status = no data stored
+- basv Hc3SummerTempLimit = 21
+- basv Hc3SummerTempLimit = no data stored
+- basv HcStorageTempBottom =  (empty for f115b5240602000000a000 / 080000a000ffffff7f)
+- basv HcStorageTempTop =  (empty for f115b52406020000009f00 / 0800009f00ffffff7f)
+- basv HolidayEndPeriod = no data stored
+- basv HolidayEndPeriod = no data stored
+- basv HolidayStartPeriod = no data stored
+- basv HolidayStartPeriod = no data stored
+- basv HolidayTemp = no data stored
+- basv HolidayTemp = no data stored
+- basv HwcBankHolidayEndPeriod = no data stored
+- basv HwcBankHolidayEndPeriod = no data stored
+- basv HwcBankHolidayStartPeriod = no data stored
+- basv HwcBankHolidayStartPeriod = no data stored
+- basv HwcFlowTemp = 93
+- basv HwcHolidayEndPeriod = 02.01.2026
+- basv HwcHolidayEndPeriod = no data stored
+- basv HwcHolidayStartPeriod = 30.12.2025
+- basv HwcHolidayStartPeriod = no data stored
+- basv HwcLockTime = 60
+- basv HwcLockTime = no data stored
+- basv HwcMaxFlowTempDesired = 80
+- basv HwcMaxFlowTempDesired = no data stored
+- basv HwcOpMode = auto
+- basv HwcOpMode = no data stored
+- basv HwcParallelLoading = off
+- basv HwcParallelLoading = no data stored
+- basv HwcSFMode = load
+- basv HwcSFMode = no data stored
+- basv HwcStorageTemp = 46
+- basv HwcStorageTempBottom =  (empty for f115b52406020000009e00 / 0800009e00ffffff7f)
+- basv HwcStorageTempTop =  (empty for f115b52406020000009d00 / 0800009d00ffffff7f)
+- basv HwcTempDesired = 68
+- basv HwcTempDesired = no data stored
+- basv HwcTimer_Friday = no data stored
+- basv HwcTimer_Friday = no data stored
+- basv HwcTimer_Monday = no data stored
+- basv HwcTimer_Monday = no data stored
+- basv HwcTimer_Saturday = no data stored
+- basv HwcTimer_Saturday = no data stored
+- basv HwcTimer_Sunday = no data stored
+- basv HwcTimer_Sunday = no data stored
+- basv HwcTimer_Thursday = no data stored
+- basv HwcTimer_Thursday = no data stored
+- basv HwcTimer_Tuesday = no data stored
+- basv HwcTimer_Tuesday = no data stored
+- basv HwcTimer_Wednesday = no data stored
+- basv HwcTimer_Wednesday = no data stored
+- basv HydraulicScheme = 8
+- basv HydraulicScheme = no data stored
+- basv Installer1 = no data stored
+- basv Installer1 = no data stored
+- basv Installer2 = no data stored
+- basv Installer2 = no data stored
+- basv KeyCodeforConfigMenu = no data stored
+- basv KeyCodeforConfigMenu = no data stored
+- basv MaintenanceDate = no data stored
+- basv MaintenanceDate = no data stored
+- basv MaintenanceDue = no data stored
+- basv ManualCooling = no data stored
+- basv ManualCooling = no data stored
+- basv MaxCylinderChargeTime = 120
+- basv MaxCylinderChargeTime = no data stored
+- basv MaxRoomHumidity = 40
+- basv MaxRoomHumidity = no data stored
+- basv MultiRelaySetting = 4
+- basv MultiRelaySetting = no data stored
+- basv NoiseReductionTimer_Friday = no data stored
+- basv NoiseReductionTimer_Friday = no data stored
+- basv NoiseReductionTimer_Monday = no data stored
+- basv NoiseReductionTimer_Monday = no data stored
+- basv NoiseReductionTimer_Saturday = no data stored
+- basv NoiseReductionTimer_Saturday = no data stored
+- basv NoiseReductionTimer_Sunday = no data stored
+- basv NoiseReductionTimer_Sunday = no data stored
+- basv NoiseReductionTimer_Thursday = no data stored
+- basv NoiseReductionTimer_Thursday = no data stored
+- basv NoiseReductionTimer_Tuesday = no data stored
+- basv NoiseReductionTimer_Tuesday = no data stored
+- basv NoiseReductionTimer_Wednesday = no data stored
+- basv NoiseReductionTimer_Wednesday = no data stored
+- basv OpMode = no data stored
+- basv OpMode = no data stored
+- basv OpModeCooling = no data stored
+- basv OpModeCooling = no data stored
+- basv OpModeEffect = no data stored
+- basv OpModeEffect = no data stored
+- basv OpModeVentilation = no data stored
+- basv OpModeVentilation = no data stored
+- basv OutsideTempAvg = 17.6992
+- basv OutsideTempAvg = no data stored
+- basv PhoneNumber1 = no data stored
+- basv PhoneNumber1 = no data stored
+- basv PhoneNumber2 = no data stored
+- basv PhoneNumber2 = no data stored
+- 'basv PrEnergySum =  (ERR: invalid position for 3115b52406020000005c00 / 00)'
+- basv PrEnergySum = no data stored
+- basv PrEnergySumHc = 7192
+- basv PrEnergySumHc = no data stored
+- basv PrEnergySumHcLastMonth = 7
+- basv PrEnergySumHcLastMonth = no data stored
+- basv PrEnergySumHcThisMonth = 6
+- basv PrEnergySumHcThisMonth = no data stored
+- basv PrEnergySumHwc = 1279
+- basv PrEnergySumHwc = no data stored
+- basv PrEnergySumHwcLastMonth = 28
+- basv PrEnergySumHwcLastMonth = no data stored
+- basv PrEnergySumHwcThisMonth = 23
+- basv PrEnergySumHwcThisMonth = no data stored
+- basv PrFuelSum = no data stored
+- basv PrFuelSum = no data stored
+- basv PrFuelSumHc = no data stored
+- basv PrFuelSumHc = no data stored
+- basv PrFuelSumHcLastMonth = no data stored
+- basv PrFuelSumHcLastMonth = no data stored
+- basv PrFuelSumHcThisMonth = no data stored
+- basv PrFuelSumHcThisMonth = no data stored
+- basv PrFuelSumHwc = no data stored
+- basv PrFuelSumHwc = no data stored
+- basv PrFuelSumHwcLastMonth = no data stored
+- basv PrFuelSumHwcLastMonth = no data stored
+- basv PrFuelSumHwcThisMonth = no data stored
+- basv PrFuelSumHwcThisMonth = no data stored
+- basv PumpAdditionalTime = no data stored
+- basv PumpAdditionalTime = no data stored
+- basv SFMode = no data stored
+- basv SFMode = no data stored
+- basv SolarYieldTotal = no data stored
+- basv SolarYieldTotal = no data stored
+- basv SystemFlowTemp =  (empty for f115b52406020000004b00 / 0800004b00ffffff7f)
+- basv TariffTimer_Friday = no data stored
+- basv TariffTimer_Friday = no data stored
+- basv TariffTimer_Monday = no data stored
+- basv TariffTimer_Monday = no data stored
+- basv TariffTimer_Saturday = no data stored
+- basv TariffTimer_Saturday = no data stored
+- basv TariffTimer_Sunday = no data stored
+- basv TariffTimer_Sunday = no data stored
+- basv TariffTimer_Thursday = no data stored
+- basv TariffTimer_Thursday = no data stored
+- basv TariffTimer_Tuesday = no data stored
+- basv TariffTimer_Tuesday = no data stored
+- basv TariffTimer_Wednesday = no data stored
+- basv TariffTimer_Wednesday = no data stored
+- basv Time = 10:54:32
+- basv Time = no data stored
+- basv VentilationDay = no data stored
+- basv VentilationDay = no data stored
+- basv VentilationNight = no data stored
+- basv VentilationNight = no data stored
+- basv VentilationTimer_Friday = no data stored
+- basv VentilationTimer_Friday = no data stored
+- basv VentilationTimer_Monday = no data stored
+- basv VentilationTimer_Monday = no data stored
+- basv VentilationTimer_Saturday = no data stored
+- basv VentilationTimer_Saturday = no data stored
+- basv VentilationTimer_Sunday = no data stored
+- basv VentilationTimer_Sunday = no data stored
+- basv VentilationTimer_Thursday = no data stored
+- basv VentilationTimer_Thursday = no data stored
+- basv VentilationTimer_Tuesday = no data stored
+- basv VentilationTimer_Tuesday = no data stored
+- basv VentilationTimer_Wednesday = no data stored
+- basv VentilationTimer_Wednesday = no data stored
+- basv WaterPressure = 1.7
+- basv YieldTotal = 21748
+- basv YieldTotal = no data stored
+- basv Z1ActualRoomTempDesired = 5
+- basv Z1ActualRoomTempDesired = no data stored
+- basv Z1BankHolidayEndPeriod = no data stored
+- basv Z1BankHolidayEndPeriod = no data stored
+- basv Z1BankHolidayStartPeriod = no data stored
+- basv Z1BankHolidayStartPeriod = no data stored
+- basv Z1CoolingTemp = 24
+- basv Z1CoolingTemp = no data stored
+- basv Z1CoolingTimer_Friday = no data stored
+- basv Z1CoolingTimer_Friday = no data stored
+- basv Z1CoolingTimer_Monday = no data stored
+- basv Z1CoolingTimer_Monday = no data stored
+- basv Z1CoolingTimer_Saturday = no data stored
+- basv Z1CoolingTimer_Saturday = no data stored
+- basv Z1CoolingTimer_Sunday = no data stored
+- basv Z1CoolingTimer_Sunday = no data stored
+- basv Z1CoolingTimer_Thursday = no data stored
+- basv Z1CoolingTimer_Thursday = no data stored
+- basv Z1CoolingTimer_Tuesday = no data stored
+- basv Z1CoolingTimer_Tuesday = no data stored
+- basv Z1CoolingTimer_Wednesday = no data stored
+- basv Z1CoolingTimer_Wednesday = no data stored
+- 'basv Z1DayTemp =  (ERR: invalid position for 3115b52406020003000700 / 00)'
+- basv Z1DayTemp = no data stored
+- basv Z1HolidayEndPeriod = 02.01.2026
+- basv Z1HolidayEndPeriod = no data stored
+- basv Z1HolidayStartPeriod = 30.12.2025
+- basv Z1HolidayStartPeriod = no data stored
+- basv Z1HolidayTemp = 21
+- basv Z1HolidayTemp = no data stored
+- 'basv Z1Name1 = Zone '
+- basv Z1Name1 = no data stored
+- 'basv Z1Name2 =  (ERR: invalid position for f115b52406020003001800 / 06030318003100)'
+- basv Z1Name2 = no data stored
+- basv Z1NightTemp = 22
+- basv Z1NightTemp = no data stored
+- basv Z1OpMode = off
+- basv Z1OpMode = no data stored
+- basv Z1OpModeCooling = no data stored
+- basv Z1OpModeCooling = no data stored
+- basv Z1QuickVetoTemp = 22.5
+- basv Z1QuickVetoTemp = no data stored
+- basv Z1RoomTemp = 22.25
+- basv Z1RoomZoneMapping = VRC700
+- basv Z1RoomZoneMapping = no data stored
+- basv Z1SFMode = auto
+- basv Z1SFMode = no data stored
+- basv Z1Shortname = no data stored
+- basv Z1Shortname = no data stored
+- basv Z1Timer_Friday = no data stored
+- basv Z1Timer_Friday = no data stored
+- basv Z1Timer_Monday = no data stored
+- basv Z1Timer_Monday = no data stored
+- basv Z1Timer_Saturday = no data stored
+- basv Z1Timer_Saturday = no data stored
+- basv Z1Timer_Sunday = no data stored
+- basv Z1Timer_Sunday = no data stored
+- basv Z1Timer_Thursday = no data stored
+- basv Z1Timer_Thursday = no data stored
+- basv Z1Timer_Tuesday = no data stored
+- basv Z1Timer_Tuesday = no data stored
+- basv Z1Timer_Wednesday = no data stored
+- basv Z1Timer_Wednesday = no data stored
+- basv Z1ValveStatus = no data stored
+- basv Z1ValveStatus = no data stored
+- basv Z2ActualRoomTempDesired = no data stored
+- basv Z2ActualRoomTempDesired = no data stored
+- basv Z2BankHolidayEndPeriod = no data stored
+- basv Z2BankHolidayEndPeriod = no data stored
+- basv Z2BankHolidayStartPeriod = no data stored
+- basv Z2BankHolidayStartPeriod = no data stored
+- basv Z2CoolingTemp = no data stored
+- basv Z2CoolingTemp = no data stored
+- basv Z2CoolingTimer_Friday = no data stored
+- basv Z2CoolingTimer_Friday = no data stored
+- basv Z2CoolingTimer_Monday = no data stored
+- basv Z2CoolingTimer_Monday = no data stored
+- basv Z2CoolingTimer_Saturday = no data stored
+- basv Z2CoolingTimer_Saturday = no data stored
+- basv Z2CoolingTimer_Sunday = no data stored
+- basv Z2CoolingTimer_Sunday = no data stored
+- basv Z2CoolingTimer_Thursday = no data stored
+- basv Z2CoolingTimer_Thursday = no data stored
+- basv Z2CoolingTimer_Tuesday = no data stored
+- basv Z2CoolingTimer_Tuesday = no data stored
+- basv Z2CoolingTimer_Wednesday = no data stored
+- basv Z2CoolingTimer_Wednesday = no data stored
+- basv Z2DayTemp = no data stored
+- basv Z2DayTemp = no data stored
+- basv Z2HolidayEndPeriod = no data stored
+- basv Z2HolidayEndPeriod = no data stored
+- basv Z2HolidayStartPeriod = no data stored
+- basv Z2HolidayStartPeriod = no data stored
+- basv Z2HolidayTemp = no data stored
+- basv Z2HolidayTemp = no data stored
+- basv Z2Name1 = no data stored
+- basv Z2Name1 = no data stored
+- basv Z2Name2 = no data stored
+- basv Z2Name2 = no data stored
+- basv Z2NightTemp = no data stored
+- basv Z2NightTemp = no data stored
+- basv Z2OpMode = no data stored
+- basv Z2OpMode = no data stored
+- basv Z2OpModeCooling = no data stored
+- basv Z2OpModeCooling = no data stored
+- basv Z2QuickVetoTemp = no data stored
+- basv Z2QuickVetoTemp = no data stored
+- basv Z2RoomTemp =  (empty for 3115b52406020003010f00 / 0800030f00ffffff7f)
+- basv Z2RoomZoneMapping = none
+- basv Z2RoomZoneMapping = no data stored
+- basv Z2SFMode = no data stored
+- basv Z2SFMode = no data stored
+- basv Z2Shortname = no data stored
+- basv Z2Shortname = no data stored
+- basv Z2Timer_Friday = no data stored
+- basv Z2Timer_Friday = no data stored
+- basv Z2Timer_Monday = no data stored
+- basv Z2Timer_Monday = no data stored
+- basv Z2Timer_Saturday = no data stored
+- basv Z2Timer_Saturday = no data stored
+- basv Z2Timer_Sunday = no data stored
+- basv Z2Timer_Sunday = no data stored
+- basv Z2Timer_Thursday = no data stored
+- basv Z2Timer_Thursday = no data stored
+- basv Z2Timer_Tuesday = no data stored
+- basv Z2Timer_Tuesday = no data stored
+- basv Z2Timer_Wednesday = no data stored
+- basv Z2Timer_Wednesday = no data stored
+- basv Z2ValveStatus = no data stored
+- basv Z2ValveStatus = no data stored
+- basv Z3ActualRoomTempDesired = no data stored
+- basv Z3ActualRoomTempDesired = no data stored
+- basv Z3BankHolidayEndPeriod = no data stored
+- basv Z3BankHolidayEndPeriod = no data stored
+- basv Z3BankHolidayStartPeriod = no data stored
+- basv Z3BankHolidayStartPeriod = no data stored
+- basv Z3CoolingTemp = no data stored
+- basv Z3CoolingTemp = no data stored
+- basv Z3CoolingTimer_Friday = no data stored
+- basv Z3CoolingTimer_Friday = no data stored
+- basv Z3CoolingTimer_Monday = no data stored
+- basv Z3CoolingTimer_Monday = no data stored
+- basv Z3CoolingTimer_Saturday = no data stored
+- basv Z3CoolingTimer_Saturday = no data stored
+- basv Z3CoolingTimer_Sunday = no data stored
+- basv Z3CoolingTimer_Sunday = no data stored
+- basv Z3CoolingTimer_Thursday = no data stored
+- basv Z3CoolingTimer_Thursday = no data stored
+- basv Z3CoolingTimer_Tuesday = no data stored
+- basv Z3CoolingTimer_Tuesday = no data stored
+- basv Z3CoolingTimer_Wednesday = no data stored
+- basv Z3CoolingTimer_Wednesday = no data stored
+- basv Z3DayTemp = no data stored
+- basv Z3DayTemp = no data stored
+- basv Z3HolidayEndPeriod = no data stored
+- basv Z3HolidayEndPeriod = no data stored
+- basv Z3HolidayStartPeriod = no data stored
+- basv Z3HolidayStartPeriod = no data stored
+- basv Z3HolidayTemp = no data stored
+- basv Z3HolidayTemp = no data stored
+- basv Z3Name1 = no data stored
+- basv Z3Name1 = no data stored
+- basv Z3Name2 = no data stored
+- basv Z3Name2 = no data stored
+- basv Z3NightTemp = no data stored
+- basv Z3NightTemp = no data stored
+- basv Z3OpMode = no data stored
+- basv Z3OpMode = no data stored
+- basv Z3OpModeCooling = no data stored
+- basv Z3OpModeCooling = no data stored
+- basv Z3QuickVetoTemp = no data stored
+- basv Z3QuickVetoTemp = no data stored
+- basv Z3RoomTemp = no data stored
+- basv Z3RoomZoneMapping = none
+- basv Z3RoomZoneMapping = no data stored
+- basv Z3SFMode = no data stored
+- basv Z3SFMode = no data stored
+- basv Z3Shortname = no data stored
+- basv Z3Shortname = no data stored
+- basv Z3Timer_Friday = no data stored
+- basv Z3Timer_Friday = no data stored
+- basv Z3Timer_Monday = no data stored
+- basv Z3Timer_Monday = no data stored
+- basv Z3Timer_Saturday = no data stored
+- basv Z3Timer_Saturday = no data stored
+- basv Z3Timer_Sunday = no data stored
+- basv Z3Timer_Sunday = no data stored
+- basv Z3Timer_Thursday = no data stored
+- basv Z3Timer_Thursday = no data stored
+- basv Z3Timer_Tuesday = no data stored
+- basv Z3Timer_Tuesday = no data stored
+- basv Z3Timer_Wednesday = no data stored
+- basv Z3Timer_Wednesday = no data stored
+- basv Z3ValveStatus = no data stored
+- basv Z3ValveStatus = no data stored
+- Broadcast Datetime = no data stored
+- Broadcast Error = no data stored
+- Broadcast HwcStatus = no data stored
+- Broadcast Id = no data stored
+- Broadcast IdAnswer = no data stored
+- Broadcast IdQuery = no data stored
+- Broadcast Load = no data stored
+- Broadcast Outsidetemp = 21.449
+- Broadcast Queryexistence =  (empty for 31fe07fe00 / )
+- Broadcast Signoflife = no data stored
+- Broadcast Vdatetime = 11:15:44;26.08.2026
+- Broadcast Vdatetime = no data stored
+- 'ctlv2 Hc1DewPointTemp =  (ERR: invalid position for 3115b52406020002002300 / 00)'
+- 'ctlv2 Hc1FlowTempCalc =  (ERR: invalid position for 3115b52406020002002000 / 050102200002)'
+- 'ctlv2 Hc1Humidity =  (ERR: invalid position for 3115b52406020002002200 / 00)'
+- 'ctlv2 Hc1MixerPosition =  (ERR: invalid position for 3115b52406020002002100 / 00)'
+- 'ctlv2 Hc1PumpHours =  (ERR: invalid position for 3115b52406020002002400 / 00)'
+- 'ctlv2 Hc1PumpStarts =  (ERR: invalid position for 3115b52406020002002500 / 00)'
+- 'ctlv2 Hc2DewPointTemp =  (ERR: invalid position for 3115b52406020002012300 / 00)'
+- 'ctlv2 Hc2FlowTempCalc =  (ERR: invalid position for 3115b52406020002012000 / 050002200000)'
+- 'ctlv2 Hc2Humidity =  (ERR: invalid position for 3115b52406020002012200 / 00)'
+- 'ctlv2 Hc2MixerPosition =  (ERR: invalid position for 3115b52406020002012100 / 00)'
+- 'ctlv2 Hc2PumpHours =  (ERR: invalid position for 3115b52406020002012400 / 00)'
+- 'ctlv2 Hc2PumpStarts =  (ERR: invalid position for 3115b52406020002012500 / 00)'
+- ctlv2 ManualCoolingEndDate = 01.01.2019
+- ctlv2 ManualCoolingEndDate = no data stored
+- ctlv2 ManualCoolingStartDate = 01.01.2019
+- ctlv2 ManualCoolingStartDate = no data stored
+- ctlv2 z1RoomHumidity = 52
+- General Valuerange = no data stored
+- hmu BuildingCircuitFlow = 0
+- hmu Clearerrorhistory = no data stored
+- hmu CompressorBlocktime = no data stored
+- hmu CompressorHc = no data stored (message not available due to condition)
+- hmu CompressorHwc = no data stored (message not available due to condition)
+- hmu CoolElecConsTotal = 0.0
+- hmu CoolEnvYieldDay = 0.0
+- hmu CoolEnvYieldMonth = 0.0
+- hmu CoolEnvYieldTotal = 0.0
+- hmu CopCooling = 1.0
+- hmu CopCoolingMonth = 1.0
+- hmu CopHc = 3.6
+- hmu CopHcMonth = 1.0
+- hmu CopHwc = 3.6
+- hmu CopHwcMonth = 4.6
+- hmu CurrentCompressorUtil = 0.00
+- hmu CurrentConsumedPower = 0.0
+- hmu Currenterror = -;-;-;-;-
+- hmu CurrentYieldPower = 0.0
+- hmu DateTime = nosignal;-:-:-;-.-.-;-
+- hmu EnergyIntegral = no data stored
+- hmu Errorhistory = no data stored
+- hmu FlowPressure = no data stored (message not available due to condition)
+- hmu FlowTemp = 53.56
+- hmu PowerConsumptionHmu = 1.558503509
+- hmu RunDataAirInletTemp = 23.3857
+- hmu RunDataBuildingCPumpPower = 100
+- hmu RunDataCompressorInletTemp = 19.3162
+- hmu RunDataCompressorOutletTemp = 20
+- hmu RunDataCompressorSpeed = 64.0033
+- hmu RunDataEEVOutletTemp = 19.3448
+- hmu RunDataEEVPositionAbs = 250
+- hmu RunDataFan1Speed = 0.0
+- hmu RunDataFan2Speed = 0.0
+- hmu RunDataHighPressure = 13.283
+- hmu RunDataStatuscode = hwc_compressor_active
+- hmu RunStats4PortValveHours = 73
+- hmu RunStats4PortValveSwitches = 1093
+- hmu RunStatsBuildingCPumpStarts = 1721
+- hmu RunStatsBuildingPumpHours = 10930
+- hmu RunStatsCompressorHours = 8454
+- hmu RunStatsCompressorStarts = 4925
+- hmu RunStatsFan1Hours = 8631
+- hmu RunStatsFan1Starts = 6044
+- hmu RunStatsFan2Hours = 0
+- hmu RunStatsFan2Starts = 0
+- hmu RunStatsHcHours = 9934
+- hmu RunStatsHMUHours = 27563
+- hmu RunStatsHwcHours = 812
+- hmu SetMode = water;-;-;160;1;1;1;1;0;0
+- hmu SetMode = no data stored
+- 'hmu SourceTempInput =  (ERR: invalid position for 3108b51a0405ff3222 / 02ff01)'
+- hmu Status01 = 54.0;52.0;-;-;-;hwc
+- hmu Status02 = no data stored
+- hmu Status16 = no data stored
+- hmu Status = no data stored
+- hmu StatusCirPump = on
+- hmu SupplyTempWeighted = 20.00
+- hmu TotalEnergyUsage = 7824
+- hmu YieldCoolDay = 0.0
+- hmu YieldCooling = 0.0
+- hmu YieldCoolingMonth = 0.0
+- hmu YieldHc = 18767
+- hmu YieldHcDay = 0.0
+- hmu YieldHcMonth = 0.0
+- hmu YieldHwc = 2967
+- hmu YieldHwcDay = 1.7
+- hmu YieldHwcMonth = 56.6
+- Memory Eeprom = no data stored
+- Memory Eeprom = no data stored
+- Memory Ram = no data stored
+- Memory Ram = no data stored
+- Scan Id = no data stored
+- scan.08  = Vaillant;HMU00;0901;5103
+- scan.15  = Vaillant;BASV2;0507;1704
+- Scan.15 Id = 21;22;25;0020262148;0082;006876;N9
+- scan.76  = Vaillant;VWZIO;0902;5103
+- Scan.76 Id = 21;23;21;0010022084;3100;005613;N0
+- scan.f6  = Vaillant;NETX2;4040;5703
+- Scan.f6 Id = 21;22;30;0020260962;0938;053360;N1
+- vwzio EnableTestHwcTemp = no data stored
+- vwzio EnableTestOutdoorTemp = no data stored
+- vwzio EnableTestThreeWayValve = no data stored
+- vwzio TestHwcTemp = no data stored
+- vwzio TestOutdoorTemp = no data stored
+- vwzio TestThreeWayValve = no data stored
+- ''

--- a/tests/test_boost_fixture.py
+++ b/tests/test_boost_fixture.py
@@ -1,0 +1,117 @@
+"""Tests for the aroTHERM BASV2 boost-mode community fixtures (discussion #31).
+
+MichaelLachmann captured two discovery dumps around a DHW boost toggle: the
+first with boost on (11:16:49), the second with boost off (11:18:07). Both
+dumps show ``basv HwcSFMode = load`` while the compressor is actively heating
+the cylinder toward 68 C. These tests pin that capture so the write-verification
+fix (a read-back that does not match the written value must fail) has a
+real-bus fixture behind it, and so the boost registers are discoverable with
+data.
+"""
+
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import sys
+from pathlib import Path
+
+from tests.fake_ebusd import load_discovery_dump, load_find_lines
+
+BACKEND_PATH = Path(__file__).parents[1] / "custom_components/vaillant_ebus/backend"
+COMPONENT_PATH = BACKEND_PATH.parent
+
+for name in ("vaillant_ebus", "vaillant_ebus.backend"):
+    pkg = importlib.util.module_from_spec(importlib.machinery.ModuleSpec(name, None))
+    pkg.__path__ = [str(COMPONENT_PATH)] if name == "vaillant_ebus" else [str(BACKEND_PATH)]
+    sys.modules[name] = pkg
+
+MODELS_SPEC = importlib.util.spec_from_file_location("vaillant_ebus.backend.models", BACKEND_PATH / "models.py")
+assert MODELS_SPEC and MODELS_SPEC.loader
+MODELS = importlib.util.module_from_spec(MODELS_SPEC)
+sys.modules["vaillant_ebus.backend.models"] = MODELS
+MODELS_SPEC.loader.exec_module(MODELS)
+
+MAPPING_SPEC = importlib.util.spec_from_file_location(
+    "vaillant_ebus.backend.mapping", BACKEND_PATH / "mapping.py"
+)
+assert MAPPING_SPEC and MAPPING_SPEC.loader
+MAPPING = importlib.util.module_from_spec(MAPPING_SPEC)
+sys.modules["vaillant_ebus.backend.mapping"] = MAPPING
+MAPPING_SPEC.loader.exec_module(MAPPING)
+
+ENTITY_SPEC = importlib.util.spec_from_file_location(
+    "vaillant_ebus.backend.entity_factory", BACKEND_PATH / "entity_factory.py"
+)
+assert ENTITY_SPEC and ENTITY_SPEC.loader
+ENTITY = importlib.util.module_from_spec(ENTITY_SPEC)
+sys.modules["vaillant_ebus.backend.entity_factory"] = ENTITY
+ENTITY_SPEC.loader.exec_module(ENTITY)
+
+DISCOVERY_SPEC = importlib.util.spec_from_file_location(
+    "vaillant_ebus.backend.discovery_service", BACKEND_PATH / "discovery_service.py"
+)
+assert DISCOVERY_SPEC and DISCOVERY_SPEC.loader
+DISCOVERY = importlib.util.module_from_spec(DISCOVERY_SPEC)
+sys.modules["vaillant_ebus.backend.discovery_service"] = DISCOVERY
+DISCOVERY_SPEC.loader.exec_module(DISCOVERY)
+
+DiscoveryService = DISCOVERY.DiscoveryService
+EntityFactoryService = ENTITY.EntityFactoryService
+
+BOOST_ON_DUMP = "community/arotherm_basv_boost_on_discovery.yaml"
+BOOST_OFF_DUMP = "community/arotherm_basv_boost_off_discovery.yaml"
+
+
+def _find_value(lines: list[str], circuit: str, name: str) -> str | None:
+    """Return the first live value for circuit.name in raw find lines."""
+    for line in lines:
+        if "=" not in line:
+            continue
+        lhs, rhs = line.split("=", 1)
+        parts = lhs.strip().split(" ", 1)
+        if len(parts) != 2 or parts[0] != circuit or parts[1] != name:
+            continue
+        val = rhs.strip()
+        if val and val != "no data stored" and not val.startswith("(ERR"):
+            return val
+    return None
+
+
+def test_boost_fixtures_load() -> None:
+    for dump in (BOOST_ON_DUMP, BOOST_OFF_DUMP):
+        data = load_discovery_dump(dump)
+        assert data.get("raw_find_lines")
+        assert data.get("before_registers")
+        assert data.get("metadata", {}).get("register_count") > 500
+
+
+def test_boost_on_dump_shows_sfmode_load() -> None:
+    # The whole point of the capture: even with boost "off" (second dump), the
+    # register still reads load while the compressor runs the cylinder up.
+    for dump in (BOOST_ON_DUMP, BOOST_OFF_DUMP):
+        lines = load_find_lines(dump)
+        assert _find_value(lines, "basv", "HwcSFMode") == "load", dump
+        assert _find_value(lines, "basv", "HwcStorageTemp") == "46", dump
+        assert _find_value(lines, "basv", "HwcTempDesired") == "68", dump
+
+
+def test_boost_fixture_entities() -> None:
+    lines = load_find_lines(BOOST_ON_DUMP)
+    graph = DiscoveryService.build_device_graph(lines)
+    entities = EntityFactoryService().generate(graph)
+    by_key = {e.key: e for e in entities}
+
+    # The boost-relevant registers must generate entities with live data on
+    # the basv circuit (heating controller for this hardware).
+    for key in (
+        "basv.HwcSFMode.value",
+        "basv.HwcOpMode.value",
+        "basv.HwcStorageTemp.value",
+        "basv.HwcTempDesired.value",
+    ):
+        entity = by_key.get(key)
+        assert entity is not None, f"{key} must be an entity"
+
+    assert by_key["basv.HwcStorageTemp.value"].meta.device_class == "temperature"
+    assert by_key["basv.HwcSFMode.value"].meta.friendly_name == "DHW Special Function"

--- a/tests/test_boost_switch.py
+++ b/tests/test_boost_switch.py
@@ -1,0 +1,169 @@
+"""Unit tests for the DHW boost desired-state behavior.
+
+HwcSFMode reports "load" while the cylinder charges even after boost is turned
+off, so the boost switch and water heater report the coordinator's desired DHW
+boost state once a toggle has happened. These tests pin that behavior.
+
+Reuses the homeassistant mock scaffolding from tests.test_coordinator.
+"""
+
+from __future__ import annotations
+
+import enum
+import importlib.machinery
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+from tests import test_coordinator as tc  # noqa: F401 — installs shared HA mocks
+
+PROJECT_ROOT = Path(__file__).parents[1]
+COMPONENT_PATH = PROJECT_ROOT / "custom_components/vaillant_ebus"
+
+mock_homeassistant = sys.modules["homeassistant"]
+
+
+class _MockBaseEntity:
+    @property
+    def unique_id(self) -> str | None:
+        return getattr(self, "_attr_unique_id", None)
+
+    @property
+    def name(self) -> str | None:
+        return getattr(self, "_attr_name", None)
+
+    @property
+    def is_on(self):  # pragma: no cover - overridden by real entities
+        return None
+
+
+class _MockCoordinatorEntity(_MockBaseEntity):
+    def __init__(self, coordinator) -> None:
+        self.coordinator = coordinator
+
+    def async_write_ha_state(self) -> None:
+        pass
+
+    def _handle_coordinator_update(self) -> None:
+        pass
+
+    async def async_update(self) -> None:
+        pass
+
+    def __class_getitem__(cls, item):
+        return cls
+
+
+class _UnitOfTemperature:
+    CELSIUS = "°C"
+
+
+class _WaterHeaterEntityFeature(enum.IntFlag):
+    TARGET_TEMPERATURE = 1
+    OPERATION_MODE = 2
+    AWAY_MODE = 4
+    ON_OFF = 8
+
+
+components_pkg = importlib.util.module_from_spec(importlib.machinery.ModuleSpec("homeassistant.components", None))
+switch_pkg = importlib.util.module_from_spec(
+    importlib.machinery.ModuleSpec("homeassistant.components.switch", None)
+)
+switch_pkg.SwitchEntity = _MockBaseEntity
+water_heater_pkg = importlib.util.module_from_spec(
+    importlib.machinery.ModuleSpec("homeassistant.components.water_heater", None)
+)
+water_heater_pkg.WaterHeaterEntity = _MockBaseEntity
+water_heater_pkg.WaterHeaterEntityFeature = _WaterHeaterEntityFeature
+sys.modules["homeassistant.components"] = components_pkg
+sys.modules["homeassistant.components.switch"] = switch_pkg
+sys.modules["homeassistant.components.water_heater"] = water_heater_pkg
+
+ha_const = sys.modules["homeassistant.const"]
+ha_const.ATTR_TEMPERATURE = "temperature"
+ha_const.UnitOfTemperature = _UnitOfTemperature
+
+entity_platform = importlib.util.module_from_spec(
+    importlib.machinery.ModuleSpec("homeassistant.helpers.entity_platform", None)
+)
+entity_platform.AddEntitiesCallback = object
+sys.modules["homeassistant.helpers.entity_platform"] = entity_platform
+
+mock_homeassistant.helpers.update_coordinator.CoordinatorEntity = _MockCoordinatorEntity
+mock_homeassistant.config_entries.ConfigEntry = object
+mock_homeassistant.core.HomeAssistant = object
+
+const_module = sys.modules["vaillant_ebus.const"]
+const_module.CONF_AWAY_DURATION = "away_duration"
+const_module.DEFAULT_AWAY_DURATION = 5
+const_module.DOMAIN = "vaillant_ebus"
+
+for _name in ("switch", "water_heater"):
+    _spec = importlib.util.spec_from_file_location(f"vaillant_ebus.{_name}", COMPONENT_PATH / f"{_name}.py")
+    assert _spec and _spec.loader
+    _mod = importlib.util.module_from_spec(_spec)
+    sys.modules[f"vaillant_ebus.{_name}"] = _mod
+    _spec.loader.exec_module(_mod)
+
+from vaillant_ebus.switch import HwcBoostSwitch  # noqa: E402
+from vaillant_ebus.water_heater import EbusdWaterHeater  # noqa: E402
+
+
+def _coordinator(dhw_boost_desired=None, sfmode="load") -> MagicMock:
+    c = MagicMock()
+    c.heating_circuit = "basv"
+    c.dhw_boost_desired = dhw_boost_desired
+    c.data = {"ebusd": {"basv.HwcSFMode.value": sfmode, "basv.HwcOpMode.value": "auto"}}
+    c.async_write_register = AsyncMock(return_value=True)
+    c.async_write_registers = AsyncMock(return_value=True)
+    c.get_device_info = MagicMock(return_value={"identifiers": {("vaillant_ebus", "dhw")}})
+    c.last_update_success = True
+    return c
+
+
+def _entry() -> MagicMock:
+    e = MagicMock()
+    e.entry_id = "entry-1"
+    e.options = {}
+    e.data = {}
+    return e
+
+
+# Without a prior toggle, the switch falls back to the raw HwcSFMode register.
+def test_boost_switch_falls_back_to_raw_register() -> None:
+    sw = HwcBoostSwitch(_coordinator(dhw_boost_desired=None, sfmode="load"), _entry())
+    assert sw.is_on is True
+    sw2 = HwcBoostSwitch(_coordinator(dhw_boost_desired=None, sfmode="auto"), _entry())
+    assert sw2.is_on is False
+
+
+# After a toggle the switch reports the desired state, not the raw register.
+def test_boost_switch_reports_desired_state() -> None:
+    c = _coordinator(dhw_boost_desired=False, sfmode="load")
+    sw = HwcBoostSwitch(c, _entry())
+    # HwcSFMode still "load" (charging) but boost was turned off.
+    assert sw.is_on is False
+
+
+# Turning boost on/off writes HwcSFMode without strict verification (read-back
+# lags while the cylinder charges) and records the desired state.
+async def test_boost_switch_turn_on_and_off() -> None:
+    c = _coordinator(dhw_boost_desired=False)
+    sw = HwcBoostSwitch(c, _entry())
+    await sw.async_turn_on()
+    assert c.dhw_boost_desired is True
+    c.async_write_register.assert_awaited_once_with("basv", "HwcSFMode", "load", strict_verify=False)
+
+    c.async_write_register.reset_mock()
+    await sw.async_turn_off()
+    assert c.dhw_boost_desired is False
+    c.async_write_register.assert_awaited_once_with("basv", "HwcSFMode", "auto", strict_verify=False)
+
+
+# The water heater reports boost once desired, even when HwcSFMode reads "load".
+def test_water_heater_current_operation_boost_desired() -> None:
+    wh = EbusdWaterHeater(_coordinator(dhw_boost_desired=True, sfmode="load"), _entry())
+    assert wh.current_operation == "boost"
+    wh2 = EbusdWaterHeater(_coordinator(dhw_boost_desired=False, sfmode="load"), _entry())
+    assert wh2.current_operation == "auto"

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -1,0 +1,179 @@
+"""Unit tests for the calendar platform.
+
+The calendar exposes eBUS timer programs as read-only recurring events. These
+tests pin the timer-slot parser and the entity behavior against a coordinator
+whose timer registers may or may not carry data.
+
+Reuses the homeassistant mock scaffolding from tests.test_coordinator.
+"""
+
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import sys
+from datetime import date, datetime
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from tests import test_coordinator as tc  # noqa: F401 — installs shared HA mocks
+
+PROJECT_ROOT = Path(__file__).parents[1]
+COMPONENT_PATH = PROJECT_ROOT / "custom_components/vaillant_ebus"
+
+mock_homeassistant = sys.modules["homeassistant"]
+
+
+class CalendarEvent:
+    def __init__(self, start, end, summary, description=None) -> None:
+        self.start = start
+        self.end = end
+        self.summary = summary
+        self.description = description
+
+
+class _MockCalendarEntity:
+    @property
+    def unique_id(self) -> str | None:
+        return getattr(self, "_attr_unique_id", None)
+
+    @property
+    def name(self) -> str | None:
+        return getattr(self, "_attr_name", None)
+
+    @property
+    def event(self):
+        return None
+
+
+class _MockCoordinatorEntity(_MockCalendarEntity):
+    def __init__(self, coordinator) -> None:
+        self.coordinator = coordinator
+
+    def async_write_ha_state(self) -> None:
+        pass
+
+    def _handle_coordinator_update(self) -> None:
+        pass
+
+    async def async_update(self) -> None:
+        pass
+
+    def __class_getitem__(cls, item):
+        return cls
+
+
+def _local(dt: datetime) -> datetime:
+    return dt
+
+
+calendar_pkg = importlib.util.module_from_spec(
+    importlib.machinery.ModuleSpec("homeassistant.components.calendar", None)
+)
+calendar_pkg.CalendarEntity = _MockCalendarEntity
+calendar_pkg.CalendarEvent = CalendarEvent
+sys.modules["homeassistant.components.calendar"] = calendar_pkg
+
+ha_util = importlib.util.module_from_spec(importlib.machinery.ModuleSpec("homeassistant.util", None))
+ha_util.dt = MagicMock()
+ha_util.dt.as_local = _local
+ha_util.dt.now = lambda: datetime(2026, 8, 27, 12, 0, 0)
+sys.modules["homeassistant.util"] = ha_util
+sys.modules["homeassistant.util.dt"] = ha_util.dt
+
+entity_platform = importlib.util.module_from_spec(
+    importlib.machinery.ModuleSpec("homeassistant.helpers.entity_platform", None)
+)
+entity_platform.AddEntitiesCallback = object
+sys.modules["homeassistant.helpers.entity_platform"] = entity_platform
+
+mock_homeassistant.helpers.update_coordinator.CoordinatorEntity = _MockCoordinatorEntity
+mock_homeassistant.config_entries.ConfigEntry = object
+mock_homeassistant.core.HomeAssistant = object
+
+const_module = sys.modules["vaillant_ebus.const"]
+const_module.DOMAIN = "vaillant_ebus"
+
+CALENDAR_SPEC = importlib.util.spec_from_file_location("vaillant_ebus.calendar", COMPONENT_PATH / "calendar.py")
+assert CALENDAR_SPEC and CALENDAR_SPEC.loader
+CALENDAR = importlib.util.module_from_spec(CALENDAR_SPEC)
+sys.modules["vaillant_ebus.calendar"] = CALENDAR
+CALENDAR_SPEC.loader.exec_module(CALENDAR)
+
+EbusdCalendar = CALENDAR.EbusdCalendar
+_parse_slot = CALENDAR._parse_slot
+SCHEDULES = CALENDAR.SCHEDULES
+
+
+def _entry() -> MagicMock:
+    e = MagicMock()
+    e.entry_id = "entry-1"
+    e.options = {}
+    e.data = {}
+    return e
+
+
+def _coordinator(heating_circuit: str = "basv", registers: dict | None = None) -> MagicMock:
+    c = MagicMock()
+    c.heating_circuit = heating_circuit
+    c.data = {"ebusd": {}}
+    c.registers = registers or {}
+    c.get_device_info = MagicMock(return_value={"identifiers": {("vaillant_ebus", "basv")}})
+    return c
+
+
+# A cooling-timer schedule entry is registered in SCHEDULES.
+def test_cooling_program_in_schedules() -> None:
+    assert "Cooling Program" in SCHEDULES
+    assert SCHEDULES["Cooling Program"] == "Z1CoolingTimer"
+    assert "Cooling Program 2" in SCHEDULES
+    assert SCHEDULES["Cooling Program 2"] == "Z2CoolingTimer"
+
+
+# _parse_slot parses a "HH:MM;HH:MM;temp" slot, ignoring empty/zero slots.
+def test_parse_slot() -> None:
+    day = date(2026, 8, 27)
+    ev = _parse_slot(day, "06:00;12:00;21", "Cooling Program")
+    assert ev is not None
+    assert ev.summary == "Cooling Program"
+    assert ev.description == "Target temperature: 21 C"
+    assert ev.start == datetime(2026, 8, 27, 6, 0)
+    assert ev.end == datetime(2026, 8, 27, 12, 0)
+
+    # An interval that crosses midnight rolls over to the next day.
+    ev2 = _parse_slot(day, "22:00;02:00;21", "Cooling Program")
+    assert ev2 is not None
+    assert ev2.end == datetime(2026, 8, 28, 2, 0)
+
+    assert _parse_slot(day, "00:00;00:00;21", "Cooling Program") is None
+    assert _parse_slot(day, None, "Cooling Program") is None
+    assert _parse_slot(day, "no data stored", "Cooling Program") is None
+
+
+# A calendar entity with no timer data yields no events (additive/empty).
+def test_calendar_empty_without_data() -> None:
+    cal = EbusdCalendar(_coordinator(), _entry(), "Cooling Program", "Z1CoolingTimer")
+    assert cal._attr_unique_id == "entry-1_calendar_z1coolingtimer"
+    assert cal._attr_name == "Cooling Program"
+    start = datetime(2026, 8, 27, 0, 0)
+    end = datetime(2026, 8, 28, 0, 0)
+    assert cal._events_between(start, end) == []
+
+
+# A calendar entity populates events from discovered timer register data.
+# 2026-08-27 is a Thursday, so the Thursday0..2 slots apply.
+def test_calendar_populates_from_register_data() -> None:
+    registers = {
+        "basv.Z1CoolingTimer_Thursday0": MagicMock(value={"value": "06:00;12:00;21"}),
+        "basv.Z1CoolingTimer_Thursday1": MagicMock(value={"value": "18:00;22:00;-"}),
+        "basv.Z1CoolingTimer_Thursday2": MagicMock(value={"value": "00:00;00:00;-"}),
+    }
+    cal = EbusdCalendar(_coordinator(registers=registers), _entry(), "Cooling Program", "Z1CoolingTimer")
+    start = datetime(2026, 8, 27, 0, 0)
+    end = datetime(2026, 8, 28, 0, 0)
+    events = cal._events_between(start, end)
+    assert len(events) == 2
+    assert events[0].start == datetime(2026, 8, 27, 6, 0)
+    assert events[0].end == datetime(2026, 8, 27, 12, 0)
+    assert events[1].start == datetime(2026, 8, 27, 18, 0)
+    assert events[1].end == datetime(2026, 8, 27, 22, 0)

--- a/tests/test_ebus_service.py
+++ b/tests/test_ebus_service.py
@@ -137,12 +137,65 @@ async def test_write_register_success() -> None:
             TimeoutError(),  # drain for write
             b"done\n",  # write response
             TimeoutError(),  # drain for read-back
-            b"1\n",  # read-back
+            b"auto;17;-;-;1;1;1;0;0;1\n",  # read-back (semicolon form)
         ]
     )
     result = await s.write_register("hmu", "SetMode", "auto 17 - - 1 1 1 0 0 1")
     assert result.success
-    assert result.verified_value == "1"
+    assert result.verified_value == "auto;17;-;-;1;1;1;0;0;1"
+
+
+# write_register: read-back that does not match the written value fails.
+# Covers the DHW boost case where ebusd answers "done" but the controller
+# keeps HwcSFMode on "load" while a boost cycle is still running.
+async def test_write_register_readback_mismatch_fails() -> None:
+    s = _service()
+    s._reader.readline = AsyncMock(
+        side_effect=[
+            TimeoutError(),  # drain for write
+            b"done\n",  # write response
+            TimeoutError(),  # drain for read-back
+            b"load\n",  # read-back: value did not change
+        ]
+    )
+    result = await s.write_register("basv", "HwcSFMode", "auto")
+    assert not result.success
+    assert "Write verification mismatch" in result.error_message
+    assert "load" in result.error_message
+
+
+# write_register: with strict_verify=False a read-back mismatch is logged but
+# not treated as a failure. Used for HwcSFMode, whose physical state lags the
+# accepted write while the cylinder is still charging.
+async def test_write_register_readback_mismatch_non_strict() -> None:
+    s = _service()
+    s._reader.readline = AsyncMock(
+        side_effect=[
+            TimeoutError(),  # drain for write
+            b"done\n",  # write response
+            TimeoutError(),  # drain for read-back
+            b"load\n",  # read-back: value did not change yet
+        ]
+    )
+    result = await s.write_register("basv", "HwcSFMode", "auto", strict_verify=False)
+    assert result.success
+    assert result.verified_value == "load"
+
+
+# write_register: numeric formatting differences are tolerated
+async def test_write_register_readback_numeric_tolerance() -> None:
+    s = _service()
+    s._reader.readline = AsyncMock(
+        side_effect=[
+            TimeoutError(),
+            b"done\n",
+            TimeoutError(),
+            b"23.50\n",  # written as 23.5
+        ]
+    )
+    result = await s.write_register("ctlv2", "Z1DayTemp", "23.5")
+    assert result.success
+    assert result.verified_value == "23.50"
 
 
 # write_register: connection error propagates as failure

--- a/tests/test_hardening_fixes.py
+++ b/tests/test_hardening_fixes.py
@@ -122,7 +122,7 @@ async def test_write_register_preserves_values_with_spaces_and_semicolons() -> N
     svc.send_command = AsyncMock(
         side_effect=[
             EBUS.SendResult(data="done"),
-            EBUS.SendResult(data="21;5 ok"),
+            EBUS.SendResult(data="a b;c"),
         ]
     )
     result = await svc.write_register("hmu", "HwcTempDesired", "a b;c")


### PR DESCRIPTION
Release v1.5.4.

## Added
- Read-only cooling-program calendars from Z1/Z2CoolingTimer (#92)

## Fixed
- DHW boost switch/water-heater desired-state + non-strict HwcSFMode write verification (#31)