### PR TITLE
Release v1.5.5: energy refresh and rediscovery fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 1.5.5 - 2026-09-05
+
+### Fixed
+
+- **Energy counters no longer require a reload (#53, #97).** Supported
+  runtime-defined B516 energy counters are actively read every five minutes,
+  rather than relying on ebusd's unpolled cache. Daily and monthly definitions
+  refresh their date payload during operation, including across month boundaries.
+  Cached counters recover after no-data discovery, and runtime definitions are
+  restored after an ebusd transport reconnect.
+- **Rediscovery adds newly found entities to Home Assistant (#96).** Initial,
+  manual, and delayed discovery now publish additions to loaded platforms without
+  duplicating existing entities. Newly readable fallback registers also generate
+  entities. Discovery logs include the number of new entities; use
+  `export_discovery_dump`, not `rediscover`, to export a capture.
+- **Cached register name casing no longer creates duplicate entities.** Live
+  discovery updates the existing entity's lookup key when ebusd uses different
+  capitalization from the saved cache.
+- **Discovery dumps include the ebusd version (#95).** Dump metadata now uses
+  the connected transport's version instead of leaving it empty.
+
 ## 1.5.4 - 2026-08-27
 
 ### Added

--- a/custom_components/vaillant_ebus/coordinator.py
+++ b/custom_components/vaillant_ebus/coordinator.py
@@ -46,6 +46,7 @@ _LOGGER = logging.getLogger(__name__)
 DELAYED_REDISCOVERY_DELAY = timedelta(minutes=5)
 ANALYSIS_INTERVAL = timedelta(minutes=15)
 PLACEHOLDER_POLL_INTERVAL = timedelta(minutes=15)
+ENERGY_POLL_INTERVAL = timedelta(minutes=5)
 
 # Registers whose live (non-sentinel) value marks a discovered zone as
 # genuinely present. DayTemp/OpMode are excluded: ebusd reports static
@@ -95,12 +96,17 @@ def _merge_entities(
     existing: list[EntityDescription],
     additions: list[EntityDescription],
 ) -> list[EntityDescription]:
-    known = {entity.key for entity in existing}
+    known = {(entity.entity_type, entity.unique_id): entity for entity in existing}
     merged = list(existing)
     for entity in additions:
-        if entity.key not in known:
+        identity = (entity.entity_type, entity.unique_id)
+        if identity not in known:
             merged.append(entity)
-            known.add(entity.key)
+            known[identity] = entity
+        else:
+            # Cache spelling may differ from find; loaded entities keep this
+            # description object, so update its lookup key without re-adding it.
+            known[identity].name = entity.name
     return merged
 
 
@@ -129,6 +135,8 @@ class VaillantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._cancel_analysis: Callable[[], None] | None = None
         self._analysis_scheduled = False
         self._last_placeholder_poll = datetime.min
+        self._last_energy_poll = datetime.min
+        self._runtime_definitions: dict[str, str] = {}
         self._analysis = AnalysisService()
         self.entity_adders: dict[str, Callable[[list[EntityDescription]], None]] = {}
         self._post_discovery_callbacks: list[Callable[[], None]] = []
@@ -278,6 +286,8 @@ class VaillantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self.ebus = ebus
         self.discovery = DiscoveryService(ebus)
         self._ebusd_connected = True
+        self._runtime_definitions.clear()
+        self._last_energy_poll = datetime.min
 
         version = ebus.version
         if version:
@@ -331,22 +341,23 @@ class VaillantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             _LOGGER.warning("%s fallback read failed: %s", source.capitalize(), exc)
 
         generated_entities = self.entity_factory.generate(graph)
-        if previous is not None:
-            existing_entity_keys = {entity.key for entity in self.entities}
-            additions = [entity for entity in generated_entities if entity.key not in existing_entity_keys]
-            self.entities.extend(additions)
-            self._add_new_entities(additions)
-        else:
-            self.entities = generated_entities
+        existing_entity_keys = {(entity.entity_type, entity.unique_id) for entity in self.entities}
+        additions = [entity for entity in generated_entities
+                     if (entity.entity_type, entity.unique_id) not in existing_entity_keys]
+        # Platforms can already be loaded from cache, even on "initial" discovery.
+        # Retain known keys across reconnects to avoid adding the same entity twice.
+        self.entities = _merge_entities(self.entities, generated_entities)
+        self._add_new_entities(additions)
         platform_counts: dict[str, int] = {}
         for entity in self.entities:
             ptype = str(entity.entity_type or "sensor")
             platform_counts[ptype] = platform_counts.get(ptype, 0) + 1
         _LOGGER.info(
-            "Generated %d entity descriptions after %s ebusd discovery: %s",
+            "Generated %d entity descriptions after %s ebusd discovery: %s (%d new entities)",
             len(self.entities),
             source,
             ", ".join(f"{count} {ptype}" for ptype, count in sorted(platform_counts.items())),
+            len(additions),
         )
         self.async_update_listeners()
         for callback in self._post_discovery_callbacks:
@@ -438,6 +449,7 @@ class VaillantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     # Full rediscovery requested by the "rediscover" service: drop the ebusd
     # connection so the next poll reconnects and discovers from scratch.
     async def async_request_rediscover(self) -> None:
+        _LOGGER.info("Manual ebusd rediscovery requested; reconnecting and rebuilding the discovery graph")
         if self.ebus:
             await self.ebus.disconnect()
         self.ebus = None
@@ -499,8 +511,8 @@ class VaillantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # They report environmental yield / electric consumption for cooling
         # regardless of compressor operation, so they also cover passive
         # brine cooling. Verified live against ebusd; values are Wh. Day and
-        # Month variants carry a date payload that must be refreshed on each
-        # (re)connect.
+        # Month variants carry a date payload that must also roll over while
+        # connected. Only changed or previously failed definitions are sent.
         date_bytes = b516_date_bytes(datetime.now())
         defines = [
             "r5,ctlv2,z1RoomHumidity,z1RoomHumidity,31,15,B524,020003002800"
@@ -570,7 +582,7 @@ class VaillantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             # myPyllant app shows a daily "Consumed Electrical Energy Cooling"
             # value). Same b516 API with the electric usage code (Y=3) and the
             # daily X=1 selector, so the layout matches the verified cooling
-            # family; date payload refreshes per connect like CoolEnvYieldDay.
+            # family; date payload rolls over like CoolEnvYieldDay.
             f"r,hmu,CoolElecConsDay,CoolElecConsDay,31,08,B516"
             f",1001ffff0305{date_bytes},value,,IGN:7,,,,value,,EXP,,Wh"
             f",hmu Cooling Electric Consumption Today",
@@ -594,24 +606,29 @@ class VaillantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         defined = 0
         unavailable = 0
         for definition in defines:
-            name = definition.split(",", 2)[2]
+            access, circuit, name = definition.split(",", 3)[:3]
+            key = f"{access}.{circuit}.{name}"
+            if self._runtime_definitions.get(key) == definition:
+                continue
             try:
                 resp = await self.ebus.define_register(definition)
                 if resp.startswith("ERR:"):
                     unavailable += 1
                     _LOGGER.debug("Runtime register unavailable: %s (%s)", name, resp)
                 else:
+                    self._runtime_definitions[key] = definition
                     defined += 1
                     _LOGGER.debug("Runtime register defined: %s", name)
             except Exception as exc:
                 unavailable += 1
                 _LOGGER.warning("Failed to define register: %s", exc)
-        _LOGGER.info(
-            "Runtime register definitions complete: %d defined, %d unavailable, %d total",
-            defined,
-            unavailable,
-            len(defines),
-        )
+        if defined or unavailable:
+            _LOGGER.info(
+                "Runtime register definitions complete: %d defined, %d unavailable, %d total",
+                defined,
+                unavailable,
+                len(defines),
+            )
 
     async def _async_values_from_registers(self, registers: list[EbusdRegister] | None = None) -> dict[str, str]:
         values: dict[str, str] = {}
@@ -721,7 +738,7 @@ class VaillantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     return rk.split(".", 1)[0]
         return None
 
-    async def _fallback_read(self, include_placeholders: bool = False) -> None:
+    async def _fallback_read(self, include_placeholders: bool = False, include_energy: bool = False) -> None:
         if not self.ebus or not self.ebus.is_connected:
             return
         graph_keys = self._last_find_keys
@@ -742,6 +759,16 @@ class VaillantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             if key not in seen:
                 seen.add(key)
                 candidates.append(key)
+
+        # Plain-r B516 definitions are not polled by ebusd. Re-read supported
+        # counters even after find has cached their first value (#53/#97).
+        if include_energy and self._graph:
+            for definition in self._runtime_definitions.values():
+                access, circuit, name, _, _, _, message = definition.split(",", 7)[:7]
+                register = self.registers.get(f"{circuit}.{name}")
+                if (access == "r" and message == "B516" and circuit in self._graph.nodes
+                        and register is not None and register.has_data):
+                    _add(circuit, name)
 
         # Map-driven reads: registers with metadata not yet in the graph.
         for key in REGISTER_MAP:
@@ -798,7 +825,8 @@ class VaillantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     _LOGGER.debug("Fallback read %s = %s", key, value)
             except Exception as exc:
                 _LOGGER.warning("Fallback read failed: %s (%s)", key, exc)
-        if added and self._graph:
+        if self._graph:
+            graph_added = 0
             for key, register in self.registers.items():
                 if not register.has_data or key in self._graph.raw_registers:
                     continue
@@ -810,9 +838,16 @@ class VaillantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     node.registers.append(key)
                 node.has_data = True
                 self._last_find_keys.add(key)
-            _LOGGER.info("Fallback read added %d register(s) to discovery", added)
-        else:
-            _LOGGER.info("Fallback read complete: %d/%d registers with data", read_with_data, len(candidates))
+                graph_added += 1
+            if graph_added:
+                _LOGGER.info("Fallback read added %d register(s) to discovery", graph_added)
+                generated = self.entity_factory.generate(self._graph)
+                known = {(entity.entity_type, entity.unique_id) for entity in self.entities}
+                additions = [entity for entity in generated if (entity.entity_type, entity.unique_id) not in known]
+                self.entities = _merge_entities(self.entities, generated)
+                self._add_new_entities(additions)
+        _LOGGER.info("Fallback read complete: %d/%d registers with data (%d new)",
+                     read_with_data, len(candidates), added)
 
     async def _async_update_data(self) -> dict[str, Any]:
         if not self._cache_seeded:
@@ -827,6 +862,10 @@ class VaillantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         if self.ebus and self.ebus.is_connected:
             try:
+                now = datetime.now()
+                poll_energy = now - self._last_energy_poll >= ENERGY_POLL_INTERVAL
+                if poll_energy:
+                    await self._define_custom_registers()
                 lines = await self.ebus.find_registers()
                 updated = 0
                 for line in lines:
@@ -850,11 +889,12 @@ class VaillantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                         self.registers[key].has_data = True
                         updated += 1
                 self._last_find_keys = {k for k in self.registers}
-                now = datetime.now()
                 poll_placeholders = now - self._last_placeholder_poll >= PLACEHOLDER_POLL_INTERVAL
                 if poll_placeholders:
                     self._last_placeholder_poll = now
-                await self._fallback_read(include_placeholders=poll_placeholders)
+                await self._fallback_read(include_placeholders=poll_placeholders, include_energy=poll_energy)
+                if poll_energy:
+                    self._last_energy_poll = now
                 zero_idle_registers(self.registers, self.heat_pump_circuit)
                 if updated:
                     _LOGGER.info("Poll updated %d registers", updated)
@@ -866,6 +906,8 @@ class VaillantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     # dialed; a skipped single-flight reconnect proves nothing.
                     reconnected = await self.ebus._reconnect() if self.ebus else False
                     if reconnected:
+                        self._runtime_definitions.clear()
+                        self._last_energy_poll = datetime.min
                         await repairs.async_dismiss_ebusd_unreachable(self.hass)
                 except Exception as exc:
                     _LOGGER.error("ebusd reconnect failed: %s", exc)

--- a/custom_components/vaillant_ebus/manifest.json
+++ b/custom_components/vaillant_ebus/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/MarkBovee/vaillant-ebus/issues",
   "requirements": [],
-  "version": "1.5.4"
+  "version": "1.5.5"
 }

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -12,6 +12,8 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
+import pytest
+
 from tests.fake_ebusd import FakeEbusdServer, load_find_lines
 
 PROJECT_ROOT = Path(__file__).parents[1]
@@ -394,6 +396,7 @@ async def test_delayed_rediscovery_adds_new_platform_entities() -> None:
         mock_ebus.read_register = AsyncMock(return_value=None)
         coordinator.ebus = mock_ebus
         await coordinator._apply_discovery_graph(_make_graph(), "initial")
+        additions.reset_mock()
 
         await coordinator._apply_discovery_graph(
             DeviceGraph(
@@ -413,6 +416,164 @@ async def test_delayed_rediscovery_adds_new_platform_entities() -> None:
 
         additions.assert_called_once()
         assert additions.call_args.args[0][0].key == "v32.SupplyAirTemp.value"
+
+
+@pytest.mark.parametrize("seed_cache", [False, True])
+async def test_initial_discovery_pushes_new_entities_once(seed_cache, caplog) -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        c = VaillantCoordinator(_hass(tmpdir), _entry())
+        initial = DISCOVERY.DiscoveryService.build_device_graph(["hmu OutsideTemp = 18.5"])
+        if seed_cache:
+            c._graph = initial
+            c.entities = c.entity_factory.generate(initial)
+        else:
+            await c._apply_discovery_graph(initial, "initial")
+        adder = MagicMock()
+        c.register_entity_adder("sensor", adder)
+        fresh = DISCOVERY.DiscoveryService.build_device_graph(
+            ["hmu OutsideTemp = 18.5", "hmu FlowTemp = 35"]
+        )
+        with caplog.at_level("INFO", logger="vaillant_ebus.coordinator"):
+            await c._apply_discovery_graph(fresh, "initial")
+            await c._apply_discovery_graph(initial, "initial")
+            await c._apply_discovery_graph(fresh, "initial")
+        adder.assert_called_once()
+        assert [e.key for e in adder.call_args.args[0]] == ["hmu.FlowTemp.value"]
+        assert "0 new entities" in caplog.text
+
+
+async def test_runtime_energy_refreshes_without_reload(monkeypatch) -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        c = VaillantCoordinator(_hass(tmpdir), _entry())
+        c._cache_seeded = c._ebusd_connected = True
+        c.ebus = MagicMock(spec=EbusService)
+        c.ebus.is_connected = True
+        c.ebus.define_register = AsyncMock(return_value="done")
+        c.ebus.read_register = AsyncMock(return_value=None)
+        names = ("CoolElecConsDay", "HcElecConsDay", "HwcElecConsDay", "CoolEnvYieldMonth")
+        lines = [f"hmu {name} = 100" for name in names]
+        c.ebus.find_registers = AsyncMock(return_value=lines)
+        c._graph = DISCOVERY.DiscoveryService.build_device_graph(lines)
+        monkeypatch.setattr(COORDINATOR, "REGISTER_MAP", {
+            f"hmu.{name}": MAPPING.REGISTER_MAP[f"hmu.{name}"] for name in names
+        })
+        await c._define_custom_registers()
+        c.ebus.read_register = AsyncMock(return_value="200")
+        values = await c._async_update_data()
+        for name in names:
+            assert values["ebusd"][f"hmu.{name}.value"] == "200"
+        c.ebus.read_register.reset_mock()
+        # A normal poll inside the energy interval uses ebusd's updated cache.
+        c.ebus.find_registers.return_value = [f"hmu {name} = 200" for name in names]
+        await c._async_update_data()
+        c.ebus.read_register.assert_not_awaited()
+        c._last_energy_poll = datetime.min
+        c.ebus.read_register.return_value = "300"
+        values = await c._async_update_data()
+        assert values["ebusd"]["hmu.CoolElecConsDay.value"] == "300"
+
+
+async def test_runtime_definitions_roll_over_and_retry_failures(monkeypatch) -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        c = VaillantCoordinator(_hass(tmpdir), _entry())
+        c.ebus = MagicMock(spec=EbusService)
+        c.ebus.is_connected = True
+        c.ebus.define_register = AsyncMock(return_value="done")
+        clock = MagicMock()
+        clock.now.return_value = datetime(2026, 8, 31, 23, 59)
+        monkeypatch.setattr(COORDINATOR, "datetime", clock)
+        await c._define_custom_registers()
+        c.ebus.define_register.reset_mock()
+        await c._define_custom_registers()
+        c.ebus.define_register.assert_not_awaited()
+        clock.now.return_value = datetime(2026, 9, 1)
+        c.ebus.define_register.return_value = "ERR: temporarily unavailable"
+        await c._define_custom_registers()
+        assert c.ebus.define_register.await_count == 5
+        c.ebus.define_register.reset_mock()
+        c.ebus.define_register.return_value = "done"
+        await c._define_custom_registers()
+        definitions = [call.args[0] for call in c.ebus.define_register.await_args_list]
+        assert len(definitions) == 5
+        date_bytes = MAPPING.b516_date_bytes(clock.now.return_value)
+        assert all(f"{date_bytes},value" in definition for definition in definitions)
+
+
+async def test_fallback_new_register_publishes_entity_once(monkeypatch) -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        c = VaillantCoordinator(_hass(tmpdir), _entry())
+        c._graph = DISCOVERY.DiscoveryService.build_device_graph(["hmu OutsideTemp = 18.5"])
+        c.entities = c.entity_factory.generate(c._graph)
+        c.ebus = MagicMock(spec=EbusService)
+        c.ebus.is_connected = True
+        c.ebus.read_register = AsyncMock(return_value="200")
+        key = "hmu.CoolElecConsDay"
+        monkeypatch.setattr(COORDINATOR, "REGISTER_MAP", {key: MAPPING.REGISTER_MAP[key]})
+        adder = MagicMock()
+        c.register_entity_adder("sensor", adder)
+        await c._fallback_read()
+        await c._apply_discovery_graph(c._graph, "initial")
+        adder.assert_called_once()
+        assert [e.key for e in adder.call_args.args[0]] == [f"{key}.value"]
+
+
+async def test_live_discovery_updates_cached_case_variant_without_duplicate() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        c = VaillantCoordinator(_hass(tmpdir), _entry())
+        c._async_load_cache = AsyncMock(return_value={"ctlv2.HwcSfMode.value": "auto"})
+        await c._async_seed_entities_from_cache()
+        description = next(e for e in c.entities if e.name == "HwcSfMode")
+        adder = MagicMock()
+        c.register_entity_adder(description.entity_type, adder)
+        graph = DISCOVERY.DiscoveryService.build_device_graph(["ctlv2 HwcSFMode = load"])
+        await c._apply_discovery_graph(graph, "initial")
+        adder.assert_not_called()
+        assert description.key == "ctlv2.HwcSFMode.value"
+        assert len({e.unique_id for e in c.entities}) == len(c.entities)
+        values = await c._async_values_from_registers()
+        assert values[description.key] == "load"
+
+
+async def test_cached_energy_recovers_after_no_data_discovery(monkeypatch) -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        c = VaillantCoordinator(_hass(tmpdir), _entry())
+        key = "hmu.CoolElecConsDay"
+        c._async_load_cache = AsyncMock(return_value={f"{key}.value": "100"})
+        await c._async_seed_entities_from_cache()
+        c._cache_seeded = c._ebusd_connected = True
+        c.ebus = MagicMock(spec=EbusService)
+        c.ebus.is_connected = True
+        c.ebus.define_register = AsyncMock(return_value="done")
+        c.ebus.read_register = AsyncMock(return_value=None)
+        monkeypatch.setattr(COORDINATOR, "REGISTER_MAP", {key: MAPPING.REGISTER_MAP[key]})
+        await c._define_custom_registers()
+        graph = DISCOVERY.DiscoveryService.build_device_graph(
+            ["hmu OutsideTemp = 18.5", "hmu CoolElecConsDay = no data stored"]
+        )
+        await c._apply_discovery_graph(graph, "initial")
+        c.ebus.find_registers = AsyncMock(return_value=["hmu CoolElecConsDay = 100"])
+        c.ebus.read_register.return_value = "200"
+        values = await c._async_update_data()
+        assert values["ebusd"][f"{key}.value"] == "200"
+        assert key in c._graph.raw_registers
+
+
+async def test_transport_reconnect_invalidates_runtime_definitions() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        c = VaillantCoordinator(_hass(tmpdir), _entry())
+        c._cache_seeded = c._ebusd_connected = True
+        c.ebus = MagicMock(spec=EbusService)
+        c.ebus.is_connected = True
+        c.ebus.define_register = AsyncMock(return_value="done")
+        await c._define_custom_registers()
+        c.ebus.find_registers = AsyncMock(side_effect=ConnectionError())
+        c.ebus._reconnect = AsyncMock(return_value=True)
+        await c._async_update_data()
+        assert not c._runtime_definitions
+        assert c._last_energy_poll == datetime.min
+        c.ebus.define_register.reset_mock()
+        await c._define_custom_registers()
+        assert c.ebus.define_register.await_count == 27
 
 
 async def test_apply_discovery_logs_entity_platform_breakdown(caplog) -> None:


### PR DESCRIPTION
## Summary

- Actively refresh supported B516 energy counters every five minutes and roll date payloads forward without reloading.
- Restore runtime definitions after reconnect and recover cached counters after no-data discovery.
- Publish newly discovered entities to loaded platforms, including fallback reads, without case-variant duplicates.
- Update the manifest and changelog for v1.5.5. The release also includes the previously merged discovery-dump version fix (#95).

Refs #53, #96, #97. Hardware confirmation remains pending.

## Validation

- 386 tests passed.
- Ruff, compileall, and git diff --check passed.
- Independent review completed with no remaining findings.
- Not deployed or live-tested on Home Assistant.