### PR TITLE
release: v1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 1.6.1 - 2026-09-08
+
+### Added
+
+- **eloBLOCK VE 28 support coverage.** Added metadata and fixture-driven
+  discovery coverage for observed BAI temperature, pressure, heating-stage,
+  status, and energy registers from issue #103.
+- **HMUX0 status coverage.** Added parsed flow/return temperatures for HMUX0
+  `Status01` alongside the confirmed yield/COP fixture coverage from issue #99.
+
 ## 1.6.0 - 2026-09-06
 
 ### Added
@@ -34,6 +44,9 @@
 - **Placeholder defaults.** Unknown registers without usable data no longer
   become enabled entities merely because their device has other live data;
   mapped hardware variants and live energy registers remain supported.
+- **HMUX0 yield/COP coverage.** Added fixture-driven coverage for HMUX0
+  `RunDataReturnTemp`, heating/DHW yield counters, and heating/DHW COP sensors
+  reported in issue #99.
 
 - **Solar controller placeholder device is suppressed.** Registers whose
   semicolon-separated fields are all no-data placeholders no longer make an

--- a/custom_components/vaillant_ebus/backend/mapping.py
+++ b/custom_components/vaillant_ebus/backend/mapping.py
@@ -11,6 +11,8 @@ from .models import RegisterMeta
 # Source: ebusd vaillant CSV (08.hmu.csv) + community dumps.
 MULTI_FIELD_FIELDS: dict[str, list[str]] = {
     "hmu.Status01": ["temp", "temp_1", "temp_2", "temp_3", "temp_4", "pumpstate"],
+    "hmux0.Status01": ["temp", "temp_1", "temp_2", "temp_3", "temp_4", "pumpstate"],
+    "bai.Status01": ["temp", "temp_1", "temp_2", "temp_3", "temp_4", "pumpstate"],
     "hmu.CompressorHc": ["runtime", "cycles"],
     "hmu.CompressorHwc": ["runtime", "cycles"],
     "hmu.RunStatsCompressorHc": ["runtime", "cycles"],
@@ -84,6 +86,44 @@ REGISTER_MAP: dict[str, RegisterMeta] = {
         enabled=False,
     ),
     "hmu.Status01.pumpstate": RegisterMeta(
+        friendly_name="Pump State",
+        entity_type="binary_sensor",
+        entity_category="diagnostic",
+    ),
+    "hmux0.Status01": RegisterMeta(
+        friendly_name="Status",
+        icon="mdi:information",
+        entity_category="diagnostic",
+    ),
+    "hmux0.Status01.temp": RegisterMeta(
+        friendly_name="Flow Temperature",
+        device_class="temperature",
+        unit="°C",
+    ),
+    "hmux0.Status01.temp_1": RegisterMeta(
+        friendly_name="Return Temperature",
+        device_class="temperature",
+        unit="°C",
+    ),
+    "hmux0.Status01.temp_2": RegisterMeta(
+        friendly_name="Outside Temperature",
+        device_class="temperature",
+        unit="°C",
+        enabled=False,
+    ),
+    "hmux0.Status01.temp_3": RegisterMeta(
+        friendly_name="Hot Water Temperature",
+        device_class="temperature",
+        unit="°C",
+        enabled=False,
+    ),
+    "hmux0.Status01.temp_4": RegisterMeta(
+        friendly_name="Storage Temperature",
+        device_class="temperature",
+        unit="°C",
+        enabled=False,
+    ),
+    "hmux0.Status01.pumpstate": RegisterMeta(
         friendly_name="Pump State",
         entity_type="binary_sensor",
         entity_category="diagnostic",
@@ -278,6 +318,56 @@ REGISTER_MAP: dict[str, RegisterMeta] = {
         friendly_name="Yield Cooling Today",
         device_class="energy",
         unit="kWh",
+    ),
+    # eloBLOCK VE 28 / BAI00 community capture (issue #103).
+    "bai.FlowTemp": RegisterMeta(
+        friendly_name="Flow Temperature",
+        device_class="temperature",
+        unit="°C",
+    ),
+    "bai.FlowTempDesired": RegisterMeta(
+        friendly_name="Flow Temperature Desired",
+        device_class="temperature",
+        unit="°C",
+    ),
+    "bai.StorageTemp": RegisterMeta(
+        friendly_name="Storage Temperature",
+        device_class="temperature",
+        unit="°C",
+    ),
+    "bai.StorageTempDesired": RegisterMeta(
+        friendly_name="Storage Temperature Desired",
+        device_class="temperature",
+        unit="°C",
+    ),
+    "bai.WaterPressure": RegisterMeta(
+        friendly_name="Water Pressure",
+        device_class="pressure",
+        unit="bar",
+    ),
+    "bai.HeatingStage1": RegisterMeta(
+        friendly_name="Heating Element Stage 1",
+        entity_type="binary_sensor",
+    ),
+    "bai.HeatingStage3": RegisterMeta(
+        friendly_name="Heating Element Stage 3",
+        entity_type="binary_sensor",
+    ),
+    "bai.ActiveStages": RegisterMeta(
+        friendly_name="Active Heating Stages",
+        entity_category="diagnostic",
+    ),
+    "bai.PrEnergySumHc1": RegisterMeta(
+        friendly_name="Heating Energy Stage 1",
+        device_class="energy",
+        unit="kWh",
+        state_class="total_increasing",
+    ),
+    "bai.PrEnergySumHwc1": RegisterMeta(
+        friendly_name="Hot Water Energy Stage 1",
+        device_class="energy",
+        unit="kWh",
+        state_class="total_increasing",
     ),
     # Runtime-defined b516 cooling-energy registers (issue #50). The bus
     # reports Wh; the unit stays Wh because ebusd returns the raw EXP value.

--- a/custom_components/vaillant_ebus/manifest.json
+++ b/custom_components/vaillant_ebus/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/MarkBovee/vaillant-ebus/issues",
   "requirements": [],
-  "version": "1.6.0"
+  "version": "1.6.1"
 }

--- a/tests/fixtures/community/eloblock_ve28_discovery.yaml
+++ b/tests/fixtures/community/eloblock_ve28_discovery.yaml
@@ -1,0 +1,19 @@
+# Community discovery capture from issue #103 (Vaillant eloBLOCK VE 28).
+metadata:
+  source: github-issue-103
+  device: Vaillant eloBLOCK VE 28
+  hardware: HW7503
+  software: SW0109
+  circuit: bai
+raw_find_lines:
+  - "bai FlowTemp = 28.69;ok"
+  - "bai FlowTempDesired = 0.00"
+  - "bai StorageTemp = 56.12;ok"
+  - "bai StorageTempDesired = 39.00"
+  - "bai WaterPressure = 0.850;ok"
+  - "bai Status01 = 28.5;0.0;21.812;0.0;55.5;off"
+  - "bai HeatingStage1 = off"
+  - "bai HeatingStage3 = off"
+  - "bai ActiveStages = 192"
+  - "bai PrEnergySumHc1 = no data stored"
+  - "bai PrEnergySumHwc1 = no data stored"

--- a/tests/fixtures/community/hmux0_issue99_latest_find.txt
+++ b/tests/fixtures/community/hmux0_issue99_latest_find.txt
@@ -1,0 +1,13 @@
+hmux0 RunDataReturnTemp = 28.2184
+hmux0 RunDataStatuscode = (ERR: invalid position for 3108b50905540200530d / 040208530d)
+hmux0 Status01 = 31.5;28.0;19.797;-;47.5;off
+hmux0 YieldHc = 4662
+hmux0 YieldHcDay = 10.3
+hmux0 YieldHcMonth = 10.3
+hmux0 YieldHwc = 614
+hmux0 YieldHwcDay = 2.3
+hmux0 YieldHwcMonth = 18.7
+hmux0 CopHc = 3.5
+hmux0 CopHcMonth = 4.0
+hmux0 CopHwc = 2.8
+hmux0 CopHwcMonth = 3.1

--- a/tests/fixtures/community/hmux0_yield_cop_find.txt
+++ b/tests/fixtures/community/hmux0_yield_cop_find.txt
@@ -1,0 +1,12 @@
+scan.08  = Vaillant;HMUX0;0303;0504
+hmux0 RunDataReturnTemp = 33.6021
+hmux0 YieldHc = 4652
+hmux0 YieldHcDay = 0.0
+hmux0 YieldHcMonth = 0.0
+hmux0 YieldHwc = 611
+hmux0 YieldHwcDay = 1.8
+hmux0 YieldHwcMonth = 15.0
+hmux0 CopHc = 3.5
+hmux0 CopHcMonth = 1.0
+hmux0 CopHwc = 2.8
+hmux0 CopHwcMonth = 3.1

--- a/tests/test_community_issue_fixtures.py
+++ b/tests/test_community_issue_fixtures.py
@@ -1,0 +1,47 @@
+"""Regression coverage for the latest community captures from issues #99/#103."""
+
+from __future__ import annotations
+
+from tests.fake_ebusd import load_find_lines
+from tests.test_entity_factory import DiscoveryService, EntityFactoryService
+
+
+def test_eloblock_ve28_exposes_observed_bai_registers() -> None:
+    graph = DiscoveryService.build_device_graph(load_find_lines("community/eloblock_ve28_discovery.yaml"))
+    entities = {entity.key: entity for entity in EntityFactoryService().generate(graph)}
+
+    assert graph.nodes["bai"].device_type.name == "HEATING_CONTROLLER"
+    for register in ("FlowTemp", "FlowTempDesired", "StorageTemp", "StorageTempDesired", "WaterPressure"):
+        assert f"bai.{register}.value" in entities
+
+    assert entities["bai.FlowTemp.value"].meta.device_class == "temperature"
+    assert entities["bai.FlowTemp.value"].meta.unit == "°C"
+    assert entities["bai.WaterPressure.value"].meta.device_class == "pressure"
+    assert entities["bai.WaterPressure.value"].meta.unit == "bar"
+    assert entities["bai.Status01.temp"].meta.device_class == "temperature"
+    assert entities["bai.Status01.temp_1"].meta.device_class == "temperature"
+
+
+def test_hmux0_latest_issue99_values_keep_entity_metadata() -> None:
+    graph = DiscoveryService.build_device_graph(load_find_lines("community/hmux0_issue99_latest_find.txt"))
+    entities = {entity.key: entity for entity in EntityFactoryService().generate(graph)}
+
+    for register in (
+        "RunDataReturnTemp",
+        "YieldHc",
+        "YieldHcDay",
+        "YieldHcMonth",
+        "YieldHwc",
+        "YieldHwcDay",
+        "YieldHwcMonth",
+        "CopHc",
+        "CopHcMonth",
+        "CopHwc",
+        "CopHwcMonth",
+    ):
+        assert f"hmux0.{register}.value" in entities
+
+    assert entities["hmux0.RunDataReturnTemp.value"].raw_value == "28.2184"
+    assert entities["hmux0.RunDataReturnTemp.value"].meta.device_class == "temperature"
+    assert entities["hmux0.YieldHc.value"].meta.device_class == "energy"
+    assert entities["hmux0.Status01.temp"].meta.device_class == "temperature"

--- a/tests/test_entity_factory.py
+++ b/tests/test_entity_factory.py
@@ -588,6 +588,30 @@ class TestSourceTempMetadata:
         assert meta.device_class == "temperature"
         assert meta.unit == "°C"
 
+    def test_hmux0_yield_and_cop_entities_from_issue_99_fixture(self) -> None:
+        graph = DiscoveryService.build_device_graph(load_find_lines("community/hmux0_yield_cop_find.txt"))
+        entities = {entity.key: entity for entity in EntityFactoryService().generate(graph)}
+
+        for register in (
+            "RunDataReturnTemp",
+            "YieldHc",
+            "YieldHcDay",
+            "YieldHcMonth",
+            "YieldHwc",
+            "YieldHwcDay",
+            "YieldHwcMonth",
+            "CopHc",
+            "CopHcMonth",
+            "CopHwc",
+            "CopHwcMonth",
+        ):
+            entity = entities.get(f"hmux0.{register}.value")
+            assert entity is not None, register
+            assert entity.enabled_by_default is True, register
+
+        assert entities["hmux0.RunDataReturnTemp.value"].meta.device_class == "temperature"
+        assert entities["hmux0.RunDataReturnTemp.value"].meta.unit == "°C"
+
 
 class TestStateClassSemantics:
     """State class renders history as line graph (issue #54)."""


### PR DESCRIPTION
Release v1.6.1 with eloBLOCK VE 28 and HMUX0 fixture-driven coverage.\n\nValidation: ruff, 397 pytest tests, and compileall pass.