### PR TITLE
release: v1.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 1.6.2 - 2026-09-08
+
+### Added
+
+- **eloBLOCK mode override service.** Added `set_mode_override` and
+  `clear_mode_override` services for the B510 thermostat override, including a
+  50-second keep-alive while enabled.
+- **eloBLOCK gas-entity filtering.** Confirmed eloBLOCK hardware now disables
+  gas and combustion-only BAI entities by default without hiding them from
+  discovery.
+
 ## 1.6.1 - 2026-09-08
 
 ### Added

--- a/custom_components/vaillant_ebus/__init__.py
+++ b/custom_components/vaillant_ebus/__init__.py
@@ -63,6 +63,23 @@ async def _svc_write_parameter(hass: HomeAssistant, call: ServiceCall) -> None:
     _LOGGER.info("write_parameter %s.%s=%s: success=%s", circuit, name, value, ok)
 
 
+# Write the eloBLOCK B510 thermostat override and keep it alive while enabled.
+async def _svc_set_mode_override(hass: HomeAssistant, call: ServiceCall) -> None:
+    coordinator = _resolve_coordinator(hass, call)
+    ok = await coordinator.async_set_mode_override(
+        call.data["flow_temperature"],
+        call.data["storage_temperature"],
+        call.data.get("mode", 0),
+        call.data.get("keep_alive", True),
+    )
+    if not ok:
+        raise HomeAssistantError("SetModeOverride write failed")
+
+
+async def _svc_clear_mode_override(hass: HomeAssistant, call: ServiceCall) -> None:
+    _resolve_coordinator(hass, call).async_clear_mode_override()
+
+
 # Force re-read all active registers.
 async def _svc_refresh(hass: HomeAssistant, call: ServiceCall) -> None:
     coordinator = _resolve_coordinator(hass, call)
@@ -117,6 +134,26 @@ async def _register_services(hass: HomeAssistant) -> None:
                 **_ENTRY_SELECTOR,
             }
         ),
+    )
+    hass.services.async_register(
+        DOMAIN,
+        "set_mode_override",
+        lambda call: _svc_set_mode_override(hass, call),
+        schema=vol.Schema(
+            {
+                vol.Required("flow_temperature"): vol.Coerce(float),
+                vol.Required("storage_temperature"): vol.Coerce(float),
+                vol.Optional("mode", default=0): vol.Coerce(int),
+                vol.Optional("keep_alive", default=True): cv.boolean,
+                **_ENTRY_SELECTOR,
+            }
+        ),
+    )
+    hass.services.async_register(
+        DOMAIN,
+        "clear_mode_override",
+        lambda call: _svc_clear_mode_override(hass, call),
+        schema=vol.Schema(dict(_ENTRY_SELECTOR)),
     )
     hass.services.async_register(
         DOMAIN, "refresh", lambda call: _svc_refresh(hass, call), schema=vol.Schema(dict(_ENTRY_SELECTOR))

--- a/custom_components/vaillant_ebus/backend/entity_factory.py
+++ b/custom_components/vaillant_ebus/backend/entity_factory.py
@@ -6,7 +6,7 @@ import logging
 from copy import copy
 from typing import Any
 
-from .mapping import REGISTER_MAP, get_meta, multi_field_fields, split_multi_field
+from .mapping import ELOBLOCK_GAS_REGISTERS, REGISTER_MAP, get_meta, multi_field_fields, split_multi_field
 from .models import DeviceGraph, DeviceNode, DeviceType, EbusdRegister, RegisterMeta, is_no_data_value
 
 _LOGGER = logging.getLogger(__name__)
@@ -159,6 +159,17 @@ def _determine_enabled_by_default(
     return False
 
 
+def _is_eloblock(graph: DeviceGraph) -> bool:
+    """Identify the confirmed eloBLOCK VE 28 BAI hardware."""
+    for key, raw in graph.raw_registers.items():
+        if not key.lower().endswith(".partnumberbox"):
+            continue
+        normalized = "".join(character for character in (raw or "").lower() if character.isalnum())
+        if normalized == "0020260270":
+            return True
+    return False
+
+
 def _resolve_device_circuit(
     register_key: str,
     node: DeviceNode,
@@ -241,6 +252,7 @@ class EntityFactoryService:
     ) -> list[EntityDescription]:
         """Generate HA entity descriptions from a device graph."""
         overrides = yaml_overrides or {}
+        eloblock = _is_eloblock(graph)
         seen: set[str] = set()
         entities: list[EntityDescription] = []
 
@@ -274,6 +286,8 @@ class EntityFactoryService:
                     "enabled",
                     _determine_enabled_by_default(rk, raw, node.has_data, meta),
                 )
+                if eloblock and circuit.lower() == "bai" and name in ELOBLOCK_GAS_REGISTERS:
+                    entity_enabled = False
 
                 dummy_reg = EbusdRegister(
                     circuit=circuit,

--- a/custom_components/vaillant_ebus/backend/mapping.py
+++ b/custom_components/vaillant_ebus/backend/mapping.py
@@ -6,6 +6,38 @@ from datetime import datetime
 
 from .models import RegisterMeta
 
+# BAI registers that are gas/combustion-specific and do not apply to the
+# electric eloBLOCK. They remain discoverable, but are disabled by default
+# when the confirmed eloBLOCK part number is present.
+ELOBLOCK_GAS_REGISTERS: frozenset[str] = frozenset(
+    {
+        "Gasvalve",
+        "Gasvalve3UC",
+        "GasvalveASICFeedback",
+        "GasvalveUC",
+        "ExternGasvalve",
+        "Fluegasvalve",
+        "FluegasvalveOpen",
+        "FanSpeed",
+        "FanMaxSpeedOperation",
+        "FanMinSpeedOperation",
+        "TargetFanSpeed",
+        "TargetFanSpeedOutput",
+        "Flame",
+        "FlameSensingASIC",
+        "Ignitor",
+        "IonisationVoltageLevel",
+        "AverageIgnitiontime",
+        "MaxIgnitiontime",
+        "CounterStartattempts1",
+        "CounterStartattempts2",
+        "CounterStartAttempts3",
+        "CounterStartAttempts4",
+        "HcStarts",
+        "HwcStarts",
+    }
+)
+
 # Multi-field registers: register key -> field names in semicolon order of the
 # raw ebusd value. Field names follow the ebusd CSV definitions.
 # Source: ebusd vaillant CSV (08.hmu.csv) + community dumps.

--- a/custom_components/vaillant_ebus/coordinator.py
+++ b/custom_components/vaillant_ebus/coordinator.py
@@ -14,7 +14,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_registry import RegistryEntryDisabler
-from homeassistant.helpers.event import async_call_later
+from homeassistant.helpers.event import async_call_later, async_track_time_interval
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from . import repairs
@@ -156,6 +156,8 @@ class VaillantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._last_placeholder_poll = datetime.min
         self._last_energy_poll = datetime.min
         self._runtime_definitions: dict[str, str] = {}
+        self._cancel_set_mode_override: Callable[[], None] | None = None
+        self._set_mode_override_payload: str | None = None
         self._analysis = AnalysisService()
         self.entity_adders: dict[str, Callable[[list[EntityDescription]], None]] = {}
         self._post_discovery_callbacks: list[Callable[[], None]] = []
@@ -574,6 +576,13 @@ class VaillantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         defines = [
             "r5,ctlv2,z1RoomHumidity,z1RoomHumidity,31,15,B524,020003002800"
             ",value,,IGN:4,,,,value,,EXP,,%,z1 Room Humidity",
+            # eloBLOCK B510 thermostat override. It is harmless on hardware
+            # without BAI; ebusd reports it unavailable and filters it out.
+            "wi,bai,SetModeOverride,Operation Mode,,08,B510,00"
+            ",hcmode,,UCH,,,,flowtempdesired,,D1C,,,,hwctempdesired,,D1C"
+            ",,,,hwcflowtempdesired,,UCH,,,,setmode1,,UCH,,,,disablehc,,BI0"
+            ",,,,disablehwctapping,,BI1,,,,disablehwcload,,BI2,,,,setmode2,,UCH"
+            ",,,,remoteControlHcPump,,BI0,,,,releaseBackup,,BI1,,,,releaseCooling,,BI2",
             # B524 heating-circuit state registers (OP=0x02 GG=0x02, RR=0x20..0x25)
             # absent from the shipped CSVs (verified against the installed find
             # output and upstream 15.ctlv2.tsp). Layout documented in the
@@ -1003,7 +1012,43 @@ class VaillantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     ) -> bool:
         return await self.async_write_registers([(circuit, name, value)], strict_verify=strict_verify)
 
+    async def async_set_mode_override(
+        self,
+        flow_temperature: float,
+        storage_temperature: float,
+        mode: int = 0,
+        keep_alive: bool = True,
+    ) -> bool:
+        """Write eloBLOCK B510 override and optionally refresh it periodically."""
+        if not self.ebus or not self.ebus.is_connected:
+            return False
+        payload = f"{mode};{flow_temperature:g};{storage_temperature:g};-;-;0;0;0;-;0;0;0"
+        ok = await self.async_write_register("bai", "SetModeOverride", payload, strict_verify=False)
+        if not ok:
+            return False
+        self.async_clear_mode_override()
+        self._set_mode_override_payload = payload if keep_alive else None
+        if keep_alive:
+            self._cancel_set_mode_override = async_track_time_interval(
+                self.hass, self._async_keep_mode_override_alive, timedelta(seconds=50)
+            )
+        return True
+
+    async def _async_keep_mode_override_alive(self, _now: datetime) -> None:
+        if not self._set_mode_override_payload or not self.ebus or not self.ebus.is_connected:
+            return
+        await self.async_write_register(
+            "bai", "SetModeOverride", self._set_mode_override_payload, strict_verify=False
+        )
+
+    def async_clear_mode_override(self) -> None:
+        if self._cancel_set_mode_override:
+            self._cancel_set_mode_override()
+            self._cancel_set_mode_override = None
+        self._set_mode_override_payload = None
+
     async def async_stop(self) -> None:
+        self.async_clear_mode_override()
         if self._cancel_delayed_rediscovery:
             self._cancel_delayed_rediscovery()
             self._cancel_delayed_rediscovery = None

--- a/custom_components/vaillant_ebus/manifest.json
+++ b/custom_components/vaillant_ebus/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/MarkBovee/vaillant-ebus/issues",
   "requirements": [],
-  "version": "1.6.1"
+  "version": "1.6.2"
 }

--- a/custom_components/vaillant_ebus/services.yaml
+++ b/custom_components/vaillant_ebus/services.yaml
@@ -44,6 +44,59 @@ write_parameter:
       selector:
         text:
 
+set_mode_override:
+  name: Set Mode Override
+  description: Write eloBLOCK B510 thermostat override and optionally keep it alive.
+  fields:
+    flow_temperature:
+      name: Flow Temperature
+      required: true
+      selector:
+        number:
+          min: 0
+          max: 90
+          step: 0.5
+          unit_of_measurement: °C
+    storage_temperature:
+      name: Storage Temperature
+      required: true
+      selector:
+        number:
+          min: 0
+          max: 90
+          step: 0.5
+          unit_of_measurement: °C
+    mode:
+      name: Heating Mode
+      default: 0
+      selector:
+        number:
+          min: 0
+          max: 255
+          step: 1
+    keep_alive:
+      name: Keep Alive
+      default: true
+      selector:
+        boolean:
+    entry_id:
+      name: Config Entry
+      description: Select the integration config entry when multiple are loaded.
+      advanced: true
+      selector:
+        text:
+
+clear_mode_override:
+  name: Clear Mode Override
+  description: Stop sending the eloBLOCK B510 thermostat override.
+  fields:
+    entry_id:
+      name: Config Entry
+      description: Select the integration config entry when multiple are loaded.
+      advanced: true
+      selector:
+        text:
+
 refresh:
   name: Refresh
   description: Force re-read of all active registers.

--- a/tests/fixtures/community/eloblock_ve28_discovery.yaml
+++ b/tests/fixtures/community/eloblock_ve28_discovery.yaml
@@ -17,3 +17,7 @@ raw_find_lines:
   - "bai ActiveStages = 192"
   - "bai PrEnergySumHc1 = no data stored"
   - "bai PrEnergySumHwc1 = no data stored"
+  - "bai PartnumberBox = 00 20 26 02 70"
+  - "bai Gasvalve = off"
+  - "bai FanSpeed = off"
+  - "bai Flame = off"

--- a/tests/test_community_issue_fixtures.py
+++ b/tests/test_community_issue_fixtures.py
@@ -20,6 +20,9 @@ def test_eloblock_ve28_exposes_observed_bai_registers() -> None:
     assert entities["bai.WaterPressure.value"].meta.unit == "bar"
     assert entities["bai.Status01.temp"].meta.device_class == "temperature"
     assert entities["bai.Status01.temp_1"].meta.device_class == "temperature"
+    assert entities["bai.Gasvalve.value"].enabled_by_default is False
+    assert entities["bai.FanSpeed.value"].enabled_by_default is False
+    assert entities["bai.Flame.value"].enabled_by_default is False
 
 
 def test_hmux0_latest_issue99_values_keep_entity_metadata() -> None:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -601,7 +601,7 @@ async def test_transport_reconnect_invalidates_runtime_definitions() -> None:
         assert c._last_energy_poll == datetime.min
         c.ebus.define_register.reset_mock()
         await c._define_custom_registers()
-        assert c.ebus.define_register.await_count == 27
+        assert c.ebus.define_register.await_count == 28
 
 
 async def test_apply_discovery_logs_entity_platform_breakdown(caplog) -> None:
@@ -681,7 +681,7 @@ async def test_define_custom_registers_delegates_to_ebus() -> None:
         c.ebus = mock_ebus
         await c._define_custom_registers()
 
-        assert mock_ebus.define_register.call_count == 27
+        assert mock_ebus.define_register.call_count == 28
         calls = [c.args[0] for c in mock_ebus.define_register.call_args_list]
         assert any("z1RoomHumidity" in d for d in calls)
         assert any("ManualCoolingStartDate" in d and d.startswith("r5") for d in calls)
@@ -813,6 +813,28 @@ async def test_fallback_read_no_ebus_skips() -> None:
         c = VaillantCoordinator(_hass(tmpdir), _entry())
         c.ebus = None
         await c._fallback_read()
+
+
+async def test_set_mode_override_writes_payload_and_schedules_keep_alive() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        c = VaillantCoordinator(_hass(tmpdir), _entry())
+        mock_ebus = MagicMock(spec=EbusService)
+        mock_ebus.is_connected = True
+        mock_ebus.write_register = AsyncMock(return_value=WriteResult(success=True, verified_value="done"))
+        c.ebus = mock_ebus
+
+        c.async_request_refresh = AsyncMock()
+        c._cancel_set_mode_override = MagicMock()
+
+        assert await c.async_set_mode_override(55, 45) is True
+        mock_ebus.write_register.assert_awaited_once_with(
+            "bai", "SetModeOverride", "0;55;45;-;-;0;0;0;-;0;0;0", strict_verify=False
+        )
+        assert c._set_mode_override_payload == "0;55;45;-;-;0;0;0;-;0;0;0"
+        assert c._cancel_set_mode_override is not None
+
+        c.async_clear_mode_override()
+        assert c._set_mode_override_payload is None
 
 
 async def test_fallback_read_polls_known_placeholders() -> None:

--- a/tests/test_hardening_fixes.py
+++ b/tests/test_hardening_fixes.py
@@ -305,7 +305,9 @@ async def test_async_setup_registers_all_services_with_entry_selector() -> None:
         "write_parameter",
         "refresh",
         "rediscover",
-        "analyze_registers",
-        "export_discovery_dump",
-    }
+            "analyze_registers",
+            "export_discovery_dump",
+            "set_mode_override",
+            "clear_mode_override",
+        }
     assert set(registered) == expected


### PR DESCRIPTION
Release v1.6.2 with eloBLOCK B510 mode override services, 50-second keep-alive, and gas-specific default entity filtering.\n\nValidation: ruff, 398 pytest tests, and compileall pass.