### PR TITLE
release: v1.6.3

### DIFF
--- a/.github/scripts/build_release_zip.py
+++ b/.github/scripts/build_release_zip.py
@@ -6,7 +6,10 @@ TMP = "/tmp/_rel"
 os.makedirs(TMP, exist_ok=True)
 
 for root, dirs, files in os.walk("custom_components/vaillant_ebus"):
+    dirs[:] = [directory for directory in dirs if directory != "__pycache__"]
     for f in files:
+        if f.endswith(".pyc"):
+            continue
         fp = os.path.join(root, f)
         rel = os.path.relpath(fp, "custom_components/vaillant_ebus")
         dst = os.path.join(TMP, rel)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,29 +110,39 @@ CSV snippets, `define` strings, `find` output, and per-hardware field layouts th
 ## Community Data (user/upstream dumps)
 
 Data from users and upstream threads (discovery dumps, gists, `find` output, CSV or
-`define` snippets) can **never** be live-tested — the hardware is not ours. That does
-not mean the data stays out of the code; it means we adopt it conservatively so the
-integration keeps working for every other setup.
+`define` snippets) can **never** be live-tested — the hardware is not ours. Strong
+evidence from captures may still justify a conservative production assumption when
+that assumption is isolated, fixture-covered, and safe when the register is absent
+or returns no data.
 
 When adding registers, devices, or metadata derived from community data:
 
 - Add the capture as a fixture under `tests/fixtures/community/` and drive the new code
   from that fixture (see "Test Fixtures"). The fixture replaces live verification as the
   correctness gate.
+- Classify each inferred mapping as `confirmed`, `strong assumption`, or `speculative`.
+  `Confirmed` means the register name and value/layout are explicit. `Strong assumption`
+  means multiple consistent observations or a clear before/after correlation supports the
+  mapping. `Speculative` means evidence is insufficient for production code.
 - Add the entity/register through the existing data-driven paths (`REGISTER_MAP`,
   `MULTI_FIELD_FIELDS`, `_define_custom_registers()`, device-type tables) so it is
   covered by the same discovery/entity-factory logic as everything else. Do not bolt on
   one-off register-specific code paths.
+- `Confirmed` and `strong assumption` mappings may enter production when they use those
+  existing data-driven paths. Document the evidence and keep inferred entities unavailable
+  unless the expected register/value is actually discovered.
 - Keep changes additive and opt-in: enabling a community register/device must not change
   behavior for hardware that does not expose it, and must not crash discovery or entity
   generation when the register is absent.
-- Prefer conservative metadata: only map layouts and read-back values that are explicit
-  in the capture. Do not fabricate field layouts from a single untested snippet.
+- Prefer conservative metadata: map layouts and read-back values explicit in the capture;
+  for strong assumptions, document the evidence and do not fabricate a field layout from
+  an isolated or contradictory snippet.
 - Add a regression test that loads the fixture and asserts the expected register/entity
   appears on the discovered device graph without error.
+- For inferred mappings, also assert that the absent-register path remains safe.
 - If the data is incomplete or ambiguous, prefer a discovery-only or YAML-override
-  approach over a hardcoded production path, and flag the uncertainty to the owner
-  rather than guessing in code.
+  approach until evidence reaches `strong assumption`, and flag the uncertainty to the
+  owner rather than presenting it as verified hardware behavior.
 
 ## Known Limitations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 1.6.3 - 2026-09-09
+
+### Fixed
+
+- **Async service execution.** Integration services now register real async
+  callbacks, preventing `coroutine was never awaited` warnings when services
+  are run from Home Assistant Actions.
+- **Controller holiday reset handling.** `01.01.2015` and `01.01.2019` are
+  treated as unset holiday values for DHW, zone, climate, and datetime entities.
+
+### Added
+
+- Added fixture coverage for aroTHERM Pro Quiet-mode captures, HMUX0 DHW and
+  holiday data, and ecoTEC/VRT380 controller variants.
+
 ## 1.6.2 - 2026-09-08
 
 ### Added

--- a/custom_components/vaillant_ebus/__init__.py
+++ b/custom_components/vaillant_ebus/__init__.py
@@ -42,6 +42,13 @@ def _resolve_coordinator(hass: HomeAssistant, call: ServiceCall) -> VaillantCoor
     )
 
 
+def _service_handler(hass: HomeAssistant, handler):
+    async def callback(call: ServiceCall) -> None:
+        await handler(hass, call)
+
+    return callback
+
+
 # Read a single register by circuit and name.
 async def _svc_read_parameter(hass: HomeAssistant, call: ServiceCall) -> None:
     coordinator = _resolve_coordinator(hass, call)
@@ -112,7 +119,7 @@ async def _register_services(hass: HomeAssistant) -> None:
     hass.services.async_register(
         DOMAIN,
         "read_parameter",
-        lambda call: _svc_read_parameter(hass, call),
+        _service_handler(hass, _svc_read_parameter),
         schema=vol.Schema(
             {
                 vol.Required("circuit"): cv.string,
@@ -125,7 +132,7 @@ async def _register_services(hass: HomeAssistant) -> None:
     hass.services.async_register(
         DOMAIN,
         "write_parameter",
-        lambda call: _svc_write_parameter(hass, call),
+        _service_handler(hass, _svc_write_parameter),
         schema=vol.Schema(
             {
                 vol.Required("circuit"): cv.string,
@@ -138,7 +145,7 @@ async def _register_services(hass: HomeAssistant) -> None:
     hass.services.async_register(
         DOMAIN,
         "set_mode_override",
-        lambda call: _svc_set_mode_override(hass, call),
+        _service_handler(hass, _svc_set_mode_override),
         schema=vol.Schema(
             {
                 vol.Required("flow_temperature"): vol.Coerce(float),
@@ -152,28 +159,28 @@ async def _register_services(hass: HomeAssistant) -> None:
     hass.services.async_register(
         DOMAIN,
         "clear_mode_override",
-        lambda call: _svc_clear_mode_override(hass, call),
+        _service_handler(hass, _svc_clear_mode_override),
         schema=vol.Schema(dict(_ENTRY_SELECTOR)),
     )
     hass.services.async_register(
-        DOMAIN, "refresh", lambda call: _svc_refresh(hass, call), schema=vol.Schema(dict(_ENTRY_SELECTOR))
+        DOMAIN, "refresh", _service_handler(hass, _svc_refresh), schema=vol.Schema(dict(_ENTRY_SELECTOR))
     )
     hass.services.async_register(
         DOMAIN,
         "rediscover",
-        lambda call: _svc_rediscover(hass, call),
+        _service_handler(hass, _svc_rediscover),
         schema=vol.Schema(dict(_ENTRY_SELECTOR)),
     )
     hass.services.async_register(
         DOMAIN,
         "analyze_registers",
-        lambda call: _svc_analyze(hass, call),
+        _service_handler(hass, _svc_analyze),
         schema=vol.Schema(dict(_ENTRY_SELECTOR)),
     )
     hass.services.async_register(
         DOMAIN,
         "export_discovery_dump",
-        lambda call: _svc_export_discovery_dump(hass, call),
+        _service_handler(hass, _svc_export_discovery_dump),
         schema=vol.Schema({vol.Optional("grab_duration"): vol.Coerce(int), **_ENTRY_SELECTOR}),
     )
 

--- a/custom_components/vaillant_ebus/climate.py
+++ b/custom_components/vaillant_ebus/climate.py
@@ -52,6 +52,7 @@ COOLING_STATES = frozenset(
 DATE_FMT = "%d.%m.%Y"
 TIME_FMT = "%H:%M:%S"
 HOLIDAY_RESET = "01.01.2015"
+HOLIDAY_RESET_VALUES = frozenset(("01.01.2015", "01.01.2019"))
 
 # Measured against live ctlv2 hardware (2026-08-24): quick-veto writes return
 # done immediately, but the controller applies them with roughly 30-60 s
@@ -257,7 +258,7 @@ class EbusdClimate(CoordinatorEntity[VaillantCoordinator], ClimateEntity):
             return PRESET_BOOST
         h_start = _value(self.coordinator, f"{self._zn}HolidayStartPeriod", self._circuit)
         h_end = _value(self.coordinator, f"{self._zn}HolidayEndPeriod", self._circuit)
-        if h_start and h_end and h_start != HOLIDAY_RESET:
+        if h_start and h_end and h_start not in HOLIDAY_RESET_VALUES and h_end not in HOLIDAY_RESET_VALUES:
             try:
                 today = now.date()
                 start = datetime.strptime(h_start, DATE_FMT).date()

--- a/custom_components/vaillant_ebus/datetime.py
+++ b/custom_components/vaillant_ebus/datetime.py
@@ -16,9 +16,14 @@ from .coordinator import VaillantCoordinator
 
 DATE_FMT = "%d.%m.%Y"
 TIME_FMT = "%H:%M:%S"
-HOLIDAY_RESET = "01.01.2015"
+HOLIDAY_RESET_VALUES = frozenset(("01.01.2015", "01.01.2019"))
 
 DEFAULT_TIME = "00:00:00"
+
+
+def _is_holiday_reset(value: object) -> bool:
+    """Return whether controller value represents an unset holiday period."""
+    return str(value) in HOLIDAY_RESET_VALUES
 
 HOLIDAY_ENTITIES = [
     ("Z1 Holiday Start", "Z1HolidayStartPeriod", "mdi:calendar-start", "z1"),
@@ -72,7 +77,7 @@ class EbusdQuickVetoEndEntity(CoordinatorEntity[VaillantCoordinator], DateTimeEn
         c = self.coordinator.heating_circuit
         end_date = data.get(f"{c}.Z1QuickVetoEndDate.value")
         end_time = data.get(f"{c}.Z1QuickVetoEndTime.value")
-        if not end_date or not end_time or end_date == HOLIDAY_RESET:
+        if not end_date or not end_time or _is_holiday_reset(end_date):
             return None
         try:
             naive = datetime.strptime(f"{end_date} {end_time}", f"{DATE_FMT} {TIME_FMT}")
@@ -105,7 +110,7 @@ class EbusdHolidayEntity(CoordinatorEntity[VaillantCoordinator], DateTimeEntity)
     @property
     def native_value(self) -> datetime | None:
         raw = self.coordinator.data.get("ebusd", {}).get(f"{self.coordinator.heating_circuit}.{self._register}.value")
-        if not raw or str(raw) == HOLIDAY_RESET:
+        if not raw or _is_holiday_reset(raw):
             return None
         try:
             naive = datetime.strptime(f"{raw} {DEFAULT_TIME}", f"{DATE_FMT} {TIME_FMT}")

--- a/custom_components/vaillant_ebus/manifest.json
+++ b/custom_components/vaillant_ebus/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/MarkBovee/vaillant-ebus/issues",
   "requirements": [],
-  "version": "1.6.2"
+  "version": "1.6.3"
 }

--- a/custom_components/vaillant_ebus/switch.py
+++ b/custom_components/vaillant_ebus/switch.py
@@ -22,6 +22,7 @@ _LOGGER = logging.getLogger(__name__)
 SWITCH_ON_VALUES = {"1", "on", "true", "yes"}
 FAR_FUTURE = "01.01.2099"
 UNSET_DATE = "01.01.2015"
+UNSET_DATES = frozenset(("01.01.2015", "01.01.2019"))
 
 
 # Create switch entities and away-mode switch
@@ -115,6 +116,8 @@ def _parse_date(raw: str | None) -> date | None:
 
 # Check if today falls within holiday period
 def _is_holiday_active(start_raw: str | None, end_raw: str | None) -> bool:
+    if start_raw in UNSET_DATES or end_raw in UNSET_DATES:
+        return False
     start = _parse_date(start_raw)
     end = _parse_date(end_raw)
     if start is None or end is None:

--- a/custom_components/vaillant_ebus/water_heater.py
+++ b/custom_components/vaillant_ebus/water_heater.py
@@ -29,6 +29,7 @@ OPERATION_MODES = ["off", "auto", "manual", "boost"]
 
 DATE_FMT = "%d.%m.%Y"
 HOLIDAY_RESET = "01.01.2015"
+HOLIDAY_RESET_VALUES = frozenset(("01.01.2015", "01.01.2019"))
 
 
 # Look up a string value from coordinator ebusd data by register name
@@ -87,7 +88,7 @@ class EbusdWaterHeater(CoordinatorEntity[VaillantCoordinator], WaterHeaterEntity
     def is_away_mode_on(self) -> bool | None:
         h_start = _value(self.coordinator, "HwcHolidayStartPeriod")
         h_end = _value(self.coordinator, "HwcHolidayEndPeriod")
-        if not h_start or not h_end:
+        if not h_start or not h_end or h_start in HOLIDAY_RESET_VALUES or h_end in HOLIDAY_RESET_VALUES:
             return None
         try:
             now = date.today()

--- a/docs/community-dump-plan.md
+++ b/docs/community-dump-plan.md
@@ -1,0 +1,53 @@
+# Community Dump Processing Plan
+
+## Goal
+
+Process every new community capture as a fixture first, then change production code only when the register layout and behavior are supported by the captures. Do not guess registers from screenshots or add ebusd CSV overrides.
+
+## Capture groups
+
+- Issue #101: three aroTHERM Pro captures for Quiet mode: idle/off, heating/off, and heating/on. Identify `NoiseReduction`, `NoiseReductionFactor`, and timer registers.
+- Issue #99: latest aroTHERM VWL 55/8.2 HMUX0 capture. Trace `ctlv3` DHW entity state and holiday start/end behavior; HMUX0 yield/COP coverage already exists.
+- Discussion #33: ecoTEC Plus and VRT380 captures using `15.700` and `15.ctlv2`, plus the ebusd log. Compare controller layouts, writable registers, BAI data, and gas/DHW registers.
+- Issue #103: eloBLOCK VE 28 capture. Compare with the existing fixture and add only confirmed BAI/B510 behavior.
+- Discussion #107: no capture yet. Request discovery, state timestamps, and logs before investigating stale energy values.
+
+## Workflow
+
+1. Download and normalize every attachment.
+2. Store new community captures under `tests/fixtures/community/` as discovery-dump YAML where possible.
+3. Add fixture-load and discovery/entity regression tests before production changes.
+4. Compare captures from the same hardware and classify registers as supported, missing, unavailable, read-only, or writable.
+5. Implement only confirmed mappings through existing discovery, `REGISTER_MAP`, runtime definitions, and entity-factory paths.
+6. Keep `no data stored`, empty, and error responses unavailable; never expose them as normal values.
+7. Keep service lifecycle regression #106 separate from register work.
+8. Run focused tests, then the complete validation suite.
+
+## Implementation order
+
+1. Quiet mode register comparison and fixture coverage.
+2. HMUX0 DHW and holiday entity tracing.
+3. ecoTEC/VRT380 controller comparison and write-path analysis.
+4. eloBLOCK fixture comparison.
+5. Service async regression #106.
+6. Stale energy values from Discussion #107.
+7. Energy Manager State and defrost behavior after reliable status data exists.
+
+## Validation
+
+```text
+pytest -q tests/test_fake_ebusd.py
+pytest -q tests/test_community_issue_fixtures.py
+pytest -q tests/test_entity_factory.py tests/test_discovery_service.py
+pytest -q
+.venv/bin/ruff check .
+python3 -m compileall -f custom_components/vaillant_ebus/
+```
+
+## GitHub follow-up
+
+- Report confirmed Quiet mode registers and remaining conditional behavior on #101.
+- Report HMUX0 coverage and keep DHW/holiday behavior as separate follow-up on #99.
+- Explain the confirmed VRT380 controller layout and writable limitations in Discussion #33.
+- Reply to #103 only with confirmed eloBLOCK behavior.
+- Request the missing capture and logs for Discussion #107 before promising a fix.

--- a/tests/fixtures/community/arotherm_hmux0_dhw_holiday_discovery.yaml
+++ b/tests/fixtures/community/arotherm_hmux0_dhw_holiday_discovery.yaml
@@ -1,0 +1,20312 @@
+# Discovery dump for vaillant_ebus
+# Review this file for sensitive information before sharing
+metadata:
+  timestamp: '2026-09-07T21:21:54.163432'
+  ebusd_version: ebusd 26.1.26.1
+  register_count: 1036
+  grab_duration: 10
+  dump_version: 3
+raw_find_lines:
+- bai SetModeOverride = no data stored
+- Broadcast Datetime = no data stored
+- Broadcast Error = no data stored
+- Broadcast HwcStatus = no data stored
+- Broadcast Id = no data stored
+- Broadcast IdAnswer = no data stored
+- Broadcast IdQuery = no data stored
+- Broadcast Load = no data stored
+- Broadcast Outsidetemp = 23.047
+- Broadcast Queryexistence = no data stored
+- Broadcast Signoflife = no data stored
+- Broadcast Vdatetime = 21:20:37;07.09.2026
+- Broadcast Vdatetime = no data stored
+- 'ctlv2 Hc1DewPointTemp =  (ERR: invalid position for 3115b52406020002002300 / 00)'
+- 'ctlv2 Hc1FlowTempCalc =  (ERR: invalid position for 3115b52406020002002000 / 050102200002)'
+- 'ctlv2 Hc1Humidity =  (ERR: invalid position for 3115b52406020002002200 / 00)'
+- 'ctlv2 Hc1MixerPosition =  (ERR: invalid position for 3115b52406020002002100 / 00)'
+- 'ctlv2 Hc1PumpHours =  (ERR: invalid position for 3115b52406020002002400 / 00)'
+- 'ctlv2 Hc1PumpStarts =  (ERR: invalid position for 3115b52406020002002500 / 00)'
+- 'ctlv2 Hc2DewPointTemp =  (ERR: invalid position for 3115b52406020002012300 / 00)'
+- 'ctlv2 Hc2FlowTempCalc =  (ERR: invalid position for 3115b52406020002012000 / 050002200000)'
+- 'ctlv2 Hc2Humidity =  (ERR: invalid position for 3115b52406020002012200 / 00)'
+- 'ctlv2 Hc2MixerPosition =  (ERR: invalid position for 3115b52406020002012100 / 00)'
+- 'ctlv2 Hc2PumpHours =  (ERR: invalid position for 3115b52406020002012400 / 00)'
+- 'ctlv2 Hc2PumpStarts =  (ERR: invalid position for 3115b52406020002012500 / 00)'
+- ctlv2 ManualCoolingEndDate = 01.01.2019
+- ctlv2 ManualCoolingEndDate = no data stored
+- ctlv2 ManualCoolingStartDate = 01.01.2019
+- ctlv2 ManualCoolingStartDate = no data stored
+- ctlv2 z1RoomHumidity = 65
+- ctlv3 AdaptHeatCurve = no
+- ctlv3 AdaptHeatCurve = no data stored
+- ctlv3 CcTimer_Config = 00 03 0a 00 00 00 ff ff 00
+- ctlv3 CcTimer_Friday0 = 00:00;00:00
+- ctlv3 CcTimer_Friday1 = no data stored
+- ctlv3 CcTimer_Friday2 = 00:00;00:00
+- ctlv3 CcTimer_Friday = no data stored
+- ctlv3 CcTimer_Monday0 = 00:00;00:00
+- ctlv3 CcTimer_Monday1 = 00:00;00:00
+- ctlv3 CcTimer_Monday2 = 00:00;00:00
+- ctlv3 CcTimer_Monday = no data stored
+- ctlv3 CcTimer_Saturday0 = 00:00;00:00
+- ctlv3 CcTimer_Saturday1 = 00:00;00:00
+- ctlv3 CcTimer_Saturday2 = 00:00;00:00
+- ctlv3 CcTimer_Saturday = no data stored
+- ctlv3 CcTimer_Sunday0 = 00:00;00:00
+- ctlv3 CcTimer_Sunday1 = 00:00;00:00
+- ctlv3 CcTimer_Sunday2 = 00:00;00:00
+- ctlv3 CcTimer_Sunday = no data stored
+- ctlv3 CcTimer_Thursday0 = 00:00;00:00
+- ctlv3 CcTimer_Thursday1 = no data stored
+- ctlv3 CcTimer_Thursday2 = no data stored
+- ctlv3 CcTimer_Thursday = no data stored
+- ctlv3 CcTimer_Timeframes = 0;0;0;0;0;0;0
+- ctlv3 CcTimer_Tuesday0 = no data stored
+- ctlv3 CcTimer_Tuesday1 = no data stored
+- ctlv3 CcTimer_Tuesday2 = no data stored
+- ctlv3 CcTimer_Tuesday = no data stored
+- ctlv3 CcTimer_Wednesday0 = no data stored
+- ctlv3 CcTimer_Wednesday1 = no data stored
+- ctlv3 CcTimer_Wednesday2 = no data stored
+- ctlv3 CcTimer_Wednesday = no data stored
+- ctlv3 Clearerrorhistory = no data stored
+- ctlv3 ContinuousHeating = -26
+- ctlv3 ContinuousHeating = no data stored
+- ctlv3 Currenterror = -;-;-;-;-
+- ctlv3 CylinderChargeHyst = 7
+- ctlv3 CylinderChargeHyst = no data stored
+- ctlv3 CylinderChargeOffset = 8
+- ctlv3 CylinderChargeOffset = no data stored
+- ctlv3 Date = 07.09.2026
+- ctlv3 Date = no data stored
+- ctlv3 DisplayedOutsideTemp = 23
+- ctlv3 Errorhistory = no data stored
+- ctlv3 FrostOverRideTime = 4
+- ctlv3 FrostOverRideTime = no data stored
+- ctlv3 Hc1ActualFlowTempDesired = 0.0
+- ctlv3 Hc1AutoOffMode = night
+- ctlv3 Hc1AutoOffMode = no data stored
+- ctlv3 Hc1CircuitType = mixer
+- ctlv3 Hc1ExcessTemp = 0.0
+- ctlv3 Hc1ExcessTemp = no data stored
+- ctlv3 Hc1FlowTemp = 26
+- ctlv3 Hc1HeatCurve = 0.25
+- ctlv3 Hc1HeatCurve = no data stored
+- ctlv3 Hc1HeatCurveAdaption = 0.0
+- ctlv3 Hc1MaxFlowTempDesired = 50
+- ctlv3 Hc1MaxFlowTempDesired = no data stored
+- ctlv3 Hc1MinCoolingTempDesired = 20
+- ctlv3 Hc1MinCoolingTempDesired = no data stored
+- ctlv3 Hc1MinFlowTempDesired = 30
+- ctlv3 Hc1MinFlowTempDesired = no data stored
+- ctlv3 Hc1MixerMovement = 0.0
+- ctlv3 Hc1PumpStatus = 0
+- ctlv3 Hc1PumpStatus = no data stored
+- ctlv3 Hc1RoomTempSwitchOn = off
+- ctlv3 Hc1RoomTempSwitchOn = no data stored
+- ctlv3 Hc1Status = 0
+- ctlv3 Hc1Status = no data stored
+- ctlv3 Hc1SummerTempLimit = 14
+- ctlv3 Hc1SummerTempLimit = no data stored
+- ctlv3 Hc2ActualFlowTempDesired = 0.0
+- ctlv3 Hc2AutoOffMode = eco
+- ctlv3 Hc2AutoOffMode = no data stored
+- ctlv3 Hc2CircuitType = inactive
+- ctlv3 Hc2ExcessTemp = 0.0
+- ctlv3 Hc2ExcessTemp = no data stored
+- ctlv3 Hc2FlowTemp =  (empty for 3115b52406020002010800 / 0800020800ffffff7f)
+- ctlv3 Hc2HeatCurve = 0.6
+- ctlv3 Hc2HeatCurve = no data stored
+- ctlv3 Hc2HeatCurveAdaption = 0.0
+- ctlv3 Hc2MaxFlowTempDesired = 55
+- ctlv3 Hc2MaxFlowTempDesired = no data stored
+- ctlv3 Hc2MinCoolingTempDesired = 20
+- ctlv3 Hc2MinCoolingTempDesired = no data stored
+- ctlv3 Hc2MinFlowTempDesired = 15
+- ctlv3 Hc2MinFlowTempDesired = no data stored
+- ctlv3 Hc2MixerMovement = 0.0
+- ctlv3 Hc2PumpStatus = 0
+- ctlv3 Hc2PumpStatus = no data stored
+- ctlv3 Hc2RoomTempSwitchOn = off
+- ctlv3 Hc2RoomTempSwitchOn = no data stored
+- ctlv3 Hc2Status = 0
+- ctlv3 Hc2Status = no data stored
+- ctlv3 Hc2SummerTempLimit = 16
+- ctlv3 Hc2SummerTempLimit = no data stored
+- ctlv3 Hc3ActualFlowTempDesired = 0.0
+- ctlv3 Hc3AutoOffMode = eco
+- ctlv3 Hc3AutoOffMode = no data stored
+- ctlv3 Hc3CircuitType = inactive
+- ctlv3 Hc3ExcessTemp = 0.0
+- ctlv3 Hc3ExcessTemp = no data stored
+- ctlv3 Hc3FlowTemp =  (empty for 3115b52406020002020800 / 0800020800ffffff7f)
+- ctlv3 Hc3HeatCurve = 0.6
+- ctlv3 Hc3HeatCurve = no data stored
+- ctlv3 Hc3HeatCurveAdaption = 0.0
+- ctlv3 Hc3MaxFlowTempDesired = 55
+- ctlv3 Hc3MaxFlowTempDesired = no data stored
+- ctlv3 Hc3MinCoolingTempDesired = 20
+- ctlv3 Hc3MinCoolingTempDesired = no data stored
+- ctlv3 Hc3MinFlowTempDesired = 15
+- ctlv3 Hc3MinFlowTempDesired = no data stored
+- ctlv3 Hc3MixerMovement = 0.0
+- ctlv3 Hc3PumpStatus = 0
+- ctlv3 Hc3PumpStatus = no data stored
+- ctlv3 Hc3RoomTempSwitchOn = off
+- ctlv3 Hc3RoomTempSwitchOn = no data stored
+- ctlv3 Hc3Status = 0
+- ctlv3 Hc3Status = no data stored
+- ctlv3 Hc3SummerTempLimit = 16
+- ctlv3 Hc3SummerTempLimit = no data stored
+- ctlv3 HcStorageTempBottom =  (empty for f115b5240602000000a000 / 080000a000ffffff7f)
+- ctlv3 HcStorageTempTop =  (empty for f115b52406020000009f00 / 0800009f00ffffff7f)
+- ctlv3 HwcBankHolidayEndPeriod = no data stored
+- ctlv3 HwcBankHolidayEndPeriod = no data stored
+- ctlv3 HwcBankHolidayStartPeriod = no data stored
+- ctlv3 HwcBankHolidayStartPeriod = no data stored
+- ctlv3 HwcFlowTemp = 0.0
+- ctlv3 HwcHolidayEndPeriod = 01.01.2015
+- ctlv3 HwcHolidayEndPeriod = no data stored
+- ctlv3 HwcHolidayStartPeriod = 01.01.2015
+- ctlv3 HwcHolidayStartPeriod = no data stored
+- ctlv3 HwcLockTime = 60
+- ctlv3 HwcLockTime = no data stored
+- ctlv3 HwcMaxFlowTempDesired = 80
+- ctlv3 HwcMaxFlowTempDesired = no data stored
+- ctlv3 HwcOpMode = auto
+- ctlv3 HwcOpMode = no data stored
+- ctlv3 HwcParallelLoading = off
+- ctlv3 HwcParallelLoading = no data stored
+- ctlv3 HwcSFMode = auto
+- ctlv3 HwcSFMode = no data stored
+- ctlv3 HwcStorageTemp = 42
+- ctlv3 HwcStorageTempBottom =  (empty for f115b52406020000009e00 / 0800009e00ffffff7f)
+- ctlv3 HwcStorageTempTop =  (empty for f115b52406020000009d00 / 0800009d00ffffff7f)
+- ctlv3 HwcTempDesired = 50
+- ctlv3 HwcTempDesired = no data stored
+- ctlv3 HwcTimer_Config = no data stored
+- ctlv3 HwcTimer_Friday0 = no data stored
+- ctlv3 HwcTimer_Friday1 = no data stored
+- ctlv3 HwcTimer_Friday2 = no data stored
+- ctlv3 HwcTimer_Friday = no data stored
+- ctlv3 HwcTimer_Monday0 = no data stored
+- ctlv3 HwcTimer_Monday1 = no data stored
+- ctlv3 HwcTimer_Monday2 = no data stored
+- ctlv3 HwcTimer_Monday = no data stored
+- ctlv3 HwcTimer_Saturday0 = no data stored
+- ctlv3 HwcTimer_Saturday1 = no data stored
+- ctlv3 HwcTimer_Saturday2 = no data stored
+- ctlv3 HwcTimer_Saturday = no data stored
+- ctlv3 HwcTimer_Sunday0 = no data stored
+- ctlv3 HwcTimer_Sunday1 = no data stored
+- ctlv3 HwcTimer_Sunday2 = no data stored
+- ctlv3 HwcTimer_Sunday = no data stored
+- ctlv3 HwcTimer_Thursday0 = no data stored
+- ctlv3 HwcTimer_Thursday1 = no data stored
+- ctlv3 HwcTimer_Thursday2 = no data stored
+- ctlv3 HwcTimer_Thursday = no data stored
+- ctlv3 HwcTimer_Timeframes = no data stored
+- ctlv3 HwcTimer_Tuesday0 = no data stored
+- ctlv3 HwcTimer_Tuesday1 = no data stored
+- ctlv3 HwcTimer_Tuesday2 = no data stored
+- ctlv3 HwcTimer_Tuesday = no data stored
+- ctlv3 HwcTimer_Wednesday0 = no data stored
+- ctlv3 HwcTimer_Wednesday1 = no data stored
+- ctlv3 HwcTimer_Wednesday2 = no data stored
+- ctlv3 HwcTimer_Wednesday = no data stored
+- ctlv3 HydraulicScheme = 8
+- ctlv3 HydraulicScheme = no data stored
+- ctlv3 Installer1 = no data stored
+- ctlv3 Installer1 = no data stored
+- ctlv3 Installer2 = no data stored
+- ctlv3 Installer2 = no data stored
+- ctlv3 KeyCodeforConfigMenu = no data stored
+- ctlv3 KeyCodeforConfigMenu = no data stored
+- ctlv3 MaintenanceDate = no data stored
+- ctlv3 MaintenanceDate = no data stored
+- ctlv3 MaintenanceDue = no data stored
+- ctlv3 MaxCylinderChargeTime = 90
+- ctlv3 MaxCylinderChargeTime = no data stored
+- ctlv3 MaxRoomHumidity = 40
+- ctlv3 MaxRoomHumidity = no data stored
+- ctlv3 MultiRelaySetting = circulation
+- ctlv3 MultiRelaySetting = no data stored
+- ctlv3 OutsideTempAvg = 19.8516
+- ctlv3 OutsideTempAvg = no data stored
+- ctlv3 PhoneNumber1 = no data stored
+- ctlv3 PhoneNumber1 = no data stored
+- ctlv3 PhoneNumber2 = no data stored
+- ctlv3 PhoneNumber2 = no data stored
+- 'ctlv3 PrEnergySum =  (ERR: invalid position for 3115b52406020000005c00 / 00)'
+- ctlv3 PrEnergySum = no data stored
+- ctlv3 PrEnergySumHc = 1792
+- ctlv3 PrEnergySumHc = no data stored
+- ctlv3 PrEnergySumHcLastMonth = 15
+- ctlv3 PrEnergySumHcLastMonth = no data stored
+- ctlv3 PrEnergySumHcThisMonth = 3
+- ctlv3 PrEnergySumHcThisMonth = no data stored
+- ctlv3 PrEnergySumHwc = 327
+- ctlv3 PrEnergySumHwc = no data stored
+- ctlv3 PrEnergySumHwcLastMonth = 41
+- ctlv3 PrEnergySumHwcLastMonth = no data stored
+- ctlv3 PrEnergySumHwcThisMonth = 8
+- ctlv3 PrEnergySumHwcThisMonth = no data stored
+- ctlv3 PrFuelSum = no data stored
+- ctlv3 PrFuelSum = no data stored
+- ctlv3 PrFuelSumHc = no data stored
+- ctlv3 PrFuelSumHc = no data stored
+- ctlv3 PrFuelSumHcLastMonth = no data stored
+- ctlv3 PrFuelSumHcLastMonth = no data stored
+- ctlv3 PrFuelSumHcThisMonth = no data stored
+- ctlv3 PrFuelSumHcThisMonth = no data stored
+- ctlv3 PrFuelSumHwc = no data stored
+- ctlv3 PrFuelSumHwc = no data stored
+- ctlv3 PrFuelSumHwcLastMonth = no data stored
+- ctlv3 PrFuelSumHwcLastMonth = no data stored
+- ctlv3 PrFuelSumHwcThisMonth = no data stored
+- ctlv3 PrFuelSumHwcThisMonth = no data stored
+- ctlv3 PumpAdditionalTime = no data stored
+- ctlv3 PumpAdditionalTime = no data stored
+- ctlv3 SolarYieldTotal = no data stored
+- ctlv3 SolarYieldTotal = no data stored
+- ctlv3 SystemFlowTemp =  (empty for f115b52406020000004b00 / 0800004b00ffffff7f)
+- ctlv3 Time = no data stored
+- ctlv3 Time = no data stored
+- ctlv3 WaterPressure = 1.9
+- ctlv3 YieldTotal = 5277
+- ctlv3 YieldTotal = no data stored
+- ctlv3 Z1ActualRoomTempDesired = 0.0
+- ctlv3 Z1ActualRoomTempDesired = no data stored
+- ctlv3 Z1BankHolidayEndPeriod = no data stored
+- ctlv3 Z1BankHolidayEndPeriod = no data stored
+- ctlv3 Z1BankHolidayStartPeriod = no data stored
+- ctlv3 Z1BankHolidayStartPeriod = no data stored
+- ctlv3 Z1CoolingTemp = 24
+- ctlv3 Z1CoolingTemp = no data stored
+- ctlv3 Z1DayTemp = 19
+- ctlv3 Z1DayTemp = no data stored
+- ctlv3 Z1HolidayEndPeriod = 09.10.2027
+- ctlv3 Z1HolidayEndPeriod = no data stored
+- ctlv3 Z1HolidayStartPeriod = 26.09.2026
+- ctlv3 Z1HolidayStartPeriod = no data stored
+- ctlv3 Z1HolidayTemp = 15
+- ctlv3 Z1HolidayTemp = no data stored
+- ctlv3 Z1Name1 = no data stored
+- ctlv3 Z1Name1 = no data stored
+- ctlv3 Z1Name2 = no data stored
+- ctlv3 Z1Name2 = no data stored
+- ctlv3 Z1NightTemp = 18
+- ctlv3 Z1NightTemp = no data stored
+- ctlv3 Z1OpMode = auto
+- ctlv3 Z1OpMode = no data stored
+- ctlv3 Z1QuickVetoDuration = 3
+- ctlv3 Z1QuickVetoDuration = no data stored
+- ctlv3 Z1QuickVetoEndDate = 07.09.2026
+- ctlv3 Z1QuickVetoEndTime = 04:02:00
+- ctlv3 Z1QuickVetoTemp = 20
+- ctlv3 Z1QuickVetoTemp = no data stored
+- ctlv3 Z1RoomTemp = 21.9125
+- ctlv3 Z1RoomZoneMapping = no data stored
+- ctlv3 Z1RoomZoneMapping = no data stored
+- ctlv3 Z1SFMode = auto
+- ctlv3 Z1SFMode = no data stored
+- ctlv3 Z1Shortname = no data stored
+- ctlv3 Z1Shortname = no data stored
+- ctlv3 Z1Timer_Config = no data stored
+- ctlv3 Z1Timer_Friday0 = no data stored
+- ctlv3 Z1Timer_Friday1 = no data stored
+- ctlv3 Z1Timer_Friday2 = no data stored
+- ctlv3 Z1Timer_Friday = no data stored
+- ctlv3 Z1Timer_Monday0 = no data stored
+- ctlv3 Z1Timer_Monday1 = no data stored
+- ctlv3 Z1Timer_Monday2 = no data stored
+- ctlv3 Z1Timer_Monday = no data stored
+- ctlv3 Z1Timer_Saturday0 = no data stored
+- ctlv3 Z1Timer_Saturday1 = no data stored
+- ctlv3 Z1Timer_Saturday2 = no data stored
+- ctlv3 Z1Timer_Saturday = no data stored
+- ctlv3 Z1Timer_Sunday0 = no data stored
+- ctlv3 Z1Timer_Sunday1 = no data stored
+- ctlv3 Z1Timer_Sunday2 = no data stored
+- ctlv3 Z1Timer_Sunday = no data stored
+- ctlv3 Z1Timer_Thursday0 = no data stored
+- ctlv3 Z1Timer_Thursday1 = no data stored
+- ctlv3 Z1Timer_Thursday2 = no data stored
+- ctlv3 Z1Timer_Thursday = no data stored
+- ctlv3 Z1Timer_Timeframes = no data stored
+- ctlv3 Z1Timer_Tuesday0 = no data stored
+- ctlv3 Z1Timer_Tuesday1 = no data stored
+- ctlv3 Z1Timer_Tuesday2 = no data stored
+- ctlv3 Z1Timer_Tuesday = no data stored
+- ctlv3 Z1Timer_Wednesday0 = no data stored
+- ctlv3 Z1Timer_Wednesday1 = no data stored
+- ctlv3 Z1Timer_Wednesday2 = no data stored
+- ctlv3 Z1Timer_Wednesday = no data stored
+- ctlv3 Z1ValveStatus = no data stored
+- ctlv3 Z1ValveStatus = no data stored
+- ctlv3 Z2ActualRoomTempDesired = no data stored
+- ctlv3 Z2ActualRoomTempDesired = no data stored
+- ctlv3 Z2BankHolidayEndPeriod = no data stored
+- ctlv3 Z2BankHolidayEndPeriod = no data stored
+- ctlv3 Z2BankHolidayStartPeriod = no data stored
+- ctlv3 Z2BankHolidayStartPeriod = no data stored
+- ctlv3 Z2CoolingTemp = no data stored
+- ctlv3 Z2CoolingTemp = no data stored
+- ctlv3 Z2DayTemp = no data stored
+- ctlv3 Z2DayTemp = no data stored
+- ctlv3 Z2HolidayEndPeriod = no data stored
+- ctlv3 Z2HolidayEndPeriod = no data stored
+- ctlv3 Z2HolidayStartPeriod = no data stored
+- ctlv3 Z2HolidayStartPeriod = no data stored
+- ctlv3 Z2HolidayTemp = no data stored
+- ctlv3 Z2HolidayTemp = no data stored
+- ctlv3 Z2Name1 = no data stored
+- ctlv3 Z2Name1 = no data stored
+- ctlv3 Z2Name2 = no data stored
+- ctlv3 Z2Name2 = no data stored
+- ctlv3 Z2NightTemp = no data stored
+- ctlv3 Z2NightTemp = no data stored
+- ctlv3 Z2OpMode = no data stored
+- ctlv3 Z2OpMode = no data stored
+- ctlv3 Z2QuickVetoDuration = no data stored
+- ctlv3 Z2QuickVetoDuration = no data stored
+- ctlv3 Z2QuickVetoEndDate = no data stored
+- ctlv3 Z2QuickVetoEndTime = no data stored
+- ctlv3 Z2QuickVetoTemp = no data stored
+- ctlv3 Z2QuickVetoTemp = no data stored
+- ctlv3 Z2RoomTemp =  (empty for 3115b52406020003010f00 / 0802030f00ffffff7f)
+- ctlv3 Z2RoomZoneMapping = no data stored
+- ctlv3 Z2RoomZoneMapping = no data stored
+- ctlv3 Z2SFMode = no data stored
+- ctlv3 Z2SFMode = no data stored
+- ctlv3 Z2Shortname = no data stored
+- ctlv3 Z2Shortname = no data stored
+- ctlv3 Z2Timer_Config = no data stored
+- ctlv3 Z2Timer_Friday0 = no data stored
+- ctlv3 Z2Timer_Friday1 = no data stored
+- ctlv3 Z2Timer_Friday2 = no data stored
+- ctlv3 Z2Timer_Friday = no data stored
+- ctlv3 Z2Timer_Monday0 = no data stored
+- ctlv3 Z2Timer_Monday1 = no data stored
+- ctlv3 Z2Timer_Monday2 = no data stored
+- ctlv3 Z2Timer_Monday = no data stored
+- ctlv3 Z2Timer_Saturday0 = no data stored
+- ctlv3 Z2Timer_Saturday1 = no data stored
+- ctlv3 Z2Timer_Saturday2 = no data stored
+- ctlv3 Z2Timer_Saturday = no data stored
+- ctlv3 Z2Timer_Sunday0 = no data stored
+- ctlv3 Z2Timer_Sunday1 = no data stored
+- ctlv3 Z2Timer_Sunday2 = no data stored
+- ctlv3 Z2Timer_Sunday = no data stored
+- ctlv3 Z2Timer_Thursday0 = no data stored
+- ctlv3 Z2Timer_Thursday1 = no data stored
+- ctlv3 Z2Timer_Thursday2 = no data stored
+- ctlv3 Z2Timer_Thursday = no data stored
+- ctlv3 Z2Timer_Timeframes = no data stored
+- ctlv3 Z2Timer_Tuesday0 = no data stored
+- ctlv3 Z2Timer_Tuesday1 = no data stored
+- ctlv3 Z2Timer_Tuesday2 = no data stored
+- ctlv3 Z2Timer_Tuesday = no data stored
+- ctlv3 Z2Timer_Wednesday0 = no data stored
+- ctlv3 Z2Timer_Wednesday1 = no data stored
+- ctlv3 Z2Timer_Wednesday2 = no data stored
+- ctlv3 Z2Timer_Wednesday = no data stored
+- ctlv3 Z2ValveStatus = no data stored
+- ctlv3 Z2ValveStatus = no data stored
+- ctlv3 Z3ActualRoomTempDesired = no data stored
+- ctlv3 Z3ActualRoomTempDesired = no data stored
+- ctlv3 Z3BankHolidayEndPeriod = no data stored
+- ctlv3 Z3BankHolidayEndPeriod = no data stored
+- ctlv3 Z3BankHolidayStartPeriod = no data stored
+- ctlv3 Z3BankHolidayStartPeriod = no data stored
+- ctlv3 Z3DayTemp = no data stored
+- ctlv3 Z3DayTemp = no data stored
+- ctlv3 Z3HolidayEndPeriod = no data stored
+- ctlv3 Z3HolidayEndPeriod = no data stored
+- ctlv3 Z3HolidayStartPeriod = no data stored
+- ctlv3 Z3HolidayStartPeriod = no data stored
+- ctlv3 Z3HolidayTemp = no data stored
+- ctlv3 Z3HolidayTemp = no data stored
+- ctlv3 Z3Name1 = no data stored
+- ctlv3 Z3Name1 = no data stored
+- ctlv3 Z3Name2 = no data stored
+- ctlv3 Z3Name2 = no data stored
+- ctlv3 Z3NightTemp = no data stored
+- ctlv3 Z3NightTemp = no data stored
+- ctlv3 Z3OpMode = no data stored
+- ctlv3 Z3OpMode = no data stored
+- ctlv3 Z3QuickVetoDuration = no data stored
+- ctlv3 Z3QuickVetoDuration = no data stored
+- ctlv3 Z3QuickVetoEndDate = no data stored
+- ctlv3 Z3QuickVetoEndTime = no data stored
+- ctlv3 Z3QuickVetoTemp = no data stored
+- ctlv3 Z3QuickVetoTemp = no data stored
+- ctlv3 Z3RoomTemp = no data stored
+- ctlv3 Z3RoomZoneMapping = no data stored
+- ctlv3 Z3RoomZoneMapping = no data stored
+- ctlv3 Z3SFMode = no data stored
+- ctlv3 Z3SFMode = no data stored
+- ctlv3 Z3Shortname = no data stored
+- ctlv3 Z3Shortname = no data stored
+- ctlv3 Z3Timer_Config = no data stored
+- ctlv3 Z3Timer_Friday0 = no data stored
+- ctlv3 Z3Timer_Friday1 = no data stored
+- ctlv3 Z3Timer_Friday2 = no data stored
+- ctlv3 Z3Timer_Friday = no data stored
+- ctlv3 Z3Timer_Monday0 = no data stored
+- ctlv3 Z3Timer_Monday1 = no data stored
+- ctlv3 Z3Timer_Monday2 = no data stored
+- ctlv3 Z3Timer_Monday = no data stored
+- ctlv3 Z3Timer_Saturday0 = no data stored
+- ctlv3 Z3Timer_Saturday1 = no data stored
+- ctlv3 Z3Timer_Saturday2 = no data stored
+- ctlv3 Z3Timer_Saturday = no data stored
+- ctlv3 Z3Timer_Sunday0 = no data stored
+- ctlv3 Z3Timer_Sunday1 = no data stored
+- ctlv3 Z3Timer_Sunday2 = no data stored
+- ctlv3 Z3Timer_Sunday = no data stored
+- ctlv3 Z3Timer_Thursday0 = no data stored
+- ctlv3 Z3Timer_Thursday1 = no data stored
+- ctlv3 Z3Timer_Thursday2 = no data stored
+- ctlv3 Z3Timer_Thursday = no data stored
+- ctlv3 Z3Timer_Timeframes = no data stored
+- ctlv3 Z3Timer_Tuesday0 = no data stored
+- ctlv3 Z3Timer_Tuesday1 = no data stored
+- ctlv3 Z3Timer_Tuesday2 = no data stored
+- ctlv3 Z3Timer_Tuesday = no data stored
+- ctlv3 Z3Timer_Wednesday0 = no data stored
+- ctlv3 Z3Timer_Wednesday1 = no data stored
+- ctlv3 Z3Timer_Wednesday2 = no data stored
+- ctlv3 Z3Timer_Wednesday = no data stored
+- ctlv3 Z3ValveStatus = no data stored
+- ctlv3 Z3ValveStatus = no data stored
+- General Valuerange = no data stored
+- hmu CoolElecConsDay = 0.0
+- hmu CoolElecConsTotal = 0.0
+- hmu CoolEnvYieldDay = 0.0
+- hmu CoolEnvYieldMonth = 0.0
+- hmu CoolEnvYieldTotal = 0.0
+- hmu HcElecConsDay = 133.058
+- hmu HcElecConsTotal = 1.70677e+06
+- hmu HwcElecConsDay = 996.237
+- hmu HwcElecConsTotal = 325181
+- 'hmu SourceTempInput =  (ERR: invalid position for 3108b51a0405ff3222 / 02ff01)'
+- hmux0 AirIntakeTemp = no data stored
+- hmux0 BuildingCircuitFlow = 0
+- hmux0 BuildingPumpHours = no data stored
+- hmux0 BuildingPumpHours = no data stored
+- hmux0 BuildingPumpStarts = no data stored
+- hmux0 BuildingPumpStarts = no data stored
+- hmux0 Clearerrorhistory = no data stored
+- hmux0 CompressorHours = no data stored
+- hmux0 CompressorHours = no data stored
+- hmux0 CompressorHysteresisCooling = no data stored
+- hmux0 CompressorHysteresisHc = no data stored
+- hmux0 CompressorStarts = no data stored
+- hmux0 CompressorStarts = no data stored
+- hmux0 ConsumptionThisYear10 = no data stored
+- hmux0 ConsumptionThisYear11 = no data stored
+- hmux0 ConsumptionThisYear12 = no data stored
+- hmux0 ConsumptionThisYear1 = no data stored
+- hmux0 ConsumptionThisYear2 = no data stored
+- hmux0 ConsumptionThisYear3 = no data stored
+- hmux0 ConsumptionThisYear4 = no data stored
+- hmux0 ConsumptionThisYear5 = no data stored
+- hmux0 ConsumptionThisYear6 = no data stored
+- hmux0 ConsumptionThisYear7 = no data stored
+- hmux0 ConsumptionThisYear8 = no data stored
+- hmux0 ConsumptionThisYear9 = no data stored
+- 'hmux0 ConsumptionTotal =  (ERR: invalid position for 3108b516021802 / 00)'
+- hmux0 CopHc = 3.5
+- hmux0 CopHcMonth = 3.8
+- hmux0 CopHwc = 2.8
+- hmux0 CopHwcMonth = 3.1
+- hmux0 CurrentCompressorUtil = 0.00
+- hmux0 CurrentConsumedPower = 0.0
+- hmux0 Currenterror = -;-;-;-;-
+- hmux0 CurrentYieldPower = 0.0
+- hmux0 DateTime = valid;21:20:39;07.09.2026;23.000
+- hmux0 EEVSteps = no data stored
+- hmux0 EEVSteps = no data stored
+- hmux0 EnableiveMonitorMain =  (empty for f108b503020003 / 0a6400ffffffffffffffff)
+- hmux0 EnableTestCompressorExitTemp = no data stored
+- hmux0 EnableTestCompressorIntakeTemp = no data stored
+- hmux0 EnableTestCompressorSpeed = no data stored
+- hmux0 EnableTestCondensateTemp = no data stored
+- hmux0 EnableTestEEVPosition = no data stored
+- hmux0 EnableTestEEVTemp = no data stored
+- hmux0 EnableTestEvaporationTemp = no data stored
+- hmux0 EnableTestFlowTemp = no data stored
+- hmux0 EnableTestHighPress = no data stored
+- hmux0 EnableTestReturnTemp = no data stored
+- hmux0 EnableTestWaterThroughput = no data stored
+- hmux0 EnergyIntegral = no data stored
+- hmux0 Errorhistory = no data stored
+- hmux0 Fan1Hours = no data stored
+- hmux0 Fan1Hours = no data stored
+- hmux0 Fan1Starts = no data stored
+- hmux0 Fan1Starts = no data stored
+- hmux0 Fan2Hours = no data stored
+- hmux0 Fan2Hours = no data stored
+- hmux0 Fan2Starts = no data stored
+- hmux0 Fan2Starts = no data stored
+- hmux0 FlowPressure = no data stored
+- 'hmux0 FlowTemp =  (ERR: invalid position for 3108b51a0405ff3220 / 02ff01)'
+- hmux0 FourWayValveHours = no data stored
+- hmux0 FourWayValveHours = no data stored
+- hmux0 FourWayValveSwitches = no data stored
+- hmux0 FourWayValveSwitches = no data stored
+- hmux0 FourWayValveSwitchingOperations = no data stored
+- hmux0 FourWayValveSwitchingOperations = no data stored
+- hmux0 HcBivalencePoint = no data stored
+- hmux0 HcModeActive = no data stored
+- hmux0 HeatCurve = no data stored
+- hmux0 Hours = no data stored
+- hmux0 HoursCool = 0
+- hmux0 HoursHc = no data stored
+- hmux0 HoursHwc = no data stored
+- hmux0 HwcBivalencePoint = no data stored
+- hmux0 HwcChargeHysteresis = no data stored
+- hmux0 HwcMode = no data stored
+- hmux0 HwcModeActive = no data stored
+- hmux0 ImmersionHeaterMode = no data stored
+- hmux0 LiveMonitorAirIntakeTemp = no data stored
+- hmux0 LiveMonitorCurrentCompressorUtil = no data stored
+- hmux0 LiveMonitorCurrentConsumedPower = 0.0
+- hmux0 LiveMonitorCurrentSupplyTemp = no data stored
+- hmux0 LiveMonitorCurrentYieldPower = no data stored
+- hmux0 LiveMonitorDesiredSupplyTemp = no data stored
+- hmux0 LiveMonitorMain = no data stored
+- hmux0 MaxFlowTemp = no data stored
+- hmux0 MinFlowTemp = no data stored
+- hmux0 RunDataAirInletTemp = 21.25
+- hmux0 RunDataBuildingCPumpPower = 0.0
+- hmux0 RunDataCompressorInletTemp = 22.6875
+- hmux0 RunDataCompressorOutletTemp = 23.4375
+- hmux0 RunDataCompressorSpeed = 0.0
+- hmux0 RunDataEEVOutletTemp = 21.375
+- hmux0 RunDataEEVPositionAbs = 250
+- hmux0 RunDataElectricPowerConsumption = 6
+- hmux0 RunDataFan1Speed = 0.0
+- hmux0 RunDataFan2Speed = 0.0
+- hmux0 RunDataFlowTemp = no data stored
+- hmux0 RunDataHighPressure = 13.8
+- hmux0 RunDataReturnTemp = 22.2981
+- 'hmux0 RunDataStatuscode =  (ERR: invalid position for 3108b50905540200530d / 040208530d)'
+- hmux0 RunStats4PortValveHours = 50
+- hmux0 RunStats4PortValveSwitches = 387
+- hmux0 RunStatsBuildingCPumpStarts = 358
+- hmux0 RunStatsBuildingPumpHours = 2153
+- hmux0 RunStatsCompressorHc = no data stored
+- hmux0 RunStatsCompressorHours = 1862
+- hmux0 RunStatsCompressorHwc = no data stored
+- hmux0 RunStatsCompressorStarts = 1865
+- hmux0 RunStatsFan1Hours = 1908
+- hmux0 RunStatsFan1Starts = 2178
+- hmux0 RunStatsFan2Hours = 0
+- hmux0 RunStatsFan2Starts = 0
+- hmux0 RunStatsHcHours = 1761
+- hmux0 RunStatsHMUHours = 5433
+- hmux0 RunStatsHwcHours = 136
+- hmux0 SetMode = auto;0.0;-;-;1;1;1;0;0;0
+- hmux0 SourcePressure = no data stored
+- 'hmux0 SourceTempOutput =  (ERR: invalid position for 3108b51a0405ff3227 / 02ff01)'
+- hmux0 StatBuildingPumpHours = no data stored
+- hmux0 StatBuildingPumpStarts = no data stored
+- hmux0 StatCompressorHours = no data stored
+- hmux0 StatCompressorStarts = no data stored
+- hmux0 State = no data stored
+- hmux0 StatEEVSteps = no data stored
+- hmux0 StatFan1Hours = no data stored
+- hmux0 StatFan1Starts = no data stored
+- hmux0 StatFourWayValveHours = no data stored
+- hmux0 StatFourWayValveSwitchingOperations = no data stored
+- hmux0 Status01 = 26.0;22.0;23.047;-;42.0;off
+- hmux0 Status02 = no data stored
+- hmux0 Status16 = no data stored
+- hmux0 Status = no data stored
+- hmux0 StatusCirPump = off
+- hmux0 SummerSwitchOffTemp = no data stored
+- hmux0 TargetFlowTemp = no data stored
+- hmux0 TargetTempHc = no data stored
+- hmux0 TargetTempHwc = no data stored
+- hmux0 TestAirIntakeTemp = no data stored
+- hmux0 TestBuildingPumpPower = no data stored
+- hmux0 TestBuildingWaterPress = no data stored
+- hmux0 TestCompressorExitTemp = no data stored
+- hmux0 TestCompressorInletTemp = no data stored
+- hmux0 TestCompressorSpeed = no data stored
+- hmux0 TestCondensateTemp = no data stored
+- hmux0 TestCondensateTrayHeater = no data stored
+- hmux0 TestCondensorInletTemp = no data stored
+- hmux0 TestCondensorOutletTemp = no data stored
+- hmux0 TestCylinderTemp = no data stored
+- hmux0 TestDCFStatus = no data stored
+- hmux0 TestEEVOutletTemp = no data stored
+- hmux0 TestEEVPosition = no data stored
+- hmux0 TestEEVTemp = no data stored
+- hmux0 TestEvaporationTemp = no data stored
+- hmux0 TestFan1 = no data stored
+- hmux0 TestFan2 = no data stored
+- hmux0 TestFlowTemp = no data stored
+- hmux0 TestFlowTempImmersionHeater = no data stored
+- hmux0 TestFourWayValve = no data stored
+- hmux0 TestHeatingCoilCompressor = no data stored
+- hmux0 TestHighPress = no data stored
+- hmux0 TestHighPressureSwitch = no data stored
+- hmux0 TestImmersionHeaterSafetyCutOut = no data stored
+- hmux0 TestLockoutContactS20 = no data stored
+- hmux0 TestLockoutContactS21 = no data stored
+- hmux0 TestLowPress = no data stored
+- hmux0 TestMA1Output = no data stored
+- hmux0 TestMIInput = no data stored
+- hmux0 TestMO2Output = no data stored
+- hmux0 TestMO3Output = no data stored
+- hmux0 TestOutdoorTemp = no data stored
+- hmux0 TestOverheatingActualValue = no data stored
+- hmux0 TestOverheatingTargetValue = no data stored
+- hmux0 TestPrioritySwitchingValve = no data stored
+- hmux0 TestReturnTemp = no data stored
+- hmux0 TestSubcoolingActualValue = no data stored
+- hmux0 TestSubcoolingTargetValue = no data stored
+- hmux0 TestSystemTemp = no data stored
+- hmux0 TestTempSwitchCompressorOutlet = no data stored
+- hmux0 TestWaterThroughput = no data stored
+- hmux0 TotalEnergyUsage = 2031
+- hmux0 YieldCoolDay = 0.0
+- hmux0 YieldHc = 4662
+- hmux0 YieldHcDay = 0.0
+- hmux0 YieldHcMonth = 10.3
+- hmux0 YieldHwc = 616
+- hmux0 YieldHwcDay = 1.9
+- hmux0 YieldHwcMonth = 20.7
+- hmux0 YieldThisYear10 = no data stored
+- hmux0 YieldThisYear11 = no data stored
+- hmux0 YieldThisYear12 = no data stored
+- hmux0 YieldThisYear1 = no data stored
+- hmux0 YieldThisYear2 = no data stored
+- hmux0 YieldThisYear3 = no data stored
+- hmux0 YieldThisYear4 = no data stored
+- hmux0 YieldThisYear5 = no data stored
+- hmux0 YieldThisYear6 = no data stored
+- hmux0 YieldThisYear7 = no data stored
+- hmux0 YieldThisYear8 = no data stored
+- hmux0 YieldThisYear9 = no data stored
+- 'hmux0 YieldTotal =  (ERR: invalid position for 3108b516021801 / 00)'
+- Memory Eeprom = no data stored
+- Memory Eeprom = no data stored
+- Memory Ram = no data stored
+- Memory Ram = no data stored
+- sc Clearerrorhistory = no data stored
+- sc Col = no data stored
+- sc ColKickPumpTime = no data stored
+- sc ColKickTempDelta = no data stored
+- sc CollPump = no data stored
+- sc Currenterror = no data stored
+- sc D1Temp = no data stored
+- sc D2Temp = no data stored
+- sc Date = no data stored
+- sc EDFunction = no data stored
+- sc EDFunction = no data stored
+- sc EnableScProtection = no data stored
+- sc EnableScProtection = no data stored
+- sc Errorhistory = no data stored
+- sc FlowRate = no data stored
+- sc FlowRate = no data stored
+- sc FrostProtectionEnabled = no data stored
+- sc FrostProtectionLimit = no data stored
+- sc Hc1PumpKol1PP1Port = no data stored
+- sc Hc2aLegPumpP2Port = no data stored
+- sc Hc2zPort = no data stored
+- sc HydraulicScheme = no data stored
+- sc InitCircuit = no data stored
+- sc Iotest = no data stored
+- sc Ioteststop = no data stored
+- sc IsInBoostMode = no data stored
+- sc KickFunction = no data stored
+- sc KickFunction = no data stored
+- sc LpZpMaPort = no data stored
+- sc MAPreferredStorage = no data stored
+- sc MAPreferredStorage = no data stored
+- sc MaximalTemp2 = no data stored
+- sc MaximalTemp2 = no data stored
+- sc MaximalTemp = no data stored
+- sc MaximalTemp = no data stored
+- sc MultifunctionOutput = no data stored
+- sc OMultifunction = no data stored
+- sc OMultifunction = no data stored
+- sc PumpAntiLockingFlags = no data stored
+- sc QuickVetoStart = no data stored
+- sc ResetSolGain = no data stored
+- sc ResetSolGain = no data stored
+- sc RuntimeCollPump = no data stored
+- sc RuntimeCollPumpSeconds = no data stored
+- sc ScProtectionHysteresis = no data stored
+- sc ScProtectionLimit = no data stored
+- sc ScProtectionLimit = no data stored
+- sc ScProtectionTime = no data stored
+- sc SolCollPumpDcIntegrator = no data stored
+- sc SolCollPumpED = no data stored
+- sc SolGain = no data stored
+- sc SolOperationMode = no data stored
+- sc SP1 = no data stored
+- sc SP2 = no data stored
+- sc SumSolGain = no data stored
+- sc SumSolGainDayBefore = no data stored
+- sc SystemMode = no data stored
+- sc TempDifferenceOff2 = no data stored
+- sc TempDifferenceOff2 = no data stored
+- sc TempDifferenceOff = no data stored
+- sc TempDifferenceOff = no data stored
+- sc TempDifferenceOffTD12 = no data stored
+- sc TempDifferenceOffTD12 = no data stored
+- sc TempDifferenceOn2 = no data stored
+- sc TempDifferenceOn2 = no data stored
+- sc TempDifferenceOn = no data stored
+- sc TempDifferenceOn = no data stored
+- sc TempDifferenceOnTD12 = no data stored
+- sc TempDifferenceOnTD12 = no data stored
+- sc Time = no data stored
+- sc Weekday = no data stored
+- sc YieldLastYear = no data stored
+- 'sc YieldThisYear =  (ERR: invalid position for 31ecb509030d3f00 / 00)'
+- Scan Id = no data stored
+- scan.04  = Vaillant;NETX3;0129;0404
+- scan.08  = Vaillant;HMUX0;0303;0504
+- scan.15  = Vaillant;CTLV3;0808;8004
+- Scan.15 Id = 21;25;41;0010045478;0953;051794;N2
+- scan.76  = Vaillant;VWZIO;0303;0504
+- Scan.76 Id = 21;25;47;0010039571;3110;005964;N6
+- scan.ec  = Vaillant;SOL00;0808;8004
+- Scan.ec Id = 21;25;41;0010045478;0953;051794;N2
+- scan.f6  = Vaillant;NETX3;0129;0404
+- vwzio EnableTestHwcTemp = no data stored
+- vwzio EnableTestOutdoorTemp = no data stored
+- vwzio EnableTestThreeWayValve = no data stored
+- vwzio TestHwcTemp = no data stored
+- vwzio TestOutdoorTemp = no data stored
+- vwzio TestThreeWayValve = no data stored
+- ''
+before_registers:
+- circuit: Broadcast
+  name: Datetime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Error
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: Broadcast
+  name: HwcStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Id
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: IdAnswer
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: IdQuery
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Load
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Outsidetemp
+  fields:
+  - value
+  values:
+  - '23.047'
+  writable: false
+  has_data: true
+- circuit: Broadcast
+  name: Queryexistence
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Signoflife
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Vdatetime
+  fields:
+  - value
+  values:
+  - 21:20:37;07.09.2026
+  writable: false
+  has_data: true
+- circuit: Broadcast
+  name: Vdatetime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: WaterPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: General
+  name: Valuerange
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Eeprom
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Eeprom
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Ram
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Ram
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Scan
+  name: Id
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Scan.15
+  name: Id
+  fields:
+  - value
+  values:
+  - 21;25;41;0010045478;0953;051794;N2
+  writable: false
+  has_data: true
+- circuit: Scan.76
+  name: Id
+  fields:
+  - value
+  values:
+  - 21;25;47;0010039571;3110;005964;N6
+  writable: false
+  has_data: true
+- circuit: Scan.ec
+  name: Id
+  fields:
+  - value
+  values:
+  - 21;25;41;0010045478;0953;051794;N2
+  writable: false
+  has_data: true
+- circuit: bai
+  name: ActiveStages
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: bai
+  name: FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: bai
+  name: FlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: bai
+  name: HeatingStage1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: bai
+  name: HeatingStage3
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: bai
+  name: PrEnergySumHc1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: bai
+  name: PrEnergySumHwc1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: bai
+  name: SetModeOverride
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: StorageTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: bai
+  name: StorageTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: bai
+  name: WaterPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: AdaptHeatCurve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: CcTimer_Config
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: CcTimer_Timeframes
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: ContinuousHeating
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: CylinderChargeHyst
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: CylinderChargeOffset
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Date
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: DisplayedOutsideTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: FrostOverRideTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1AutoOffMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1CircuitType
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1CoolingEnabled
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1CoolingFlowTempMin
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1DewPointMonitoring
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1DewPointOffset
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1DewPointTemp
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002300 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1ExcessTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1FlowTempCalc
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002000 / 050102200002)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1HeatCurve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1Humidity
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002200 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MixerMovement
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MixerPosition
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002100 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1PumpHours
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002400 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1PumpStarts
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002500 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1PumpStatus
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1RoomTempModulation
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1Status
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1SummerTempLimit
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2AutoOffMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2CircuitType
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2DewPointTemp
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012300 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2ExcessTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2FlowTempCalc
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012000 / 050002200000)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2HeatCurve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2Humidity
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012200 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MixerMovement
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MixerPosition
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012100 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2PumpHours
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012400 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2PumpStarts
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012500 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2PumpStatus
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2Status
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2SummerTempLimit
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3AutoOffMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3CircuitType
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3ExcessTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3HeatCurve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MixerMovement
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3PumpStatus
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3Status
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3SummerTempLimit
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HcStorageTempBottom
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: ctlv2
+  name: HcStorageTempTop
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: ctlv2
+  name: HwcFlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcLockTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcMaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcOpMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcParallelLoading
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcSFMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcSfMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcStorageTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcStorageTempBottom
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcStorageTempTop
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HydraulicScheme
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: ManualCoolingEndDate
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: ManualCoolingEndDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: ManualCoolingStartDate
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: ManualCoolingStartDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: MaxCylinderChargeTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: MaxRoomHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: MultiRelaySetting
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: OutsideTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: OutsideTempAvg
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySum
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHcLastMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHcThisMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHwcLastMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHwcThisMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: SystemFlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: WaterPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingManualTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingOpMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingSetbackTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1DayTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1HolidayTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1NightTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1OpMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoDuration
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoEndDate
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoEndTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1RoomTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1SFMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z2RoomTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: z1RoomHumidity
+  fields:
+  - value
+  values:
+  - '65'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: AdaptHeatCurve
+  fields:
+  - value
+  values:
+  - 'no'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: AdaptHeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Config
+  fields:
+  - value
+  values:
+  - 00 03 0a 00 00 00 ff ff 00
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CcTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Friday0
+  fields:
+  - value
+  values:
+  - 00:00;00:00
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CcTimer_Friday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Friday2
+  fields:
+  - value
+  values:
+  - 00:00;00:00
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CcTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Monday0
+  fields:
+  - value
+  values:
+  - 00:00;00:00
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CcTimer_Monday1
+  fields:
+  - value
+  values:
+  - 00:00;00:00
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CcTimer_Monday2
+  fields:
+  - value
+  values:
+  - 00:00;00:00
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CcTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Saturday0
+  fields:
+  - value
+  values:
+  - 00:00;00:00
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CcTimer_Saturday1
+  fields:
+  - value
+  values:
+  - 00:00;00:00
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CcTimer_Saturday2
+  fields:
+  - value
+  values:
+  - 00:00;00:00
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CcTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Sunday0
+  fields:
+  - value
+  values:
+  - 00:00;00:00
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CcTimer_Sunday1
+  fields:
+  - value
+  values:
+  - 00:00;00:00
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CcTimer_Sunday2
+  fields:
+  - value
+  values:
+  - 00:00;00:00
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CcTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Thursday0
+  fields:
+  - value
+  values:
+  - 00:00;00:00
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CcTimer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Timeframes
+  fields:
+  - value
+  values:
+  - 0;0;0;0;0;0;0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CcTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Tuesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Wednesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Clearerrorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: ContinuousHeating
+  fields:
+  - value
+  values:
+  - '-26'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: ContinuousHeating
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - -;-;-;-;-
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CylinderChargeHyst
+  fields:
+  - value
+  values:
+  - '7'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CylinderChargeHyst
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CylinderChargeOffset
+  fields:
+  - value
+  values:
+  - '8'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CylinderChargeOffset
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Date
+  fields:
+  - value
+  values:
+  - 07.09.2026
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Date
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: DisplayedOutsideTemp
+  fields:
+  - value
+  values:
+  - '23'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: FrostOverRideTime
+  fields:
+  - value
+  values:
+  - '4'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: FrostOverRideTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1AutoOffMode
+  fields:
+  - value
+  values:
+  - night
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1AutoOffMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1CircuitType
+  fields:
+  - value
+  values:
+  - mixer
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1ExcessTemp
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1ExcessTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1FlowTemp
+  fields:
+  - value
+  values:
+  - '26'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1HeatCurve
+  fields:
+  - value
+  values:
+  - '0.25'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1HeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '50'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - '20'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - '30'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1MixerMovement
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1PumpStatus
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1PumpStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'off'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1Status
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1SummerTempLimit
+  fields:
+  - value
+  values:
+  - '14'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1SummerTempLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2AutoOffMode
+  fields:
+  - value
+  values:
+  - eco
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2AutoOffMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2CircuitType
+  fields:
+  - value
+  values:
+  - inactive
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2ExcessTemp
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2ExcessTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2FlowTemp
+  fields:
+  - value
+  values:
+  - (empty for 3115b52406020002010800 / 0800020800ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2HeatCurve
+  fields:
+  - value
+  values:
+  - '0.6'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2HeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '55'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - '20'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - '15'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2MixerMovement
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2PumpStatus
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2PumpStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'off'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2Status
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2SummerTempLimit
+  fields:
+  - value
+  values:
+  - '16'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2SummerTempLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3AutoOffMode
+  fields:
+  - value
+  values:
+  - eco
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3AutoOffMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3CircuitType
+  fields:
+  - value
+  values:
+  - inactive
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3ExcessTemp
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3ExcessTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3FlowTemp
+  fields:
+  - value
+  values:
+  - (empty for 3115b52406020002020800 / 0800020800ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3HeatCurve
+  fields:
+  - value
+  values:
+  - '0.6'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3HeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '55'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - '20'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - '15'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3MixerMovement
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3PumpStatus
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3PumpStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'off'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3Status
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3SummerTempLimit
+  fields:
+  - value
+  values:
+  - '16'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3SummerTempLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HcStorageTempBottom
+  fields:
+  - value
+  values:
+  - (empty for f115b5240602000000a000 / 080000a000ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HcStorageTempTop
+  fields:
+  - value
+  values:
+  - (empty for f115b52406020000009f00 / 0800009f00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcBankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcBankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcBankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcBankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcFlowTemp
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 01.01.2015
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 01.01.2015
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcLockTime
+  fields:
+  - value
+  values:
+  - '60'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcLockTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcMaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '80'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcMaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcOpMode
+  fields:
+  - value
+  values:
+  - auto
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcOpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcParallelLoading
+  fields:
+  - value
+  values:
+  - 'off'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcParallelLoading
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcSFMode
+  fields:
+  - value
+  values:
+  - auto
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcSFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcStorageTemp
+  fields:
+  - value
+  values:
+  - '42'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcStorageTempBottom
+  fields:
+  - value
+  values:
+  - (empty for f115b52406020000009e00 / 0800009e00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcStorageTempTop
+  fields:
+  - value
+  values:
+  - (empty for f115b52406020000009d00 / 0800009d00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTempDesired
+  fields:
+  - value
+  values:
+  - '50'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Config
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Friday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Friday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Friday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Monday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Monday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Monday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Saturday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Saturday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Saturday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Sunday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Sunday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Sunday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Thursday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Timeframes
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Tuesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Wednesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HydraulicScheme
+  fields:
+  - value
+  values:
+  - '8'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HydraulicScheme
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Installer1
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Installer1
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Installer2
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Installer2
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: KeyCodeforConfigMenu
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: KeyCodeforConfigMenu
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: MaintenanceDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: MaintenanceDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: MaintenanceDue
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: MaxCylinderChargeTime
+  fields:
+  - value
+  values:
+  - '90'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: MaxCylinderChargeTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: MaxRoomHumidity
+  fields:
+  - value
+  values:
+  - '40'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: MaxRoomHumidity
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: MultiRelaySetting
+  fields:
+  - value
+  values:
+  - circulation
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: MultiRelaySetting
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: OutsideTempAvg
+  fields:
+  - value
+  values:
+  - '19.8516'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: OutsideTempAvg
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PhoneNumber1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PhoneNumber1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PhoneNumber2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PhoneNumber2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySum
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020000005c00 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHc
+  fields:
+  - value
+  values:
+  - '1792'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: PrEnergySumHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHcLastMonth
+  fields:
+  - value
+  values:
+  - '15'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: PrEnergySumHcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHcThisMonth
+  fields:
+  - value
+  values:
+  - '3'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: PrEnergySumHcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHwc
+  fields:
+  - value
+  values:
+  - '327'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: PrEnergySumHwc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHwcLastMonth
+  fields:
+  - value
+  values:
+  - '41'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: PrEnergySumHwcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHwcThisMonth
+  fields:
+  - value
+  values:
+  - '8'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: PrEnergySumHwcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHwc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHwc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHwcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHwcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHwcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHwcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PumpAdditionalTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PumpAdditionalTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: SolarYieldTotal
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: SolarYieldTotal
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: SystemFlowTemp
+  fields:
+  - value
+  values:
+  - (empty for f115b52406020000004b00 / 0800004b00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Time
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Time
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: WaterPressure
+  fields:
+  - value
+  values:
+  - '1.9'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: YieldTotal
+  fields:
+  - value
+  values:
+  - '5277'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: YieldTotal
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1CoolingTemp
+  fields:
+  - value
+  values:
+  - '24'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1CoolingTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1DayTemp
+  fields:
+  - value
+  values:
+  - '19'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 09.10.2027
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 26.09.2026
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1HolidayTemp
+  fields:
+  - value
+  values:
+  - '15'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1NightTemp
+  fields:
+  - value
+  values:
+  - '18'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1OpMode
+  fields:
+  - value
+  values:
+  - auto
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1QuickVetoDuration
+  fields:
+  - value
+  values:
+  - '3'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1QuickVetoEndDate
+  fields:
+  - value
+  values:
+  - 07.09.2026
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1QuickVetoEndTime
+  fields:
+  - value
+  values:
+  - 04:02:00
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1QuickVetoTemp
+  fields:
+  - value
+  values:
+  - '20'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1RoomTemp
+  fields:
+  - value
+  values:
+  - '21.9125'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1SFMode
+  fields:
+  - value
+  values:
+  - auto
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Config
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Friday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Friday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Friday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Monday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Monday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Monday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Saturday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Saturday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Saturday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Sunday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Sunday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Sunday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Thursday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Timeframes
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Tuesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Wednesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2CoolingTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2CoolingTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2QuickVetoEndDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2QuickVetoEndTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2RoomTemp
+  fields:
+  - value
+  values:
+  - (empty for 3115b52406020003010f00 / 0802030f00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Config
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Friday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Friday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Friday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Monday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Monday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Monday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Saturday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Saturday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Saturday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Sunday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Sunday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Sunday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Thursday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Timeframes
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Tuesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Wednesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3QuickVetoEndDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3QuickVetoEndTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3RoomTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Config
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Friday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Friday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Friday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Monday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Monday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Monday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Saturday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Saturday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Saturday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Sunday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Sunday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Sunday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Thursday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Timeframes
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Tuesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Wednesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: BuildingCircuitFlow
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: BuildingCircuitPumpSpeed
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: CompressorHc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: CompressorHwc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHwc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: ConsumptionTotal
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CoolElecConsDay
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CoolElecConsTotal
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CoolEnvYieldDay
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CoolEnvYieldMonth
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CoolEnvYieldTotal
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CopCooling
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CopCoolingMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CopHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CopHcMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CopHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CopHwcMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CurrentCompressorUtil
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CurrentConsumedPower
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CurrentYieldPower
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: DateTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: FlowTemperature
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: HcElecConsDay
+  fields:
+  - value
+  values:
+  - '133.058'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: HcElecConsTotal
+  fields:
+  - value
+  values:
+  - '1.70677e+06'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: HoursCool
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: HwcElecConsDay
+  fields:
+  - value
+  values:
+  - '996.237'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: HwcElecConsTotal
+  fields:
+  - value
+  values:
+  - '325181'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: LiveMonitorCurrentConsumedPower
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: PowerConsumptionHmu
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunDataAirInletTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataBuildingCPumpPower
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataCompressorInletTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataCompressorOutletTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataCompressorSpeed
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataEEVOutletTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataEEVPositionAbs
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataElectricPowerConsumption
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataFan1Speed
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataFan2Speed
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataHighPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataLowPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunDataReturnTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataStatuscode
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStats4PortValveHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStats4PortValveSwitches
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsBuildingCPumpStarts
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsBuildingPumpHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunStatsCompressorHc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunStatsCompressorHwc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHwc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorStarts
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsFan1Hours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsFan1Starts
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsFan2Hours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsFan2Starts
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsHMUHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsHcHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsHwcHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: SourceTempInput
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: SourceTempOutput
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatElectricEnergySum
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatElectricEnergySumCool
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatElectricEnergySumHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatElectricEnergySumHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatEnvironmentEnergySum
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatEnvironmentEnergySumCool
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatEnvironmentEnergySumHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatEnvironmentEnergySumHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatSolarEnergySum
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatSolarEnergySumHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatSolarEnergySumHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.pumpstate
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.temp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.temp_1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.temp_2
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: Status01.temp_3
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: Status01.temp_4
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: StatusCirPump
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: SupplyTempWeighted
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: TotalEnergyUsage
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldCoolDay
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldCooling
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldCoolingMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldHcDay
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldHcMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldHwcDay
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldHwcMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmux0
+  name: AirIntakeTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: BuildingCircuitFlow
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: BuildingPumpHours
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: BuildingPumpHours
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: BuildingPumpStarts
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: BuildingPumpStarts
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: Clearerrorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: CompressorHours
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: CompressorHours
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: CompressorHysteresisCooling
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: CompressorHysteresisHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: CompressorStarts
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: CompressorStarts
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: ConsumptionThisYear1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: ConsumptionThisYear10
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: ConsumptionThisYear11
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: ConsumptionThisYear12
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: ConsumptionThisYear2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: ConsumptionThisYear3
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: ConsumptionThisYear4
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: ConsumptionThisYear5
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: ConsumptionThisYear6
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: ConsumptionThisYear7
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: ConsumptionThisYear8
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: ConsumptionThisYear9
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: ConsumptionTotal
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3108b516021802 / 00)'
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: CopHc
+  fields:
+  - value
+  values:
+  - '3.5'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: CopHcMonth
+  fields:
+  - value
+  values:
+  - '3.8'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: CopHwc
+  fields:
+  - value
+  values:
+  - '2.8'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: CopHwcMonth
+  fields:
+  - value
+  values:
+  - '3.1'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: CurrentCompressorUtil
+  fields:
+  - value
+  values:
+  - '0.00'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: CurrentConsumedPower
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: CurrentYieldPower
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - -;-;-;-;-
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: DateTime
+  fields:
+  - value
+  values:
+  - valid;21:20:39;07.09.2026;23.000
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: EEVSteps
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: EEVSteps
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: EnableTestCompressorExitTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: EnableTestCompressorIntakeTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: EnableTestCompressorSpeed
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: EnableTestCondensateTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: EnableTestEEVPosition
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: EnableTestEEVTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: EnableTestEvaporationTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: EnableTestFlowTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: EnableTestHighPress
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: EnableTestReturnTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: EnableTestWaterThroughput
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: EnableiveMonitorMain
+  fields:
+  - value
+  values:
+  - (empty for f108b503020003 / 0a6400ffffffffffffffff)
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: EnergyIntegral
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: Fan1Hours
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: Fan1Hours
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: Fan1Starts
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: Fan1Starts
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: Fan2Hours
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: Fan2Hours
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: Fan2Starts
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: Fan2Starts
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: FlowPressure
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: FlowTemp
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3108b51a0405ff3220 / 02ff01)'
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: FourWayValveHours
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: FourWayValveHours
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: FourWayValveSwitches
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: FourWayValveSwitches
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: FourWayValveSwitchingOperations
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: FourWayValveSwitchingOperations
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: HcBivalencePoint
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: HcModeActive
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: HeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: Hours
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: HoursCool
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: HoursHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: HoursHwc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: HwcBivalencePoint
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: HwcChargeHysteresis
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: HwcMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: HwcModeActive
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: ImmersionHeaterMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: LiveMonitorAirIntakeTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: LiveMonitorCurrentCompressorUtil
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: LiveMonitorCurrentConsumedPower
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: LiveMonitorCurrentSupplyTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: LiveMonitorCurrentYieldPower
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: LiveMonitorDesiredSupplyTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: LiveMonitorMain
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: MaxFlowTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: MinFlowTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: RunDataAirInletTemp
+  fields:
+  - value
+  values:
+  - '21.25'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: RunDataBuildingCPumpPower
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: RunDataCompressorInletTemp
+  fields:
+  - value
+  values:
+  - '22.6875'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: RunDataCompressorOutletTemp
+  fields:
+  - value
+  values:
+  - '23.4375'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: RunDataCompressorSpeed
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: RunDataEEVOutletTemp
+  fields:
+  - value
+  values:
+  - '21.375'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: RunDataEEVPositionAbs
+  fields:
+  - value
+  values:
+  - '250'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: RunDataElectricPowerConsumption
+  fields:
+  - value
+  values:
+  - '6'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: RunDataFan1Speed
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: RunDataFan2Speed
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: RunDataFlowTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: RunDataHighPressure
+  fields:
+  - value
+  values:
+  - '13.8'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: RunDataReturnTemp
+  fields:
+  - value
+  values:
+  - '22.2981'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: RunDataStatuscode
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: RunStats4PortValveHours
+  fields:
+  - value
+  values:
+  - '50'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: RunStats4PortValveSwitches
+  fields:
+  - value
+  values:
+  - '387'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: RunStatsBuildingCPumpStarts
+  fields:
+  - value
+  values:
+  - '358'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: RunStatsBuildingPumpHours
+  fields:
+  - value
+  values:
+  - '2153'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: RunStatsCompressorHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: RunStatsCompressorHours
+  fields:
+  - value
+  values:
+  - '1862'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: RunStatsCompressorHwc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: RunStatsCompressorStarts
+  fields:
+  - value
+  values:
+  - '1865'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: RunStatsFan1Hours
+  fields:
+  - value
+  values:
+  - '1908'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: RunStatsFan1Starts
+  fields:
+  - value
+  values:
+  - '2178'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: RunStatsFan2Hours
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: RunStatsFan2Starts
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: RunStatsHMUHours
+  fields:
+  - value
+  values:
+  - '5433'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: RunStatsHcHours
+  fields:
+  - value
+  values:
+  - '1761'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: RunStatsHwcHours
+  fields:
+  - value
+  values:
+  - '136'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: SetMode
+  fields:
+  - value
+  values:
+  - auto;0.0;-;-;1;1;1;0;0;0
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: SourcePressure
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: SourceTempOutput
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3108b51a0405ff3227 / 02ff01)'
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: StatBuildingPumpHours
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: StatBuildingPumpStarts
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: StatCompressorHours
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: StatCompressorStarts
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: StatEEVSteps
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: StatFan1Hours
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: StatFan1Starts
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: StatFourWayValveHours
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: StatFourWayValveSwitchingOperations
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: State
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: Status01
+  fields:
+  - value
+  values:
+  - 26.0;22.0;23.047;-;42.0;off
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: Status01.pumpstate
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmux0
+  name: Status01.temp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmux0
+  name: Status01.temp_1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmux0
+  name: Status01.temp_2
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmux0
+  name: Status01.temp_3
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmux0
+  name: Status01.temp_4
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmux0
+  name: Status02
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: Status16
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: StatusCirPump
+  fields:
+  - value
+  values:
+  - 'off'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: SummerSwitchOffTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TargetFlowTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TargetTempHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TargetTempHwc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TestAirIntakeTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TestBuildingPumpPower
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TestBuildingWaterPress
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TestCompressorExitTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TestCompressorInletTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TestCompressorSpeed
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TestCondensateTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TestCondensateTrayHeater
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TestCondensorInletTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TestCondensorOutletTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TestCylinderTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TestDCFStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TestEEVOutletTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TestEEVPosition
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TestEEVTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TestEvaporationTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TestFan1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TestFan2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TestFlowTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TestFlowTempImmersionHeater
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TestFourWayValve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TestHeatingCoilCompressor
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TestHighPress
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TestHighPressureSwitch
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TestImmersionHeaterSafetyCutOut
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TestLockoutContactS20
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TestLockoutContactS21
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TestLowPress
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TestMA1Output
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TestMIInput
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TestMO2Output
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TestMO3Output
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TestOutdoorTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TestOverheatingActualValue
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TestOverheatingTargetValue
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TestPrioritySwitchingValve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TestReturnTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TestSubcoolingActualValue
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TestSubcoolingTargetValue
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TestSystemTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TestTempSwitchCompressorOutlet
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TestWaterThroughput
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TotalEnergyUsage
+  fields:
+  - value
+  values:
+  - '2031'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: YieldCoolDay
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: YieldHc
+  fields:
+  - value
+  values:
+  - '4662'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: YieldHcDay
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: YieldHcMonth
+  fields:
+  - value
+  values:
+  - '10.3'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: YieldHwc
+  fields:
+  - value
+  values:
+  - '616'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: YieldHwcDay
+  fields:
+  - value
+  values:
+  - '1.9'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: YieldHwcMonth
+  fields:
+  - value
+  values:
+  - '20.7'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: YieldThisYear1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: YieldThisYear10
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: YieldThisYear11
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: YieldThisYear12
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: YieldThisYear2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: YieldThisYear3
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: YieldThisYear4
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: YieldThisYear5
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: YieldThisYear6
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: YieldThisYear7
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: YieldThisYear8
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: YieldThisYear9
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: YieldTotal
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3108b516021801 / 00)'
+  writable: false
+  has_data: false
+- circuit: sc
+  name: Clearerrorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: Col
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: ColKickPumpTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: ColKickTempDelta
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: CollPump
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: D1Temp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: D2Temp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: Date
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: EDFunction
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: EDFunction
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: EnableScProtection
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: EnableScProtection
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: FlowRate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: FlowRate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: FrostProtectionEnabled
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: FrostProtectionLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: Hc1PumpKol1PP1Port
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: Hc2aLegPumpP2Port
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: Hc2zPort
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: HydraulicScheme
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: InitCircuit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: Iotest
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: Ioteststop
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: IsInBoostMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: KickFunction
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: KickFunction
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: LpZpMaPort
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: MAPreferredStorage
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: MAPreferredStorage
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: MaximalTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: MaximalTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: MaximalTemp2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: MaximalTemp2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: MultifunctionOutput
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: OMultifunction
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: OMultifunction
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: PumpAntiLockingFlags
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: QuickVetoStart
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: ResetSolGain
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: ResetSolGain
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: RuntimeCollPump
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: RuntimeCollPumpSeconds
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: SP1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: SP2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: ScProtectionHysteresis
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: ScProtectionLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: ScProtectionLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: ScProtectionTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: SolCollPumpDcIntegrator
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: SolCollPumpED
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: SolGain
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: SolOperationMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: SumSolGain
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: SumSolGainDayBefore
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: SystemMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: TempDifferenceOff
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: TempDifferenceOff
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: TempDifferenceOff2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: TempDifferenceOff2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: TempDifferenceOffTD12
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: TempDifferenceOffTD12
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: TempDifferenceOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: TempDifferenceOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: TempDifferenceOn2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: TempDifferenceOn2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: TempDifferenceOnTD12
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: TempDifferenceOnTD12
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: Time
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: Weekday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: YieldLastYear
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: YieldThisYear
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 31ecb509030d3f00 / 00)'
+  writable: false
+  has_data: false
+- circuit: v32
+  name: BypassPosition
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: ExhaustAirHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: ExhaustAirTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: FanHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: FlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: FlowTempMax
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: HcHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: HoursTillService
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: HwcHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: HwcTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: v32
+  name: Maintenancedata_HwcTempMax
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: v32
+  name: MaxAirHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: MinAirHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: OutdoorstempSensor
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: v32
+  name: OutsideAirTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: PumpHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: PumpPower
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: ReturnTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: ReturnTempMax
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: Status02.hwcmode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: Status02.temp0
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: Status02.temp0_1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: Status02.temp1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: Status02.temp1_1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: StorageLoadPumpHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: StorageTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: StorageTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: SupplyAirTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: VentilationLevelDay
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: VentilationLevelNight
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldToday
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldTotal
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldYear
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Clearerrorhistory
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Mc1Operation
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Mc2Operation
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Mc3Operation
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: SensorData1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: SensorData2
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: SetActorState
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vwz
+  name: TestHwcTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: vwz
+  name: TestOutdoorTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: vwz
+  name: TestThreeWayValve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: vwzio
+  name: EnableTestHwcTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: EnableTestOutdoorTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: EnableTestThreeWayValve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: TestHwcTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: TestOutdoorTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: TestThreeWayValve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+grab:
+- '[grab] grab continued'
+- '3104070400 / 0ab54e4554583301290404 = 1: scan.04'
+- '3108070400 / 0ab5484d55583003030504 = 1: scan.08'
+- '3108b516081001ffff02052735 / 0b0100070205273500000000 = 1: hmu CoolEnvYieldDay'
+- '3108b516081000ffff02050000 / 0b0000070205273500000000 = 1: hmu CoolEnvYieldTotal'
+- '3108b516081002ffff02052735 / 0b0200070205213500000000 = 1: hmu CoolEnvYieldMonth'
+- '3108b516081001ffff03032735 / 0b01000003032735dd0e0543 = 1: hmu HcElecConsDay'
+- '3108b516081000ffff03030000 / 0b000000030327358758d049 = 1: hmu HcElecConsTotal'
+- '3108b516081001ffff03052735 / 0b0100060305273500000000 = 1: hmu CoolElecConsDay'
+- '3108b516081000ffff03040000 / 0b00000303042735a7c79e48 = 1: hmu HwcElecConsTotal'
+- '3108b516081001ffff03042735 / 0b010003030427352a0f7944 = 1: hmu HwcElecConsDay'
+- '3108b516081000ffff03050000 / 0b0000060305273500000000 = 1: hmu CoolElecConsTotal'
+- '3115070400 / 0ab543544c563308088004 = 1: scan.15'
+- '3115b5090127 / 094e3230303030303030 = 3: Scan.15 Id'
+- '3176070400 / 0ab556575a494f03030504 = 2: scan.76'
+- '3176b5090127 / 094e363c3c3c3c3c3c3c = 4: Scan.76 Id'
+- '31ec070400 / 0ab5534f4c303008088004 = 1: scan.ec'
+- '31ecb5090127 / 094e3230303030303030 = 3: Scan.ec Id'
+- '31f6070400 / 0ab54e4554583301290404 = 1: scan.f6'
+- '1008b51009000000ffffff070000 / 0101 = 40: hmux0 SetMode'
+- '1008b512020000 / 00 = 1: hmux0 StatusCirPump'
+- '10feb516080037202107090126 = 6: Broadcast Vdatetime'
+- '10feb51603010c17 = 6: Broadcast Outsidetemp'
+- '1008b5040100 / 0a03391421070901260017 = 1: hmux0 DateTime'
+- 1008b5110100 / 09a10112000000000000 = 7
+- '1008b5110101 / 09342c0c17ff540000ff = 2: hmux0 Status01'
+- 1076b5110101 / 09322c0c17ff530000ff = 40
+- 10feb505025c00 = 7
+- 10feb510020601 = 1
+- '10feb516080037142107090126 = 1: Broadcast Vdatetime'
+- '10feb51603010c17 = 1: Broadcast Outsidetemp'
+- '3115b5090124 / 09003231323534313030 = 1: Scan.15 Id'
+- '3176b5090124 / 09003231323534373030 = 1: Scan.76 Id'
+- '31ecb5090124 / 09003231323534313030 = 1: Scan.ec Id'
+- f108b5110100 / 09a10112000000000000 = 2
+- f108b5160114 / 09000000c04000000000 = 6
+- f176b5160114 / 09000000a04000000000 = 6
+- 0304b511010e / 0116 = 11
+- '1008b5040100 / 0a03392021070901260017 = 6: hmux0 DateTime'
+- '1008b5110101 / 09342c0c17ff530000ff = 48: hmux0 Status01'
+- 1008b507020900 / 025707 = 6
+- 1008b5120204ff / 00 = 1
+- 1008b513020528 / 0101 = 1
+- f108b503020002 / 0affffffffffffffffffff = 7
+- f108b503020004 / 0affffffffffffffffffff = 7
+- f108b503020005 / 0affffffffffffffffffff = 7
+- 'f115b503020001 / 0affffffffffffffffffff = 1: ctlv3 Currenterror'
+- f115b503020002 / 0affffffffffffffffffff = 5
+- f115b531020301 / 0101 = 2
+- f176b503020001 / 0affffffffffffffffffff = 7
+- 'f108b503020001 / 0affffffffffffffffffff = 7: hmux0 Currenterror'
+- '3108b516021801 / 00 = 1: hmux0 YieldTotal'
+- '3108b516021802 / 00 = 2: hmux0 ConsumptionTotal'
+- 'f115b503020001 / 0affffffffffffffffffff = 7: ctlv3 Currenterror'
+- '31ecb509030d3f58 / 00 = 12: sc YieldThisYear'
+- 'f108b503020003 / 0a6400ffffffffffffffff = 3: hmux0 EnableiveMonitorMain'
+- 1076b512030f0001 / 079f0200960113ff = 40
+- '3115b55503a30003 / 0900030a000000ffff00 = 2: ctlv3 CcTimer_Config'
+- '3115b55503a40003 / 09000000000000000000 = 2: ctlv3 CcTimer_Timeframes'
+- '1008b51009000000ffffff070000 / 0101 = 2: hmux0 SetMode'
+- 1076b51009000000ffffff010000 / 0101 = 40
+- f108b50905540200030b / 060201030b5401 = 1
+- f108b50905540200040a / 050201040a00 = 1
+- f108b50905540200190a / 050201190a00 = 1
+- f108b509055402004e0d / 0502014e0d00 = 1
+- 'f108b509055402005b0d / 0802015b0d0000c040 = 1: hmux0 RunDataElectricPowerConsumption'
+- f108b50905540200600b / 050201600b1d = 1
+- f108b50905540200610b / 050201610b1d = 1
+- f108b50905540200620b / 050201620b1d = 1
+- f108b50905540200650b / 050201650b00 = 1
+- f108b509055402008813 / 0e020188136400ffffffffffffffff = 1
+- f108b509055402008b13 / 0e02018b13ffffffffffffffffffff = 1
+- f108b50905540200cc10 / 060201cc106501 = 1
+- f108b50905540200d110 / 060201d1104001 = 1
+- f108b50905540200d610 / 060201d6100000 = 1
+- 'f108b50905540200d70b / 080201d70b74070000 = 2: hmux0 RunStatsFan1Hours'
+- 'f108b50905540200d80b / 080201d80b82080000 = 1: hmux0 RunStatsFan1Starts'
+- f108b50905540200e10b / 080201e10b01000000 = 1
+- f108b50905540200e40b / 080201e40b2f010000 = 1
+- f108b50905540200e50b / 080201e50bbf0b0000 = 1
+- f108b50905540200e60b / 080201e60b13010000 = 1
+- f108b50905540200fa0a / 050201fa0a1c = 1
+- f108b50905540200fd0a / 060201fd0aa201 = 1
+- f108b516081000ffff84030000 / 0b1000ff8403273500000000 = 1
+- f108b51a0405ff3546 / 0aff083e42010000000000 = 1
+- f115b516081000ffff01000000 / 0b0000ff0100273500000000 = 1
+- f115b52406020000004800 / 06010048000000 = 29
+- f115b52406020001000f00 / 0601010f000000 = 19
+- f115b52406020003001b00 / 0601031b000000 = 26
+- f176b50905540200040a / 050201040a00 = 1
+- f176b50905540200640b / 060201640b3700 = 1
+- '3108b51a0405003224 / 0a00083500000000000000 = 2: hmux0 LiveMonitorCurrentConsumedPower'
+- '3108b51a0405ff3200 / 0aff082f00000000000000 = 2: hmux0 YieldHcDay'
+- '3108b51a0405ff3201 / 0aff082f00000000000000 = 2: hmux0 YieldCoolDay'
+- '3108b51a0405ff3202 / 0aff082f13000000000000 = 2: hmux0 YieldHwcDay'
+- '3108b51a0405ff320e / 0aff082f67000000000000 = 2: hmux0 YieldHcMonth'
+- '3108b51a0405ff320f / 0aff081926000000000000 = 2: hmux0 CopHcMonth'
+- '3108b51a0405ff3210 / 0aff082636120000000000 = 2: hmux0 YieldHc'
+- '3108b51a0405ff3211 / 0aff081923000000000000 = 2: hmux0 CopHc'
+- '3108b51a0405ff3212 / 0aff082fcf000000000000 = 2: hmux0 YieldHwcMonth'
+- '3108b51a0405ff3213 / 0aff08191f000000000000 = 2: hmux0 CopHwcMonth'
+- '3108b51a0405ff3216 / 0aff082668020000000000 = 2: hmux0 YieldHwc'
+- '3108b51a0405ff3217 / 0aff08191c000000000000 = 2: hmux0 CopHwc'
+- '3108b51a0405ff3220 / 02ff01 = 2: hmux0 FlowTemp'
+- '3108b51a0405ff3222 / 02ff01 = 2: hmu SourceTempInput'
+- '3108b51a0405ff3223 / 0aff081300000000000000 = 2: hmux0 CurrentYieldPower'
+- '3108b51a0405ff3224 / 0aff083500000000000000 = 2: hmux0 CurrentConsumedPower'
+- '3108b51a0405ff3225 / 0aff083800000000000000 = 2: hmux0 CurrentCompressorUtil'
+- '3108b51a0405ff3227 / 02ff01 = 2: hmux0 SourceTempOutput'
+- '3108b51a0405ff323c / 0aff080e00000000000000 = 1: hmux0 BuildingCircuitFlow'
+- '3108b51a0405ff3243 / 0aff083400000000000000 = 1: hmux0 HoursCool'
+- '3108b51a0405ff324d / 0aff0826ef070000000000 = 2: hmux0 TotalEnergyUsage'
+- '3108b50905540200530d / 040208530d = 2: hmux0 RunDataStatuscode'
+- 'f108b509055402005b0d / 0802015b0d0000c040 = 5: hmux0 RunDataElectricPowerConsumption'
+- '3108b509055402009808 / 08020198080080b541 = 2: hmux0 RunDataCompressorInletTemp'
+- '3108b50905540200a208 / 080201a2080080bb41 = 2: hmux0 RunDataCompressorOutletTemp'
+- '3108b50905540200ac08 / 080201ac080000ab41 = 2: hmux0 RunDataEEVOutletTemp'
+- '3108b50905540200de08 / 080201de080000aa41 = 2: hmux0 RunDataAirInletTemp'
+- '3108b509055402000609 / 08020106099662b241 = 2: hmux0 RunDataReturnTemp'
+- '3108b509055402006a09 / 0802016a09cdcc5c41 = 2: hmux0 RunDataHighPressure'
+- 'f108b50905540200c509 / 080201c50900000000 = 2: hmux0 RunDataBuildingCPumpPower'
+- 'f108b509055402000d0a / 0802010d0a00000000 = 2: hmux0 RunDataCompressorSpeed'
+- '3108b50905540200280a / 060201280afa00 = 2: hmux0 RunDataEEVPositionAbs'
+- '3108b50905540200470a / 080201470a00000000 = 2: hmux0 RunDataFan1Speed'
+- '3108b50905540200490a / 080201490a00000000 = 2: hmux0 RunDataFan2Speed'
+- '3108b50905540200b80b / 080201b80b39150000 = 1: hmux0 RunStatsHMUHours'
+- '3108b50905540200b90b / 080201b90be1060000 = 1: hmux0 RunStatsHcHours'
+- '3108b50905540200bc0b / 080201bc0b88000000 = 1: hmux0 RunStatsHwcHours'
+- '3108b50905540200c20b / 080201c20b46070000 = 1: hmux0 RunStatsCompressorHours'
+- '3108b50905540200c30b / 080201c30b49070000 = 1: hmux0 RunStatsCompressorStarts'
+- '3108b50905540200c40b / 080201c40b69080000 = 1: hmux0 RunStatsBuildingPumpHours'
+- '3108b50905540200c50b / 080201c50b66010000 = 1: hmux0 RunStatsBuildingCPumpStarts'
+- '3108b50905540200c80b / 080201c80b32000000 = 1: hmux0 RunStats4PortValveHours'
+- '3108b50905540200c90b / 080201c90b83010000 = 1: hmux0 RunStats4PortValveSwitches'
+- '3108b50905540200d70b / 080201d70b74070000 = 1: hmux0 RunStatsFan1Hours'
+- '3108b50905540200d80b / 080201d80b82080000 = 1: hmux0 RunStatsFan1Starts'
+- '3108b50905540200d90b / 080201d90b00000000 = 1: hmux0 RunStatsFan2Hours'
+- '3108b50905540200da0b / 080201da0b00000000 = 1: hmux0 RunStatsFan2Starts'
+- '3115b55505a500030001 / 070200000000ffff = 1: ctlv3 CcTimer_Monday1'
+- '3115b55505a500030101 / 070200000000ffff = 1: ctlv3 CcTimer_Tuesday1'
+- '3115b55505a500030301 / 070200000000ffff = 1: ctlv3 CcTimer_Thursday1'
+- '3115b55505a500030501 / 070200000000ffff = 1: ctlv3 CcTimer_Saturday1'
+- '3115b55505a500030601 / 070200000000ffff = 1: ctlv3 CcTimer_Sunday1'
+- '3115b55505a500030000 / 070200000000ffff = 1: ctlv3 CcTimer_Monday0'
+- '3115b55505a500030100 / 070200000000ffff = 1: ctlv3 CcTimer_Tuesday0'
+- '3115b55505a500030300 / 070200000000ffff = 1: ctlv3 CcTimer_Thursday0'
+- '3115b55505a500030400 / 070200000000ffff = 1: ctlv3 CcTimer_Friday0'
+- '3115b55505a500030500 / 070200000000ffff = 1: ctlv3 CcTimer_Saturday0'
+- '3115b55505a500030600 / 070200000000ffff = 1: ctlv3 CcTimer_Sunday0'
+- '3115b55505a500030002 / 070200000000ffff = 1: ctlv3 CcTimer_Monday2'
+- '3115b55505a500030102 / 070200000000ffff = 1: ctlv3 CcTimer_Tuesday2'
+- '3115b55505a500030302 / 070200000000ffff = 1: ctlv3 CcTimer_Thursday2'
+- '3115b55505a500030402 / 070200000000ffff = 1: ctlv3 CcTimer_Friday2'
+- '3115b55505a500030502 / 070200000000ffff = 1: ctlv3 CcTimer_Saturday2'
+- '3115b55505a500030602 / 070200000000ffff = 1: ctlv3 CcTimer_Sunday2'
+- '3115b52406020000000200 / 08030002000000d0c1 = 1: ctlv3 ContinuousHeating'
+- '3115b52406020002000200 / 06030202000100 = 1: ctlv3 Hc1CircuitType'
+- '3115b52406020002010200 / 06020202000000 = 1: ctlv3 Hc2CircuitType'
+- '3115b52406020002020200 / 06020202000000 = 1: ctlv3 Hc3CircuitType'
+- '3115b52406020003000200 / 08020302000000c041 = 1: ctlv3 Z1CoolingTemp'
+- '3115b52406020000000300 / 06030003000400 = 1: ctlv3 FrostOverRideTime'
+- 'f115b52406020001000300 / 06030103000100 = 6: ctlv3 HwcOpMode'
+- '3115b52406020003000300 / 07030303001a091a = 1: ctlv3 Z1HolidayStartPeriod'
+- 'f115b52406020003000600 / 06030306000100 = 4: ctlv3 Z1OpMode'
+- 'f115b52406020002000700 / 080102070000000000 = 4: ctlv3 Hc1ActualFlowTempDesired'
+- '3115b52406020002010700 / 080002070000000000 = 1: ctlv3 Hc2ActualFlowTempDesired'
+- '3115b52406020002020700 / 080002070000000000 = 1: ctlv3 Hc3ActualFlowTempDesired'
+- 'f115b52406020001000400 / 080301040000004842 = 6: ctlv3 HwcTempDesired'
+- '3115b52406020003000400 / 0703030400090a1b = 1: ctlv3 Z1HolidayEndPeriod'
+- 'f115b52406020001000500 / 080101050000002842 = 6: ctlv3 HwcStorageTemp'
+- '3115b52406020003000500 / 080303050000007041 = 1: ctlv3 Z1HolidayTemp'
+- 'f115b52406020000000a00 / 0503000a0000 = 4: ctlv3 HwcParallelLoading'
+- '3115b52406020001000a00 / 0702010a0001010f = 1: ctlv3 HwcHolidayEndPeriod'
+- '3115b52406020002000b00 / 0802020b0000000000 = 1: ctlv3 Hc1ExcessTemp'
+- '3115b52406020002010b00 / 0802020b0000000000 = 1: ctlv3 Hc2ExcessTemp'
+- '3115b52406020002020b00 / 0802020b0000000000 = 1: ctlv3 Hc3ExcessTemp'
+- '3115b52406020001000800 / 080101080000000000 = 1: ctlv3 HwcFlowTemp'
+- 'f115b52406020002000800 / 08000208000000d041 = 6: ctlv3 Hc1FlowTemp'
+- '3115b52406020002010800 / 0800020800ffffff7f = 1: ctlv3 Hc2FlowTemp'
+- '3115b52406020002020800 / 0800020800ffffff7f = 1: ctlv3 Hc3FlowTemp'
+- '3115b52406020003000800 / 08030308000000a041 = 1: ctlv3 Z1QuickVetoTemp'
+- '3115b52406020001000900 / 070201090001010f = 1: ctlv3 HwcHolidayStartPeriod'
+- '3115b52406020003000900 / 080303090000009041 = 1: ctlv3 Z1NightTemp'
+- '3115b52406020000000e00 / 0603000e002800 = 1: ctlv3 MaxRoomHumidity'
+- '3115b52406020002000e00 / 0603020e000100 = 1: ctlv3 Hc1AutoOffMode'
+- '3115b52406020002010e00 / 0602020e000000 = 1: ctlv3 Hc2AutoOffMode'
+- '3115b52406020002020e00 / 0602020e000000 = 1: ctlv3 Hc3AutoOffMode'
+- '3115b52406020003000e00 / 0503030e0000 = 1: ctlv3 Z1SFMode'
+- '3115b52406020002000f00 / 0803020f000000803e = 1: ctlv3 Hc1HeatCurve'
+- '3115b52406020002010f00 / 0802020f009a99193f = 1: ctlv3 Hc2HeatCurve'
+- '3115b52406020002020f00 / 0802020f009a99193f = 1: ctlv3 Hc3HeatCurve'
+- 'f115b52406020003000f00 / 0803030f00cd4caf41 = 5: ctlv3 Z1RoomTemp'
+- '3115b52406020003010f00 / 0802030f00ffffff7f = 1: ctlv3 Z2RoomTemp'
+- '3115b52406020001000d00 / 0503010d0000 = 1: ctlv3 HwcSFMode'
+- '3115b52406020002001200 / 08030212000000f041 = 1: ctlv3 Hc1MinFlowTempDesired'
+- '3115b52406020002011200 / 080202120000007041 = 1: ctlv3 Hc2MinFlowTempDesired'
+- '3115b52406020002021200 / 080202120000007041 = 1: ctlv3 Hc3MinFlowTempDesired'
+- '3115b52406020002001000 / 080302100000004842 = 1: ctlv3 Hc1MaxFlowTempDesired'
+- '3115b52406020002011000 / 080202100000005c42 = 1: ctlv3 Hc2MaxFlowTempDesired'
+- '3115b52406020002021000 / 080202100000005c42 = 1: ctlv3 Hc3MaxFlowTempDesired'
+- '3115b52406020002001100 / 08020211000000a041 = 1: ctlv3 Hc1MinCoolingTempDesired'
+- '[grab stop] grab stopped'
+labeled_telegrams:
+- msgid: '0704'
+  master: '31'
+  slave: '04'
+  sub: '00'
+  resp: 0ab54e4554583301290404
+  count: '1'
+  label: scan.04
+- msgid: '0704'
+  master: '31'
+  slave: 08
+  sub: '00'
+  resp: 0ab5484d55583003030504
+  count: '1'
+  label: scan.08
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081001ffff02052735
+  resp: 0b0100070205273500000000
+  count: '1'
+  label: hmu CoolEnvYieldDay
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081000ffff02050000
+  resp: 0b0000070205273500000000
+  count: '1'
+  label: hmu CoolEnvYieldTotal
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081002ffff02052735
+  resp: 0b0200070205213500000000
+  count: '1'
+  label: hmu CoolEnvYieldMonth
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081001ffff03032735
+  resp: 0b01000003032735dd0e0543
+  count: '1'
+  label: hmu HcElecConsDay
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081000ffff03030000
+  resp: 0b000000030327358758d049
+  count: '1'
+  label: hmu HcElecConsTotal
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081001ffff03052735
+  resp: 0b0100060305273500000000
+  count: '1'
+  label: hmu CoolElecConsDay
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081000ffff03040000
+  resp: 0b00000303042735a7c79e48
+  count: '1'
+  label: hmu HwcElecConsTotal
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081001ffff03042735
+  resp: 0b010003030427352a0f7944
+  count: '1'
+  label: hmu HwcElecConsDay
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081000ffff03050000
+  resp: 0b0000060305273500000000
+  count: '1'
+  label: hmu CoolElecConsTotal
+- msgid: '0704'
+  master: '31'
+  slave: '15'
+  sub: '00'
+  resp: 0ab543544c563308088004
+  count: '1'
+  label: scan.15
+- msgid: b509
+  master: '31'
+  slave: '15'
+  sub: '0127'
+  resp: 094e3230303030303030
+  count: '3'
+  label: Scan.15 Id
+- msgid: '0704'
+  master: '31'
+  slave: '76'
+  sub: '00'
+  resp: 0ab556575a494f03030504
+  count: '2'
+  label: scan.76
+- msgid: b509
+  master: '31'
+  slave: '76'
+  sub: '0127'
+  resp: 094e363c3c3c3c3c3c3c
+  count: '4'
+  label: Scan.76 Id
+- msgid: '0704'
+  master: '31'
+  slave: ec
+  sub: '00'
+  resp: 0ab5534f4c303008088004
+  count: '1'
+  label: scan.ec
+- msgid: b509
+  master: '31'
+  slave: ec
+  sub: '0127'
+  resp: 094e3230303030303030
+  count: '3'
+  label: Scan.ec Id
+- msgid: '0704'
+  master: '31'
+  slave: f6
+  sub: '00'
+  resp: 0ab54e4554583301290404
+  count: '1'
+  label: scan.f6
+- msgid: b510
+  master: '10'
+  slave: 08
+  sub: 09000000ffffff070000
+  resp: '0101'
+  count: '40'
+  label: hmux0 SetMode
+- msgid: b512
+  master: '10'
+  slave: 08
+  sub: '020000'
+  resp: '00'
+  count: '1'
+  label: hmux0 StatusCirPump
+- msgid: b516
+  master: '10'
+  slave: fe
+  sub: 080037202107090126
+  resp: null
+  count: '6'
+  label: Broadcast Vdatetime
+- msgid: b516
+  master: '10'
+  slave: fe
+  sub: 03010c17
+  resp: null
+  count: '6'
+  label: Broadcast Outsidetemp
+- msgid: b504
+  master: '10'
+  slave: 08
+  sub: '0100'
+  resp: 0a03391421070901260017
+  count: '1'
+  label: hmux0 DateTime
+- msgid: b511
+  master: '10'
+  slave: 08
+  sub: '0101'
+  resp: 09342c0c17ff540000ff
+  count: '2'
+  label: hmux0 Status01
+- msgid: b516
+  master: '10'
+  slave: fe
+  sub: 080037142107090126
+  resp: null
+  count: '1'
+  label: Broadcast Vdatetime
+- msgid: b516
+  master: '10'
+  slave: fe
+  sub: 03010c17
+  resp: null
+  count: '1'
+  label: Broadcast Outsidetemp
+- msgid: b509
+  master: '31'
+  slave: '15'
+  sub: '0124'
+  resp: 09003231323534313030
+  count: '1'
+  label: Scan.15 Id
+- msgid: b509
+  master: '31'
+  slave: '76'
+  sub: '0124'
+  resp: 09003231323534373030
+  count: '1'
+  label: Scan.76 Id
+- msgid: b509
+  master: '31'
+  slave: ec
+  sub: '0124'
+  resp: 09003231323534313030
+  count: '1'
+  label: Scan.ec Id
+- msgid: b504
+  master: '10'
+  slave: 08
+  sub: '0100'
+  resp: 0a03392021070901260017
+  count: '6'
+  label: hmux0 DateTime
+- msgid: b511
+  master: '10'
+  slave: 08
+  sub: '0101'
+  resp: 09342c0c17ff530000ff
+  count: '48'
+  label: hmux0 Status01
+- msgid: b503
+  master: f1
+  slave: '15'
+  sub: '020001'
+  resp: 0affffffffffffffffffff
+  count: '1'
+  label: ctlv3 Currenterror
+- msgid: b503
+  master: f1
+  slave: 08
+  sub: '020001'
+  resp: 0affffffffffffffffffff
+  count: '7'
+  label: hmux0 Currenterror
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 021801
+  resp: '00'
+  count: '1'
+  label: hmux0 YieldTotal
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 021802
+  resp: '00'
+  count: '2'
+  label: hmux0 ConsumptionTotal
+- msgid: b503
+  master: f1
+  slave: '15'
+  sub: '020001'
+  resp: 0affffffffffffffffffff
+  count: '7'
+  label: ctlv3 Currenterror
+- msgid: b509
+  master: '31'
+  slave: ec
+  sub: 030d3f58
+  resp: '00'
+  count: '12'
+  label: sc YieldThisYear
+- msgid: b503
+  master: f1
+  slave: 08
+  sub: '020003'
+  resp: 0a6400ffffffffffffffff
+  count: '3'
+  label: hmux0 EnableiveMonitorMain
+- msgid: b555
+  master: '31'
+  slave: '15'
+  sub: 03a30003
+  resp: 0900030a000000ffff00
+  count: '2'
+  label: ctlv3 CcTimer_Config
+- msgid: b555
+  master: '31'
+  slave: '15'
+  sub: 03a40003
+  resp: 09000000000000000000
+  count: '2'
+  label: ctlv3 CcTimer_Timeframes
+- msgid: b510
+  master: '10'
+  slave: 08
+  sub: 09000000ffffff070000
+  resp: '0101'
+  count: '2'
+  label: hmux0 SetMode
+- msgid: b509
+  master: f1
+  slave: 08
+  sub: 055402005b0d
+  resp: 0802015b0d0000c040
+  count: '1'
+  label: hmux0 RunDataElectricPowerConsumption
+- msgid: b509
+  master: f1
+  slave: 08
+  sub: 05540200d70b
+  resp: 080201d70b74070000
+  count: '2'
+  label: hmux0 RunStatsFan1Hours
+- msgid: b509
+  master: f1
+  slave: 08
+  sub: 05540200d80b
+  resp: 080201d80b82080000
+  count: '1'
+  label: hmux0 RunStatsFan1Starts
+- msgid: b51a
+  master: '31'
+  slave: 08
+  sub: '0405003224'
+  resp: 0a00083500000000000000
+  count: '2'
+  label: hmux0 LiveMonitorCurrentConsumedPower
+- msgid: b51a
+  master: '31'
+  slave: 08
+  sub: 0405ff3200
+  resp: 0aff082f00000000000000
+  count: '2'
+  label: hmux0 YieldHcDay
+- msgid: b51a
+  master: '31'
+  slave: 08
+  sub: 0405ff3201
+  resp: 0aff082f00000000000000
+  count: '2'
+  label: hmux0 YieldCoolDay
+- msgid: b51a
+  master: '31'
+  slave: 08
+  sub: 0405ff3202
+  resp: 0aff082f13000000000000
+  count: '2'
+  label: hmux0 YieldHwcDay
+- msgid: b51a
+  master: '31'
+  slave: 08
+  sub: 0405ff320e
+  resp: 0aff082f67000000000000
+  count: '2'
+  label: hmux0 YieldHcMonth
+- msgid: b51a
+  master: '31'
+  slave: 08
+  sub: 0405ff320f
+  resp: 0aff081926000000000000
+  count: '2'
+  label: hmux0 CopHcMonth
+- msgid: b51a
+  master: '31'
+  slave: 08
+  sub: 0405ff3210
+  resp: 0aff082636120000000000
+  count: '2'
+  label: hmux0 YieldHc
+- msgid: b51a
+  master: '31'
+  slave: 08
+  sub: 0405ff3211
+  resp: 0aff081923000000000000
+  count: '2'
+  label: hmux0 CopHc
+- msgid: b51a
+  master: '31'
+  slave: 08
+  sub: 0405ff3212
+  resp: 0aff082fcf000000000000
+  count: '2'
+  label: hmux0 YieldHwcMonth
+- msgid: b51a
+  master: '31'
+  slave: 08
+  sub: 0405ff3213
+  resp: 0aff08191f000000000000
+  count: '2'
+  label: hmux0 CopHwcMonth
+- msgid: b51a
+  master: '31'
+  slave: 08
+  sub: 0405ff3216
+  resp: 0aff082668020000000000
+  count: '2'
+  label: hmux0 YieldHwc
+- msgid: b51a
+  master: '31'
+  slave: 08
+  sub: 0405ff3217
+  resp: 0aff08191c000000000000
+  count: '2'
+  label: hmux0 CopHwc
+- msgid: b51a
+  master: '31'
+  slave: 08
+  sub: 0405ff3220
+  resp: 02ff01
+  count: '2'
+  label: hmux0 FlowTemp
+- msgid: b51a
+  master: '31'
+  slave: 08
+  sub: 0405ff3222
+  resp: 02ff01
+  count: '2'
+  label: hmu SourceTempInput
+- msgid: b51a
+  master: '31'
+  slave: 08
+  sub: 0405ff3223
+  resp: 0aff081300000000000000
+  count: '2'
+  label: hmux0 CurrentYieldPower
+- msgid: b51a
+  master: '31'
+  slave: 08
+  sub: 0405ff3224
+  resp: 0aff083500000000000000
+  count: '2'
+  label: hmux0 CurrentConsumedPower
+- msgid: b51a
+  master: '31'
+  slave: 08
+  sub: 0405ff3225
+  resp: 0aff083800000000000000
+  count: '2'
+  label: hmux0 CurrentCompressorUtil
+- msgid: b51a
+  master: '31'
+  slave: 08
+  sub: 0405ff3227
+  resp: 02ff01
+  count: '2'
+  label: hmux0 SourceTempOutput
+- msgid: b51a
+  master: '31'
+  slave: 08
+  sub: 0405ff323c
+  resp: 0aff080e00000000000000
+  count: '1'
+  label: hmux0 BuildingCircuitFlow
+- msgid: b51a
+  master: '31'
+  slave: 08
+  sub: 0405ff3243
+  resp: 0aff083400000000000000
+  count: '1'
+  label: hmux0 HoursCool
+- msgid: b51a
+  master: '31'
+  slave: 08
+  sub: 0405ff324d
+  resp: 0aff0826ef070000000000
+  count: '2'
+  label: hmux0 TotalEnergyUsage
+- msgid: b509
+  master: '31'
+  slave: 08
+  sub: 05540200530d
+  resp: 040208530d
+  count: '2'
+  label: hmux0 RunDataStatuscode
+- msgid: b509
+  master: f1
+  slave: 08
+  sub: 055402005b0d
+  resp: 0802015b0d0000c040
+  count: '5'
+  label: hmux0 RunDataElectricPowerConsumption
+- msgid: b509
+  master: '31'
+  slave: 08
+  sub: 055402009808
+  resp: 08020198080080b541
+  count: '2'
+  label: hmux0 RunDataCompressorInletTemp
+- msgid: b509
+  master: '31'
+  slave: 08
+  sub: 05540200a208
+  resp: 080201a2080080bb41
+  count: '2'
+  label: hmux0 RunDataCompressorOutletTemp
+- msgid: b509
+  master: '31'
+  slave: 08
+  sub: 05540200ac08
+  resp: 080201ac080000ab41
+  count: '2'
+  label: hmux0 RunDataEEVOutletTemp
+- msgid: b509
+  master: '31'
+  slave: 08
+  sub: 05540200de08
+  resp: 080201de080000aa41
+  count: '2'
+  label: hmux0 RunDataAirInletTemp
+- msgid: b509
+  master: '31'
+  slave: 08
+  sub: 055402000609
+  resp: 08020106099662b241
+  count: '2'
+  label: hmux0 RunDataReturnTemp
+- msgid: b509
+  master: '31'
+  slave: 08
+  sub: 055402006a09
+  resp: 0802016a09cdcc5c41
+  count: '2'
+  label: hmux0 RunDataHighPressure
+- msgid: b509
+  master: f1
+  slave: 08
+  sub: 05540200c509
+  resp: 080201c50900000000
+  count: '2'
+  label: hmux0 RunDataBuildingCPumpPower
+- msgid: b509
+  master: f1
+  slave: 08
+  sub: 055402000d0a
+  resp: 0802010d0a00000000
+  count: '2'
+  label: hmux0 RunDataCompressorSpeed
+- msgid: b509
+  master: '31'
+  slave: 08
+  sub: 05540200280a
+  resp: 060201280afa00
+  count: '2'
+  label: hmux0 RunDataEEVPositionAbs
+- msgid: b509
+  master: '31'
+  slave: 08
+  sub: 05540200470a
+  resp: 080201470a00000000
+  count: '2'
+  label: hmux0 RunDataFan1Speed
+- msgid: b509
+  master: '31'
+  slave: 08
+  sub: 05540200490a
+  resp: 080201490a00000000
+  count: '2'
+  label: hmux0 RunDataFan2Speed
+- msgid: b509
+  master: '31'
+  slave: 08
+  sub: 05540200b80b
+  resp: 080201b80b39150000
+  count: '1'
+  label: hmux0 RunStatsHMUHours
+- msgid: b509
+  master: '31'
+  slave: 08
+  sub: 05540200b90b
+  resp: 080201b90be1060000
+  count: '1'
+  label: hmux0 RunStatsHcHours
+- msgid: b509
+  master: '31'
+  slave: 08
+  sub: 05540200bc0b
+  resp: 080201bc0b88000000
+  count: '1'
+  label: hmux0 RunStatsHwcHours
+- msgid: b509
+  master: '31'
+  slave: 08
+  sub: 05540200c20b
+  resp: 080201c20b46070000
+  count: '1'
+  label: hmux0 RunStatsCompressorHours
+- msgid: b509
+  master: '31'
+  slave: 08
+  sub: 05540200c30b
+  resp: 080201c30b49070000
+  count: '1'
+  label: hmux0 RunStatsCompressorStarts
+- msgid: b509
+  master: '31'
+  slave: 08
+  sub: 05540200c40b
+  resp: 080201c40b69080000
+  count: '1'
+  label: hmux0 RunStatsBuildingPumpHours
+- msgid: b509
+  master: '31'
+  slave: 08
+  sub: 05540200c50b
+  resp: 080201c50b66010000
+  count: '1'
+  label: hmux0 RunStatsBuildingCPumpStarts
+- msgid: b509
+  master: '31'
+  slave: 08
+  sub: 05540200c80b
+  resp: 080201c80b32000000
+  count: '1'
+  label: hmux0 RunStats4PortValveHours
+- msgid: b509
+  master: '31'
+  slave: 08
+  sub: 05540200c90b
+  resp: 080201c90b83010000
+  count: '1'
+  label: hmux0 RunStats4PortValveSwitches
+- msgid: b509
+  master: '31'
+  slave: 08
+  sub: 05540200d70b
+  resp: 080201d70b74070000
+  count: '1'
+  label: hmux0 RunStatsFan1Hours
+- msgid: b509
+  master: '31'
+  slave: 08
+  sub: 05540200d80b
+  resp: 080201d80b82080000
+  count: '1'
+  label: hmux0 RunStatsFan1Starts
+- msgid: b509
+  master: '31'
+  slave: 08
+  sub: 05540200d90b
+  resp: 080201d90b00000000
+  count: '1'
+  label: hmux0 RunStatsFan2Hours
+- msgid: b509
+  master: '31'
+  slave: 08
+  sub: 05540200da0b
+  resp: 080201da0b00000000
+  count: '1'
+  label: hmux0 RunStatsFan2Starts
+- msgid: b555
+  master: '31'
+  slave: '15'
+  sub: 05a500030001
+  resp: 070200000000ffff
+  count: '1'
+  label: ctlv3 CcTimer_Monday1
+- msgid: b555
+  master: '31'
+  slave: '15'
+  sub: 05a500030101
+  resp: 070200000000ffff
+  count: '1'
+  label: ctlv3 CcTimer_Tuesday1
+- msgid: b555
+  master: '31'
+  slave: '15'
+  sub: 05a500030301
+  resp: 070200000000ffff
+  count: '1'
+  label: ctlv3 CcTimer_Thursday1
+- msgid: b555
+  master: '31'
+  slave: '15'
+  sub: 05a500030501
+  resp: 070200000000ffff
+  count: '1'
+  label: ctlv3 CcTimer_Saturday1
+- msgid: b555
+  master: '31'
+  slave: '15'
+  sub: 05a500030601
+  resp: 070200000000ffff
+  count: '1'
+  label: ctlv3 CcTimer_Sunday1
+- msgid: b555
+  master: '31'
+  slave: '15'
+  sub: 05a500030000
+  resp: 070200000000ffff
+  count: '1'
+  label: ctlv3 CcTimer_Monday0
+- msgid: b555
+  master: '31'
+  slave: '15'
+  sub: 05a500030100
+  resp: 070200000000ffff
+  count: '1'
+  label: ctlv3 CcTimer_Tuesday0
+- msgid: b555
+  master: '31'
+  slave: '15'
+  sub: 05a500030300
+  resp: 070200000000ffff
+  count: '1'
+  label: ctlv3 CcTimer_Thursday0
+- msgid: b555
+  master: '31'
+  slave: '15'
+  sub: 05a500030400
+  resp: 070200000000ffff
+  count: '1'
+  label: ctlv3 CcTimer_Friday0
+- msgid: b555
+  master: '31'
+  slave: '15'
+  sub: 05a500030500
+  resp: 070200000000ffff
+  count: '1'
+  label: ctlv3 CcTimer_Saturday0
+- msgid: b555
+  master: '31'
+  slave: '15'
+  sub: 05a500030600
+  resp: 070200000000ffff
+  count: '1'
+  label: ctlv3 CcTimer_Sunday0
+- msgid: b555
+  master: '31'
+  slave: '15'
+  sub: 05a500030002
+  resp: 070200000000ffff
+  count: '1'
+  label: ctlv3 CcTimer_Monday2
+- msgid: b555
+  master: '31'
+  slave: '15'
+  sub: 05a500030102
+  resp: 070200000000ffff
+  count: '1'
+  label: ctlv3 CcTimer_Tuesday2
+- msgid: b555
+  master: '31'
+  slave: '15'
+  sub: 05a500030302
+  resp: 070200000000ffff
+  count: '1'
+  label: ctlv3 CcTimer_Thursday2
+- msgid: b555
+  master: '31'
+  slave: '15'
+  sub: 05a500030402
+  resp: 070200000000ffff
+  count: '1'
+  label: ctlv3 CcTimer_Friday2
+- msgid: b555
+  master: '31'
+  slave: '15'
+  sub: 05a500030502
+  resp: 070200000000ffff
+  count: '1'
+  label: ctlv3 CcTimer_Saturday2
+- msgid: b555
+  master: '31'
+  slave: '15'
+  sub: 05a500030602
+  resp: 070200000000ffff
+  count: '1'
+  label: ctlv3 CcTimer_Sunday2
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020000000200'
+  resp: 08030002000000d0c1
+  count: '1'
+  label: ctlv3 ContinuousHeating
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020002000200'
+  resp: '06030202000100'
+  count: '1'
+  label: ctlv3 Hc1CircuitType
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020002010200'
+  resp: '06020202000000'
+  count: '1'
+  label: ctlv3 Hc2CircuitType
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020002020200'
+  resp: '06020202000000'
+  count: '1'
+  label: ctlv3 Hc3CircuitType
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020003000200'
+  resp: 08020302000000c041
+  count: '1'
+  label: ctlv3 Z1CoolingTemp
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020000000300'
+  resp: '06030003000400'
+  count: '1'
+  label: ctlv3 FrostOverRideTime
+- msgid: b524
+  master: f1
+  slave: '15'
+  sub: '06020001000300'
+  resp: '06030103000100'
+  count: '6'
+  label: ctlv3 HwcOpMode
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020003000300'
+  resp: 07030303001a091a
+  count: '1'
+  label: ctlv3 Z1HolidayStartPeriod
+- msgid: b524
+  master: f1
+  slave: '15'
+  sub: '06020003000600'
+  resp: '06030306000100'
+  count: '4'
+  label: ctlv3 Z1OpMode
+- msgid: b524
+  master: f1
+  slave: '15'
+  sub: '06020002000700'
+  resp: 080102070000000000
+  count: '4'
+  label: ctlv3 Hc1ActualFlowTempDesired
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020002010700'
+  resp: 080002070000000000
+  count: '1'
+  label: ctlv3 Hc2ActualFlowTempDesired
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020002020700'
+  resp: 080002070000000000
+  count: '1'
+  label: ctlv3 Hc3ActualFlowTempDesired
+- msgid: b524
+  master: f1
+  slave: '15'
+  sub: '06020001000400'
+  resp: 080301040000004842
+  count: '6'
+  label: ctlv3 HwcTempDesired
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020003000400'
+  resp: 0703030400090a1b
+  count: '1'
+  label: ctlv3 Z1HolidayEndPeriod
+- msgid: b524
+  master: f1
+  slave: '15'
+  sub: '06020001000500'
+  resp: 080101050000002842
+  count: '6'
+  label: ctlv3 HwcStorageTemp
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020003000500'
+  resp: 080303050000007041
+  count: '1'
+  label: ctlv3 Z1HolidayTemp
+- msgid: b524
+  master: f1
+  slave: '15'
+  sub: 06020000000a00
+  resp: 0503000a0000
+  count: '4'
+  label: ctlv3 HwcParallelLoading
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020001000a00
+  resp: 0702010a0001010f
+  count: '1'
+  label: ctlv3 HwcHolidayEndPeriod
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020002000b00
+  resp: 0802020b0000000000
+  count: '1'
+  label: ctlv3 Hc1ExcessTemp
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020002010b00
+  resp: 0802020b0000000000
+  count: '1'
+  label: ctlv3 Hc2ExcessTemp
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020002020b00
+  resp: 0802020b0000000000
+  count: '1'
+  label: ctlv3 Hc3ExcessTemp
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020001000800
+  resp: 080101080000000000
+  count: '1'
+  label: ctlv3 HwcFlowTemp
+- msgid: b524
+  master: f1
+  slave: '15'
+  sub: 06020002000800
+  resp: 08000208000000d041
+  count: '6'
+  label: ctlv3 Hc1FlowTemp
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020002010800
+  resp: 0800020800ffffff7f
+  count: '1'
+  label: ctlv3 Hc2FlowTemp
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020002020800
+  resp: 0800020800ffffff7f
+  count: '1'
+  label: ctlv3 Hc3FlowTemp
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020003000800
+  resp: 08030308000000a041
+  count: '1'
+  label: ctlv3 Z1QuickVetoTemp
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020001000900
+  resp: 070201090001010f
+  count: '1'
+  label: ctlv3 HwcHolidayStartPeriod
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020003000900
+  resp: 080303090000009041
+  count: '1'
+  label: ctlv3 Z1NightTemp
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020000000e00
+  resp: 0603000e002800
+  count: '1'
+  label: ctlv3 MaxRoomHumidity
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020002000e00
+  resp: 0603020e000100
+  count: '1'
+  label: ctlv3 Hc1AutoOffMode
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020002010e00
+  resp: 0602020e000000
+  count: '1'
+  label: ctlv3 Hc2AutoOffMode
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020002020e00
+  resp: 0602020e000000
+  count: '1'
+  label: ctlv3 Hc3AutoOffMode
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020003000e00
+  resp: 0503030e0000
+  count: '1'
+  label: ctlv3 Z1SFMode
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020002000f00
+  resp: 0803020f000000803e
+  count: '1'
+  label: ctlv3 Hc1HeatCurve
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020002010f00
+  resp: 0802020f009a99193f
+  count: '1'
+  label: ctlv3 Hc2HeatCurve
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020002020f00
+  resp: 0802020f009a99193f
+  count: '1'
+  label: ctlv3 Hc3HeatCurve
+- msgid: b524
+  master: f1
+  slave: '15'
+  sub: 06020003000f00
+  resp: 0803030f00cd4caf41
+  count: '5'
+  label: ctlv3 Z1RoomTemp
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020003010f00
+  resp: 0802030f00ffffff7f
+  count: '1'
+  label: ctlv3 Z2RoomTemp
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020001000d00
+  resp: 0503010d0000
+  count: '1'
+  label: ctlv3 HwcSFMode
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020002001200'
+  resp: 08030212000000f041
+  count: '1'
+  label: ctlv3 Hc1MinFlowTempDesired
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020002011200'
+  resp: 080202120000007041
+  count: '1'
+  label: ctlv3 Hc2MinFlowTempDesired
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020002021200'
+  resp: 080202120000007041
+  count: '1'
+  label: ctlv3 Hc3MinFlowTempDesired
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020002001000'
+  resp: 080302100000004842
+  count: '1'
+  label: ctlv3 Hc1MaxFlowTempDesired
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020002011000'
+  resp: 080202100000005c42
+  count: '1'
+  label: ctlv3 Hc2MaxFlowTempDesired
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020002021000'
+  resp: 080202100000005c42
+  count: '1'
+  label: ctlv3 Hc3MaxFlowTempDesired
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020002001100'
+  resp: 08020211000000a041
+  count: '1'
+  label: ctlv3 Hc1MinCoolingTempDesired
+unknown_telegrams:
+- msgid: b511
+  master: '10'
+  slave: 08
+  sub: '0100'
+  resp: 09a10112000000000000
+  count: '7'
+  label: null
+- msgid: b511
+  master: '10'
+  slave: '76'
+  sub: '0101'
+  resp: 09322c0c17ff530000ff
+  count: '40'
+  label: null
+- msgid: b505
+  master: '10'
+  slave: fe
+  sub: 025c00
+  resp: null
+  count: '7'
+  label: null
+- msgid: b510
+  master: '10'
+  slave: fe
+  sub: '020601'
+  resp: null
+  count: '1'
+  label: null
+- msgid: b511
+  master: f1
+  slave: 08
+  sub: '0100'
+  resp: 09a10112000000000000
+  count: '2'
+  label: null
+- msgid: b516
+  master: f1
+  slave: 08
+  sub: '0114'
+  resp: 09000000c04000000000
+  count: '6'
+  label: null
+- msgid: b516
+  master: f1
+  slave: '76'
+  sub: '0114'
+  resp: 09000000a04000000000
+  count: '6'
+  label: null
+- msgid: b507
+  master: '10'
+  slave: 08
+  sub: 020900
+  resp: '025707'
+  count: '6'
+  label: null
+- msgid: b512
+  master: '10'
+  slave: 08
+  sub: 0204ff
+  resp: '00'
+  count: '1'
+  label: null
+- msgid: b513
+  master: '10'
+  slave: 08
+  sub: 020528
+  resp: '0101'
+  count: '1'
+  label: null
+- msgid: b503
+  master: f1
+  slave: 08
+  sub: '020002'
+  resp: 0affffffffffffffffffff
+  count: '7'
+  label: null
+- msgid: b503
+  master: f1
+  slave: 08
+  sub: '020004'
+  resp: 0affffffffffffffffffff
+  count: '7'
+  label: null
+- msgid: b503
+  master: f1
+  slave: 08
+  sub: '020005'
+  resp: 0affffffffffffffffffff
+  count: '7'
+  label: null
+- msgid: b503
+  master: f1
+  slave: '15'
+  sub: '020002'
+  resp: 0affffffffffffffffffff
+  count: '5'
+  label: null
+- msgid: b531
+  master: f1
+  slave: '15'
+  sub: '020301'
+  resp: '0101'
+  count: '2'
+  label: null
+- msgid: b503
+  master: f1
+  slave: '76'
+  sub: '020001'
+  resp: 0affffffffffffffffffff
+  count: '7'
+  label: null
+- msgid: b512
+  master: '10'
+  slave: '76'
+  sub: 030f0001
+  resp: 079f0200960113ff
+  count: '40'
+  label: null
+- msgid: b510
+  master: '10'
+  slave: '76'
+  sub: 09000000ffffff010000
+  resp: '0101'
+  count: '40'
+  label: null
+- msgid: b509
+  master: f1
+  slave: 08
+  sub: 05540200030b
+  resp: 060201030b5401
+  count: '1'
+  label: null
+- msgid: b509
+  master: f1
+  slave: 08
+  sub: 05540200040a
+  resp: 050201040a00
+  count: '1'
+  label: null
+- msgid: b509
+  master: f1
+  slave: 08
+  sub: 05540200190a
+  resp: 050201190a00
+  count: '1'
+  label: null
+- msgid: b509
+  master: f1
+  slave: 08
+  sub: 055402004e0d
+  resp: 0502014e0d00
+  count: '1'
+  label: null
+- msgid: b509
+  master: f1
+  slave: 08
+  sub: 05540200600b
+  resp: 050201600b1d
+  count: '1'
+  label: null
+- msgid: b509
+  master: f1
+  slave: 08
+  sub: 05540200610b
+  resp: 050201610b1d
+  count: '1'
+  label: null
+- msgid: b509
+  master: f1
+  slave: 08
+  sub: 05540200620b
+  resp: 050201620b1d
+  count: '1'
+  label: null
+- msgid: b509
+  master: f1
+  slave: 08
+  sub: 05540200650b
+  resp: 050201650b00
+  count: '1'
+  label: null
+- msgid: b509
+  master: f1
+  slave: 08
+  sub: 055402008813
+  resp: 0e020188136400ffffffffffffffff
+  count: '1'
+  label: null
+- msgid: b509
+  master: f1
+  slave: 08
+  sub: 055402008b13
+  resp: 0e02018b13ffffffffffffffffffff
+  count: '1'
+  label: null
+- msgid: b509
+  master: f1
+  slave: 08
+  sub: 05540200cc10
+  resp: 060201cc106501
+  count: '1'
+  label: null
+- msgid: b509
+  master: f1
+  slave: 08
+  sub: 05540200d110
+  resp: 060201d1104001
+  count: '1'
+  label: null
+- msgid: b509
+  master: f1
+  slave: 08
+  sub: 05540200d610
+  resp: 060201d6100000
+  count: '1'
+  label: null
+- msgid: b509
+  master: f1
+  slave: 08
+  sub: 05540200e10b
+  resp: 080201e10b01000000
+  count: '1'
+  label: null
+- msgid: b509
+  master: f1
+  slave: 08
+  sub: 05540200e40b
+  resp: 080201e40b2f010000
+  count: '1'
+  label: null
+- msgid: b509
+  master: f1
+  slave: 08
+  sub: 05540200e50b
+  resp: 080201e50bbf0b0000
+  count: '1'
+  label: null
+- msgid: b509
+  master: f1
+  slave: 08
+  sub: 05540200e60b
+  resp: 080201e60b13010000
+  count: '1'
+  label: null
+- msgid: b509
+  master: f1
+  slave: 08
+  sub: 05540200fa0a
+  resp: 050201fa0a1c
+  count: '1'
+  label: null
+- msgid: b509
+  master: f1
+  slave: 08
+  sub: 05540200fd0a
+  resp: 060201fd0aa201
+  count: '1'
+  label: null
+- msgid: b516
+  master: f1
+  slave: 08
+  sub: 081000ffff84030000
+  resp: 0b1000ff8403273500000000
+  count: '1'
+  label: null
+- msgid: b51a
+  master: f1
+  slave: 08
+  sub: 0405ff3546
+  resp: 0aff083e42010000000000
+  count: '1'
+  label: null
+- msgid: b516
+  master: f1
+  slave: '15'
+  sub: 081000ffff01000000
+  resp: 0b0000ff0100273500000000
+  count: '1'
+  label: null
+- msgid: b524
+  master: f1
+  slave: '15'
+  sub: 06020000004800
+  resp: 06010048000000
+  count: '29'
+  label: null
+- msgid: b524
+  master: f1
+  slave: '15'
+  sub: 06020001000f00
+  resp: 0601010f000000
+  count: '19'
+  label: null
+- msgid: b524
+  master: f1
+  slave: '15'
+  sub: 06020003001b00
+  resp: 0601031b000000
+  count: '26'
+  label: null
+- msgid: b509
+  master: f1
+  slave: '76'
+  sub: 05540200040a
+  resp: 050201040a00
+  count: '1'
+  label: null
+- msgid: b509
+  master: f1
+  slave: '76'
+  sub: 05540200640b
+  resp: 060201640b3700
+  count: '1'
+  label: null
+after_registers:
+- circuit: Broadcast
+  name: Datetime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Error
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: Broadcast
+  name: HwcStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Id
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: IdAnswer
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: IdQuery
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Load
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Outsidetemp
+  fields:
+  - value
+  values:
+  - '23.047'
+  writable: false
+  has_data: true
+- circuit: Broadcast
+  name: Queryexistence
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Signoflife
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Vdatetime
+  fields:
+  - value
+  values:
+  - 21:20:37;07.09.2026
+  writable: false
+  has_data: true
+- circuit: Broadcast
+  name: Vdatetime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: WaterPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: General
+  name: Valuerange
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Eeprom
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Eeprom
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Ram
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Ram
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Scan
+  name: Id
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Scan.15
+  name: Id
+  fields:
+  - value
+  values:
+  - 21;25;41;0010045478;0953;051794;N2
+  writable: false
+  has_data: true
+- circuit: Scan.76
+  name: Id
+  fields:
+  - value
+  values:
+  - 21;25;47;0010039571;3110;005964;N6
+  writable: false
+  has_data: true
+- circuit: Scan.ec
+  name: Id
+  fields:
+  - value
+  values:
+  - 21;25;41;0010045478;0953;051794;N2
+  writable: false
+  has_data: true
+- circuit: bai
+  name: ActiveStages
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: bai
+  name: FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: bai
+  name: FlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: bai
+  name: HeatingStage1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: bai
+  name: HeatingStage3
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: bai
+  name: PrEnergySumHc1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: bai
+  name: PrEnergySumHwc1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: bai
+  name: SetModeOverride
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: StorageTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: bai
+  name: StorageTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: bai
+  name: WaterPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: AdaptHeatCurve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: CcTimer_Config
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: CcTimer_Timeframes
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: ContinuousHeating
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: CylinderChargeHyst
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: CylinderChargeOffset
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Date
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: DisplayedOutsideTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: FrostOverRideTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1AutoOffMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1CircuitType
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1CoolingEnabled
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1CoolingFlowTempMin
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1DewPointMonitoring
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1DewPointOffset
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1DewPointTemp
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002300 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1ExcessTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1FlowTempCalc
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002000 / 050102200002)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1HeatCurve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1Humidity
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002200 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MixerMovement
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MixerPosition
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002100 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1PumpHours
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002400 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1PumpStarts
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002500 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1PumpStatus
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1RoomTempModulation
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1Status
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1SummerTempLimit
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2AutoOffMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2CircuitType
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2DewPointTemp
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012300 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2ExcessTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2FlowTempCalc
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012000 / 050002200000)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2HeatCurve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2Humidity
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012200 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MixerMovement
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MixerPosition
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012100 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2PumpHours
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012400 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2PumpStarts
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012500 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2PumpStatus
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2Status
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2SummerTempLimit
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3AutoOffMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3CircuitType
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3ExcessTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3HeatCurve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MixerMovement
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3PumpStatus
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3Status
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3SummerTempLimit
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HcStorageTempBottom
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: ctlv2
+  name: HcStorageTempTop
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: ctlv2
+  name: HwcFlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcLockTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcMaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcOpMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcParallelLoading
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcSFMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcSfMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcStorageTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcStorageTempBottom
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcStorageTempTop
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HydraulicScheme
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: ManualCoolingEndDate
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: ManualCoolingEndDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: ManualCoolingStartDate
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: ManualCoolingStartDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: MaxCylinderChargeTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: MaxRoomHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: MultiRelaySetting
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: OutsideTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: OutsideTempAvg
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySum
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHcLastMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHcThisMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHwcLastMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHwcThisMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: SystemFlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: WaterPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingManualTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingOpMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingSetbackTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1DayTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1HolidayTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1NightTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1OpMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoDuration
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoEndDate
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoEndTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1RoomTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1SFMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z2RoomTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: z1RoomHumidity
+  fields:
+  - value
+  values:
+  - '65'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: AdaptHeatCurve
+  fields:
+  - value
+  values:
+  - 'no'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: AdaptHeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Config
+  fields:
+  - value
+  values:
+  - 00 03 0a 00 00 00 ff ff 00
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CcTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Friday0
+  fields:
+  - value
+  values:
+  - 00:00;00:00
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CcTimer_Friday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Friday2
+  fields:
+  - value
+  values:
+  - 00:00;00:00
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CcTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Monday0
+  fields:
+  - value
+  values:
+  - 00:00;00:00
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CcTimer_Monday1
+  fields:
+  - value
+  values:
+  - 00:00;00:00
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CcTimer_Monday2
+  fields:
+  - value
+  values:
+  - 00:00;00:00
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CcTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Saturday0
+  fields:
+  - value
+  values:
+  - 00:00;00:00
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CcTimer_Saturday1
+  fields:
+  - value
+  values:
+  - 00:00;00:00
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CcTimer_Saturday2
+  fields:
+  - value
+  values:
+  - 00:00;00:00
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CcTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Sunday0
+  fields:
+  - value
+  values:
+  - 00:00;00:00
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CcTimer_Sunday1
+  fields:
+  - value
+  values:
+  - 00:00;00:00
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CcTimer_Sunday2
+  fields:
+  - value
+  values:
+  - 00:00;00:00
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CcTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Thursday0
+  fields:
+  - value
+  values:
+  - 00:00;00:00
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CcTimer_Thursday1
+  fields:
+  - value
+  values:
+  - 00:00;00:00
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CcTimer_Thursday2
+  fields:
+  - value
+  values:
+  - 00:00;00:00
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CcTimer_Timeframes
+  fields:
+  - value
+  values:
+  - 0;0;0;0;0;0;0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CcTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Tuesday0
+  fields:
+  - value
+  values:
+  - 00:00;00:00
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CcTimer_Tuesday1
+  fields:
+  - value
+  values:
+  - 00:00;00:00
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CcTimer_Tuesday2
+  fields:
+  - value
+  values:
+  - 00:00;00:00
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CcTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Wednesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Clearerrorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: ContinuousHeating
+  fields:
+  - value
+  values:
+  - '-26'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: ContinuousHeating
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - -;-;-;-;-
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CylinderChargeHyst
+  fields:
+  - value
+  values:
+  - '7'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CylinderChargeHyst
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CylinderChargeOffset
+  fields:
+  - value
+  values:
+  - '8'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CylinderChargeOffset
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Date
+  fields:
+  - value
+  values:
+  - 07.09.2026
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Date
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: DisplayedOutsideTemp
+  fields:
+  - value
+  values:
+  - '23'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: FrostOverRideTime
+  fields:
+  - value
+  values:
+  - '4'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: FrostOverRideTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1AutoOffMode
+  fields:
+  - value
+  values:
+  - night
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1AutoOffMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1CircuitType
+  fields:
+  - value
+  values:
+  - mixer
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1ExcessTemp
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1ExcessTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1FlowTemp
+  fields:
+  - value
+  values:
+  - '26'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1HeatCurve
+  fields:
+  - value
+  values:
+  - '0.25'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1HeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '50'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - '20'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - '30'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1MixerMovement
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1PumpStatus
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1PumpStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'off'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1Status
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1SummerTempLimit
+  fields:
+  - value
+  values:
+  - '14'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1SummerTempLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2AutoOffMode
+  fields:
+  - value
+  values:
+  - eco
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2AutoOffMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2CircuitType
+  fields:
+  - value
+  values:
+  - inactive
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2ExcessTemp
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2ExcessTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2FlowTemp
+  fields:
+  - value
+  values:
+  - (empty for 3115b52406020002010800 / 0800020800ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2HeatCurve
+  fields:
+  - value
+  values:
+  - '0.6'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2HeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '55'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - '20'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - '15'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2MixerMovement
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2PumpStatus
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2PumpStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'off'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2Status
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2SummerTempLimit
+  fields:
+  - value
+  values:
+  - '16'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2SummerTempLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3AutoOffMode
+  fields:
+  - value
+  values:
+  - eco
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3AutoOffMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3CircuitType
+  fields:
+  - value
+  values:
+  - inactive
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3ExcessTemp
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3ExcessTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3FlowTemp
+  fields:
+  - value
+  values:
+  - (empty for 3115b52406020002020800 / 0800020800ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3HeatCurve
+  fields:
+  - value
+  values:
+  - '0.6'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3HeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '55'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - '20'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - '15'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3MixerMovement
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3PumpStatus
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3PumpStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'off'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3Status
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3SummerTempLimit
+  fields:
+  - value
+  values:
+  - '16'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3SummerTempLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HcStorageTempBottom
+  fields:
+  - value
+  values:
+  - (empty for f115b5240602000000a000 / 080000a000ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HcStorageTempTop
+  fields:
+  - value
+  values:
+  - (empty for f115b52406020000009f00 / 0800009f00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcBankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcBankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcBankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcBankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcFlowTemp
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 01.01.2015
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 01.01.2015
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcLockTime
+  fields:
+  - value
+  values:
+  - '60'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcLockTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcMaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '80'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcMaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcOpMode
+  fields:
+  - value
+  values:
+  - auto
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcOpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcParallelLoading
+  fields:
+  - value
+  values:
+  - 'off'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcParallelLoading
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcSFMode
+  fields:
+  - value
+  values:
+  - auto
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcSFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcStorageTemp
+  fields:
+  - value
+  values:
+  - '42'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcStorageTempBottom
+  fields:
+  - value
+  values:
+  - (empty for f115b52406020000009e00 / 0800009e00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcStorageTempTop
+  fields:
+  - value
+  values:
+  - (empty for f115b52406020000009d00 / 0800009d00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTempDesired
+  fields:
+  - value
+  values:
+  - '50'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Config
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Friday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Friday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Friday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Monday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Monday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Monday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Saturday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Saturday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Saturday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Sunday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Sunday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Sunday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Thursday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Timeframes
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Tuesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Wednesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HydraulicScheme
+  fields:
+  - value
+  values:
+  - '8'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HydraulicScheme
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Installer1
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Installer1
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Installer2
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Installer2
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: KeyCodeforConfigMenu
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: KeyCodeforConfigMenu
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: MaintenanceDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: MaintenanceDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: MaintenanceDue
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: MaxCylinderChargeTime
+  fields:
+  - value
+  values:
+  - '90'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: MaxCylinderChargeTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: MaxRoomHumidity
+  fields:
+  - value
+  values:
+  - '40'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: MaxRoomHumidity
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: MultiRelaySetting
+  fields:
+  - value
+  values:
+  - circulation
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: MultiRelaySetting
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: OutsideTempAvg
+  fields:
+  - value
+  values:
+  - '19.8516'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: OutsideTempAvg
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PhoneNumber1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PhoneNumber1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PhoneNumber2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PhoneNumber2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySum
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020000005c00 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHc
+  fields:
+  - value
+  values:
+  - '1792'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: PrEnergySumHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHcLastMonth
+  fields:
+  - value
+  values:
+  - '15'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: PrEnergySumHcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHcThisMonth
+  fields:
+  - value
+  values:
+  - '3'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: PrEnergySumHcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHwc
+  fields:
+  - value
+  values:
+  - '327'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: PrEnergySumHwc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHwcLastMonth
+  fields:
+  - value
+  values:
+  - '41'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: PrEnergySumHwcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHwcThisMonth
+  fields:
+  - value
+  values:
+  - '8'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: PrEnergySumHwcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHwc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHwc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHwcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHwcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHwcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHwcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PumpAdditionalTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PumpAdditionalTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: SolarYieldTotal
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: SolarYieldTotal
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: SystemFlowTemp
+  fields:
+  - value
+  values:
+  - (empty for f115b52406020000004b00 / 0800004b00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Time
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Time
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: WaterPressure
+  fields:
+  - value
+  values:
+  - '1.9'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: YieldTotal
+  fields:
+  - value
+  values:
+  - '5277'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: YieldTotal
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1CoolingTemp
+  fields:
+  - value
+  values:
+  - '24'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1CoolingTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1DayTemp
+  fields:
+  - value
+  values:
+  - '19'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 09.10.2027
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 26.09.2026
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1HolidayTemp
+  fields:
+  - value
+  values:
+  - '15'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1NightTemp
+  fields:
+  - value
+  values:
+  - '18'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1OpMode
+  fields:
+  - value
+  values:
+  - auto
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1QuickVetoDuration
+  fields:
+  - value
+  values:
+  - '3'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1QuickVetoEndDate
+  fields:
+  - value
+  values:
+  - 07.09.2026
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1QuickVetoEndTime
+  fields:
+  - value
+  values:
+  - 04:02:00
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1QuickVetoTemp
+  fields:
+  - value
+  values:
+  - '20'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1RoomTemp
+  fields:
+  - value
+  values:
+  - '21.9125'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1SFMode
+  fields:
+  - value
+  values:
+  - auto
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Config
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Friday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Friday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Friday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Monday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Monday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Monday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Saturday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Saturday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Saturday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Sunday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Sunday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Sunday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Thursday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Timeframes
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Tuesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Wednesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2CoolingTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2CoolingTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2QuickVetoEndDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2QuickVetoEndTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2RoomTemp
+  fields:
+  - value
+  values:
+  - (empty for 3115b52406020003010f00 / 0802030f00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Config
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Friday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Friday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Friday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Monday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Monday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Monday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Saturday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Saturday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Saturday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Sunday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Sunday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Sunday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Thursday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Timeframes
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Tuesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Wednesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3QuickVetoEndDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3QuickVetoEndTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3RoomTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Config
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Friday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Friday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Friday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Monday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Monday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Monday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Saturday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Saturday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Saturday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Sunday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Sunday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Sunday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Thursday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Timeframes
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Tuesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Wednesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: BuildingCircuitFlow
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: BuildingCircuitPumpSpeed
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: CompressorHc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: CompressorHwc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHwc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: ConsumptionTotal
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CoolElecConsDay
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CoolElecConsTotal
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CoolEnvYieldDay
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CoolEnvYieldMonth
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CoolEnvYieldTotal
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CopCooling
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CopCoolingMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CopHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CopHcMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CopHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CopHwcMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CurrentCompressorUtil
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CurrentConsumedPower
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CurrentYieldPower
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: DateTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: FlowTemperature
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: HcElecConsDay
+  fields:
+  - value
+  values:
+  - '133.058'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: HcElecConsTotal
+  fields:
+  - value
+  values:
+  - '1.70677e+06'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: HoursCool
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: HwcElecConsDay
+  fields:
+  - value
+  values:
+  - '996.237'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: HwcElecConsTotal
+  fields:
+  - value
+  values:
+  - '325181'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: LiveMonitorCurrentConsumedPower
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: PowerConsumptionHmu
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunDataAirInletTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataBuildingCPumpPower
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataCompressorInletTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataCompressorOutletTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataCompressorSpeed
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataEEVOutletTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataEEVPositionAbs
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataElectricPowerConsumption
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataFan1Speed
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataFan2Speed
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataHighPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataLowPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunDataReturnTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataStatuscode
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStats4PortValveHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStats4PortValveSwitches
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsBuildingCPumpStarts
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsBuildingPumpHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunStatsCompressorHc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunStatsCompressorHwc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHwc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorStarts
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsFan1Hours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsFan1Starts
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsFan2Hours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsFan2Starts
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsHMUHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsHcHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsHwcHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: SourceTempInput
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: SourceTempOutput
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatElectricEnergySum
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatElectricEnergySumCool
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatElectricEnergySumHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatElectricEnergySumHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatEnvironmentEnergySum
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatEnvironmentEnergySumCool
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatEnvironmentEnergySumHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatEnvironmentEnergySumHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatSolarEnergySum
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatSolarEnergySumHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatSolarEnergySumHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.pumpstate
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.temp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.temp_1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.temp_2
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: Status01.temp_3
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: Status01.temp_4
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: StatusCirPump
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: SupplyTempWeighted
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: TotalEnergyUsage
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldCoolDay
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldCooling
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldCoolingMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldHcDay
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldHcMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldHwcDay
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldHwcMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmux0
+  name: AirIntakeTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: BuildingCircuitFlow
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: BuildingPumpHours
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: BuildingPumpHours
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: BuildingPumpStarts
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: BuildingPumpStarts
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: Clearerrorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: CompressorHours
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: CompressorHours
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: CompressorHysteresisCooling
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: CompressorHysteresisHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: CompressorStarts
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: CompressorStarts
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: ConsumptionThisYear1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: ConsumptionThisYear10
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: ConsumptionThisYear11
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: ConsumptionThisYear12
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: ConsumptionThisYear2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: ConsumptionThisYear3
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: ConsumptionThisYear4
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: ConsumptionThisYear5
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: ConsumptionThisYear6
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: ConsumptionThisYear7
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: ConsumptionThisYear8
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: ConsumptionThisYear9
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: ConsumptionTotal
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3108b516021802 / 00)'
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: CopHc
+  fields:
+  - value
+  values:
+  - '3.5'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: CopHcMonth
+  fields:
+  - value
+  values:
+  - '3.8'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: CopHwc
+  fields:
+  - value
+  values:
+  - '2.8'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: CopHwcMonth
+  fields:
+  - value
+  values:
+  - '3.1'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: CurrentCompressorUtil
+  fields:
+  - value
+  values:
+  - '0.00'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: CurrentConsumedPower
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: CurrentYieldPower
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - -;-;-;-;-
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: DateTime
+  fields:
+  - value
+  values:
+  - valid;21:20:39;07.09.2026;23.000
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: EEVSteps
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: EEVSteps
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: EnableTestCompressorExitTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: EnableTestCompressorIntakeTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: EnableTestCompressorSpeed
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: EnableTestCondensateTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: EnableTestEEVPosition
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: EnableTestEEVTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: EnableTestEvaporationTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: EnableTestFlowTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: EnableTestHighPress
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: EnableTestReturnTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: EnableTestWaterThroughput
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: EnableiveMonitorMain
+  fields:
+  - value
+  values:
+  - (empty for f108b503020003 / 0a6400ffffffffffffffff)
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: EnergyIntegral
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: Fan1Hours
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: Fan1Hours
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: Fan1Starts
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: Fan1Starts
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: Fan2Hours
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: Fan2Hours
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: Fan2Starts
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: Fan2Starts
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: FlowPressure
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: FlowTemp
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3108b51a0405ff3220 / 02ff01)'
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: FourWayValveHours
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: FourWayValveHours
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: FourWayValveSwitches
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: FourWayValveSwitches
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: FourWayValveSwitchingOperations
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: FourWayValveSwitchingOperations
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: HcBivalencePoint
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: HcModeActive
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: HeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: Hours
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: HoursCool
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: HoursHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: HoursHwc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: HwcBivalencePoint
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: HwcChargeHysteresis
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: HwcMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: HwcModeActive
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: ImmersionHeaterMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: LiveMonitorAirIntakeTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: LiveMonitorCurrentCompressorUtil
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: LiveMonitorCurrentConsumedPower
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: LiveMonitorCurrentSupplyTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: LiveMonitorCurrentYieldPower
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: LiveMonitorDesiredSupplyTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: LiveMonitorMain
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: MaxFlowTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: MinFlowTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: RunDataAirInletTemp
+  fields:
+  - value
+  values:
+  - '21.25'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: RunDataBuildingCPumpPower
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: RunDataCompressorInletTemp
+  fields:
+  - value
+  values:
+  - '22.6875'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: RunDataCompressorOutletTemp
+  fields:
+  - value
+  values:
+  - '23.4375'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: RunDataCompressorSpeed
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: RunDataEEVOutletTemp
+  fields:
+  - value
+  values:
+  - '21.375'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: RunDataEEVPositionAbs
+  fields:
+  - value
+  values:
+  - '250'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: RunDataElectricPowerConsumption
+  fields:
+  - value
+  values:
+  - '6'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: RunDataFan1Speed
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: RunDataFan2Speed
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: RunDataFlowTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: RunDataHighPressure
+  fields:
+  - value
+  values:
+  - '13.8'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: RunDataReturnTemp
+  fields:
+  - value
+  values:
+  - '22.2981'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: RunDataStatuscode
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: RunStats4PortValveHours
+  fields:
+  - value
+  values:
+  - '50'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: RunStats4PortValveSwitches
+  fields:
+  - value
+  values:
+  - '387'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: RunStatsBuildingCPumpStarts
+  fields:
+  - value
+  values:
+  - '358'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: RunStatsBuildingPumpHours
+  fields:
+  - value
+  values:
+  - '2153'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: RunStatsCompressorHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: RunStatsCompressorHours
+  fields:
+  - value
+  values:
+  - '1862'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: RunStatsCompressorHwc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: RunStatsCompressorStarts
+  fields:
+  - value
+  values:
+  - '1865'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: RunStatsFan1Hours
+  fields:
+  - value
+  values:
+  - '1908'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: RunStatsFan1Starts
+  fields:
+  - value
+  values:
+  - '2178'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: RunStatsFan2Hours
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: RunStatsFan2Starts
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: RunStatsHMUHours
+  fields:
+  - value
+  values:
+  - '5433'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: RunStatsHcHours
+  fields:
+  - value
+  values:
+  - '1761'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: RunStatsHwcHours
+  fields:
+  - value
+  values:
+  - '136'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: SetMode
+  fields:
+  - value
+  values:
+  - auto;0.0;-;-;1;1;1;0;0;0
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: SourcePressure
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: SourceTempOutput
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3108b51a0405ff3227 / 02ff01)'
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: StatBuildingPumpHours
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: StatBuildingPumpStarts
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: StatCompressorHours
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: StatCompressorStarts
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: StatEEVSteps
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: StatFan1Hours
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: StatFan1Starts
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: StatFourWayValveHours
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: StatFourWayValveSwitchingOperations
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: State
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: Status01
+  fields:
+  - value
+  values:
+  - 26.0;22.0;23.047;-;41.5;off
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: Status01.pumpstate
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmux0
+  name: Status01.temp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmux0
+  name: Status01.temp_1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmux0
+  name: Status01.temp_2
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmux0
+  name: Status01.temp_3
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmux0
+  name: Status01.temp_4
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmux0
+  name: Status02
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: Status16
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: StatusCirPump
+  fields:
+  - value
+  values:
+  - 'off'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: SummerSwitchOffTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TargetFlowTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TargetTempHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TargetTempHwc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TestAirIntakeTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TestBuildingPumpPower
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TestBuildingWaterPress
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TestCompressorExitTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TestCompressorInletTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TestCompressorSpeed
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TestCondensateTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TestCondensateTrayHeater
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TestCondensorInletTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TestCondensorOutletTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TestCylinderTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TestDCFStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TestEEVOutletTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TestEEVPosition
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TestEEVTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TestEvaporationTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TestFan1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TestFan2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TestFlowTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TestFlowTempImmersionHeater
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TestFourWayValve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TestHeatingCoilCompressor
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TestHighPress
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TestHighPressureSwitch
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TestImmersionHeaterSafetyCutOut
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TestLockoutContactS20
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TestLockoutContactS21
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TestLowPress
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TestMA1Output
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TestMIInput
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TestMO2Output
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TestMO3Output
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TestOutdoorTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TestOverheatingActualValue
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TestOverheatingTargetValue
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TestPrioritySwitchingValve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TestReturnTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TestSubcoolingActualValue
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TestSubcoolingTargetValue
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TestSystemTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TestTempSwitchCompressorOutlet
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TestWaterThroughput
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: TotalEnergyUsage
+  fields:
+  - value
+  values:
+  - '2031'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: YieldCoolDay
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: YieldHc
+  fields:
+  - value
+  values:
+  - '4662'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: YieldHcDay
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: YieldHcMonth
+  fields:
+  - value
+  values:
+  - '10.3'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: YieldHwc
+  fields:
+  - value
+  values:
+  - '616'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: YieldHwcDay
+  fields:
+  - value
+  values:
+  - '1.9'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: YieldHwcMonth
+  fields:
+  - value
+  values:
+  - '20.7'
+  writable: false
+  has_data: true
+- circuit: hmux0
+  name: YieldThisYear1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: YieldThisYear10
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: YieldThisYear11
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: YieldThisYear12
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: YieldThisYear2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: YieldThisYear3
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: YieldThisYear4
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: YieldThisYear5
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: YieldThisYear6
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: YieldThisYear7
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: YieldThisYear8
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: YieldThisYear9
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmux0
+  name: YieldTotal
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3108b516021801 / 00)'
+  writable: false
+  has_data: false
+- circuit: sc
+  name: Clearerrorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: Col
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: ColKickPumpTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: ColKickTempDelta
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: CollPump
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: D1Temp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: D2Temp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: Date
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: EDFunction
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: EDFunction
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: EnableScProtection
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: EnableScProtection
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: FlowRate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: FlowRate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: FrostProtectionEnabled
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: FrostProtectionLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: Hc1PumpKol1PP1Port
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: Hc2aLegPumpP2Port
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: Hc2zPort
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: HydraulicScheme
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: InitCircuit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: Iotest
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: Ioteststop
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: IsInBoostMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: KickFunction
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: KickFunction
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: LpZpMaPort
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: MAPreferredStorage
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: MAPreferredStorage
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: MaximalTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: MaximalTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: MaximalTemp2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: MaximalTemp2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: MultifunctionOutput
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: OMultifunction
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: OMultifunction
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: PumpAntiLockingFlags
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: QuickVetoStart
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: ResetSolGain
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: ResetSolGain
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: RuntimeCollPump
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: RuntimeCollPumpSeconds
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: SP1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: SP2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: ScProtectionHysteresis
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: ScProtectionLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: ScProtectionLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: ScProtectionTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: SolCollPumpDcIntegrator
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: SolCollPumpED
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: SolGain
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: SolOperationMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: SumSolGain
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: SumSolGainDayBefore
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: SystemMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: TempDifferenceOff
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: TempDifferenceOff
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: TempDifferenceOff2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: TempDifferenceOff2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: TempDifferenceOffTD12
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: TempDifferenceOffTD12
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: TempDifferenceOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: TempDifferenceOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: TempDifferenceOn2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: TempDifferenceOn2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: TempDifferenceOnTD12
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: TempDifferenceOnTD12
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: Time
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: Weekday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: YieldLastYear
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: YieldThisYear
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 31ecb509030d3f00 / 00)'
+  writable: false
+  has_data: false
+- circuit: v32
+  name: BypassPosition
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: ExhaustAirHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: ExhaustAirTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: FanHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: FlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: FlowTempMax
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: HcHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: HoursTillService
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: HwcHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: HwcTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: v32
+  name: Maintenancedata_HwcTempMax
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: v32
+  name: MaxAirHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: MinAirHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: OutdoorstempSensor
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: v32
+  name: OutsideAirTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: PumpHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: PumpPower
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: ReturnTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: ReturnTempMax
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: Status02.hwcmode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: Status02.temp0
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: Status02.temp0_1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: Status02.temp1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: Status02.temp1_1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: StorageLoadPumpHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: StorageTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: StorageTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: SupplyAirTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: VentilationLevelDay
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: VentilationLevelNight
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldToday
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldTotal
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldYear
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Clearerrorhistory
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Mc1Operation
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Mc2Operation
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Mc3Operation
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: SensorData1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: SensorData2
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: SetActorState
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vwz
+  name: TestHwcTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: vwz
+  name: TestOutdoorTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: vwz
+  name: TestThreeWayValve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: vwzio
+  name: EnableTestHwcTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: EnableTestOutdoorTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: EnableTestThreeWayValve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: TestHwcTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: TestOutdoorTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: TestThreeWayValve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+raw_find_lines_after:
+- bai SetModeOverride = no data stored
+- Broadcast Datetime = no data stored
+- Broadcast Error = no data stored
+- Broadcast HwcStatus = no data stored
+- Broadcast Id = no data stored
+- Broadcast IdAnswer = no data stored
+- Broadcast IdQuery = no data stored
+- Broadcast Load = no data stored
+- Broadcast Outsidetemp = 23.047
+- Broadcast Queryexistence = no data stored
+- Broadcast Signoflife = no data stored
+- Broadcast Vdatetime = 21:20:37;07.09.2026
+- Broadcast Vdatetime = no data stored
+- 'ctlv2 Hc1DewPointTemp =  (ERR: invalid position for 3115b52406020002002300 / 00)'
+- 'ctlv2 Hc1FlowTempCalc =  (ERR: invalid position for 3115b52406020002002000 / 050102200002)'
+- 'ctlv2 Hc1Humidity =  (ERR: invalid position for 3115b52406020002002200 / 00)'
+- 'ctlv2 Hc1MixerPosition =  (ERR: invalid position for 3115b52406020002002100 / 00)'
+- 'ctlv2 Hc1PumpHours =  (ERR: invalid position for 3115b52406020002002400 / 00)'
+- 'ctlv2 Hc1PumpStarts =  (ERR: invalid position for 3115b52406020002002500 / 00)'
+- 'ctlv2 Hc2DewPointTemp =  (ERR: invalid position for 3115b52406020002012300 / 00)'
+- 'ctlv2 Hc2FlowTempCalc =  (ERR: invalid position for 3115b52406020002012000 / 050002200000)'
+- 'ctlv2 Hc2Humidity =  (ERR: invalid position for 3115b52406020002012200 / 00)'
+- 'ctlv2 Hc2MixerPosition =  (ERR: invalid position for 3115b52406020002012100 / 00)'
+- 'ctlv2 Hc2PumpHours =  (ERR: invalid position for 3115b52406020002012400 / 00)'
+- 'ctlv2 Hc2PumpStarts =  (ERR: invalid position for 3115b52406020002012500 / 00)'
+- ctlv2 ManualCoolingEndDate = 01.01.2019
+- ctlv2 ManualCoolingEndDate = no data stored
+- ctlv2 ManualCoolingStartDate = 01.01.2019
+- ctlv2 ManualCoolingStartDate = no data stored
+- ctlv2 z1RoomHumidity = 65
+- ctlv3 AdaptHeatCurve = no
+- ctlv3 AdaptHeatCurve = no data stored
+- ctlv3 CcTimer_Config = 00 03 0a 00 00 00 ff ff 00
+- ctlv3 CcTimer_Friday0 = 00:00;00:00
+- ctlv3 CcTimer_Friday1 = no data stored
+- ctlv3 CcTimer_Friday2 = 00:00;00:00
+- ctlv3 CcTimer_Friday = no data stored
+- ctlv3 CcTimer_Monday0 = 00:00;00:00
+- ctlv3 CcTimer_Monday1 = 00:00;00:00
+- ctlv3 CcTimer_Monday2 = 00:00;00:00
+- ctlv3 CcTimer_Monday = no data stored
+- ctlv3 CcTimer_Saturday0 = 00:00;00:00
+- ctlv3 CcTimer_Saturday1 = 00:00;00:00
+- ctlv3 CcTimer_Saturday2 = 00:00;00:00
+- ctlv3 CcTimer_Saturday = no data stored
+- ctlv3 CcTimer_Sunday0 = 00:00;00:00
+- ctlv3 CcTimer_Sunday1 = 00:00;00:00
+- ctlv3 CcTimer_Sunday2 = 00:00;00:00
+- ctlv3 CcTimer_Sunday = no data stored
+- ctlv3 CcTimer_Thursday0 = 00:00;00:00
+- ctlv3 CcTimer_Thursday1 = 00:00;00:00
+- ctlv3 CcTimer_Thursday2 = 00:00;00:00
+- ctlv3 CcTimer_Thursday = no data stored
+- ctlv3 CcTimer_Timeframes = 0;0;0;0;0;0;0
+- ctlv3 CcTimer_Tuesday0 = 00:00;00:00
+- ctlv3 CcTimer_Tuesday1 = 00:00;00:00
+- ctlv3 CcTimer_Tuesday2 = 00:00;00:00
+- ctlv3 CcTimer_Tuesday = no data stored
+- ctlv3 CcTimer_Wednesday0 = no data stored
+- ctlv3 CcTimer_Wednesday1 = no data stored
+- ctlv3 CcTimer_Wednesday2 = no data stored
+- ctlv3 CcTimer_Wednesday = no data stored
+- ctlv3 Clearerrorhistory = no data stored
+- ctlv3 ContinuousHeating = -26
+- ctlv3 ContinuousHeating = no data stored
+- ctlv3 Currenterror = -;-;-;-;-
+- ctlv3 CylinderChargeHyst = 7
+- ctlv3 CylinderChargeHyst = no data stored
+- ctlv3 CylinderChargeOffset = 8
+- ctlv3 CylinderChargeOffset = no data stored
+- ctlv3 Date = 07.09.2026
+- ctlv3 Date = no data stored
+- ctlv3 DisplayedOutsideTemp = 23
+- ctlv3 Errorhistory = no data stored
+- ctlv3 FrostOverRideTime = 4
+- ctlv3 FrostOverRideTime = no data stored
+- ctlv3 Hc1ActualFlowTempDesired = 0.0
+- ctlv3 Hc1AutoOffMode = night
+- ctlv3 Hc1AutoOffMode = no data stored
+- ctlv3 Hc1CircuitType = mixer
+- ctlv3 Hc1ExcessTemp = 0.0
+- ctlv3 Hc1ExcessTemp = no data stored
+- ctlv3 Hc1FlowTemp = 26
+- ctlv3 Hc1HeatCurve = 0.25
+- ctlv3 Hc1HeatCurve = no data stored
+- ctlv3 Hc1HeatCurveAdaption = 0.0
+- ctlv3 Hc1MaxFlowTempDesired = 50
+- ctlv3 Hc1MaxFlowTempDesired = no data stored
+- ctlv3 Hc1MinCoolingTempDesired = 20
+- ctlv3 Hc1MinCoolingTempDesired = no data stored
+- ctlv3 Hc1MinFlowTempDesired = 30
+- ctlv3 Hc1MinFlowTempDesired = no data stored
+- ctlv3 Hc1MixerMovement = 0.0
+- ctlv3 Hc1PumpStatus = 0
+- ctlv3 Hc1PumpStatus = no data stored
+- ctlv3 Hc1RoomTempSwitchOn = off
+- ctlv3 Hc1RoomTempSwitchOn = no data stored
+- ctlv3 Hc1Status = 0
+- ctlv3 Hc1Status = no data stored
+- ctlv3 Hc1SummerTempLimit = 14
+- ctlv3 Hc1SummerTempLimit = no data stored
+- ctlv3 Hc2ActualFlowTempDesired = 0.0
+- ctlv3 Hc2AutoOffMode = eco
+- ctlv3 Hc2AutoOffMode = no data stored
+- ctlv3 Hc2CircuitType = inactive
+- ctlv3 Hc2ExcessTemp = 0.0
+- ctlv3 Hc2ExcessTemp = no data stored
+- ctlv3 Hc2FlowTemp =  (empty for 3115b52406020002010800 / 0800020800ffffff7f)
+- ctlv3 Hc2HeatCurve = 0.6
+- ctlv3 Hc2HeatCurve = no data stored
+- ctlv3 Hc2HeatCurveAdaption = 0.0
+- ctlv3 Hc2MaxFlowTempDesired = 55
+- ctlv3 Hc2MaxFlowTempDesired = no data stored
+- ctlv3 Hc2MinCoolingTempDesired = 20
+- ctlv3 Hc2MinCoolingTempDesired = no data stored
+- ctlv3 Hc2MinFlowTempDesired = 15
+- ctlv3 Hc2MinFlowTempDesired = no data stored
+- ctlv3 Hc2MixerMovement = 0.0
+- ctlv3 Hc2PumpStatus = 0
+- ctlv3 Hc2PumpStatus = no data stored
+- ctlv3 Hc2RoomTempSwitchOn = off
+- ctlv3 Hc2RoomTempSwitchOn = no data stored
+- ctlv3 Hc2Status = 0
+- ctlv3 Hc2Status = no data stored
+- ctlv3 Hc2SummerTempLimit = 16
+- ctlv3 Hc2SummerTempLimit = no data stored
+- ctlv3 Hc3ActualFlowTempDesired = 0.0
+- ctlv3 Hc3AutoOffMode = eco
+- ctlv3 Hc3AutoOffMode = no data stored
+- ctlv3 Hc3CircuitType = inactive
+- ctlv3 Hc3ExcessTemp = 0.0
+- ctlv3 Hc3ExcessTemp = no data stored
+- ctlv3 Hc3FlowTemp =  (empty for 3115b52406020002020800 / 0800020800ffffff7f)
+- ctlv3 Hc3HeatCurve = 0.6
+- ctlv3 Hc3HeatCurve = no data stored
+- ctlv3 Hc3HeatCurveAdaption = 0.0
+- ctlv3 Hc3MaxFlowTempDesired = 55
+- ctlv3 Hc3MaxFlowTempDesired = no data stored
+- ctlv3 Hc3MinCoolingTempDesired = 20
+- ctlv3 Hc3MinCoolingTempDesired = no data stored
+- ctlv3 Hc3MinFlowTempDesired = 15
+- ctlv3 Hc3MinFlowTempDesired = no data stored
+- ctlv3 Hc3MixerMovement = 0.0
+- ctlv3 Hc3PumpStatus = 0
+- ctlv3 Hc3PumpStatus = no data stored
+- ctlv3 Hc3RoomTempSwitchOn = off
+- ctlv3 Hc3RoomTempSwitchOn = no data stored
+- ctlv3 Hc3Status = 0
+- ctlv3 Hc3Status = no data stored
+- ctlv3 Hc3SummerTempLimit = 16
+- ctlv3 Hc3SummerTempLimit = no data stored
+- ctlv3 HcStorageTempBottom =  (empty for f115b5240602000000a000 / 080000a000ffffff7f)
+- ctlv3 HcStorageTempTop =  (empty for f115b52406020000009f00 / 0800009f00ffffff7f)
+- ctlv3 HwcBankHolidayEndPeriod = no data stored
+- ctlv3 HwcBankHolidayEndPeriod = no data stored
+- ctlv3 HwcBankHolidayStartPeriod = no data stored
+- ctlv3 HwcBankHolidayStartPeriod = no data stored
+- ctlv3 HwcFlowTemp = 0.0
+- ctlv3 HwcHolidayEndPeriod = 01.01.2015
+- ctlv3 HwcHolidayEndPeriod = no data stored
+- ctlv3 HwcHolidayStartPeriod = 01.01.2015
+- ctlv3 HwcHolidayStartPeriod = no data stored
+- ctlv3 HwcLockTime = 60
+- ctlv3 HwcLockTime = no data stored
+- ctlv3 HwcMaxFlowTempDesired = 80
+- ctlv3 HwcMaxFlowTempDesired = no data stored
+- ctlv3 HwcOpMode = auto
+- ctlv3 HwcOpMode = no data stored
+- ctlv3 HwcParallelLoading = off
+- ctlv3 HwcParallelLoading = no data stored
+- ctlv3 HwcSFMode = auto
+- ctlv3 HwcSFMode = no data stored
+- ctlv3 HwcStorageTemp = 42
+- ctlv3 HwcStorageTempBottom =  (empty for f115b52406020000009e00 / 0800009e00ffffff7f)
+- ctlv3 HwcStorageTempTop =  (empty for f115b52406020000009d00 / 0800009d00ffffff7f)
+- ctlv3 HwcTempDesired = 50
+- ctlv3 HwcTempDesired = no data stored
+- ctlv3 HwcTimer_Config = no data stored
+- ctlv3 HwcTimer_Friday0 = no data stored
+- ctlv3 HwcTimer_Friday1 = no data stored
+- ctlv3 HwcTimer_Friday2 = no data stored
+- ctlv3 HwcTimer_Friday = no data stored
+- ctlv3 HwcTimer_Monday0 = no data stored
+- ctlv3 HwcTimer_Monday1 = no data stored
+- ctlv3 HwcTimer_Monday2 = no data stored
+- ctlv3 HwcTimer_Monday = no data stored
+- ctlv3 HwcTimer_Saturday0 = no data stored
+- ctlv3 HwcTimer_Saturday1 = no data stored
+- ctlv3 HwcTimer_Saturday2 = no data stored
+- ctlv3 HwcTimer_Saturday = no data stored
+- ctlv3 HwcTimer_Sunday0 = no data stored
+- ctlv3 HwcTimer_Sunday1 = no data stored
+- ctlv3 HwcTimer_Sunday2 = no data stored
+- ctlv3 HwcTimer_Sunday = no data stored
+- ctlv3 HwcTimer_Thursday0 = no data stored
+- ctlv3 HwcTimer_Thursday1 = no data stored
+- ctlv3 HwcTimer_Thursday2 = no data stored
+- ctlv3 HwcTimer_Thursday = no data stored
+- ctlv3 HwcTimer_Timeframes = no data stored
+- ctlv3 HwcTimer_Tuesday0 = no data stored
+- ctlv3 HwcTimer_Tuesday1 = no data stored
+- ctlv3 HwcTimer_Tuesday2 = no data stored
+- ctlv3 HwcTimer_Tuesday = no data stored
+- ctlv3 HwcTimer_Wednesday0 = no data stored
+- ctlv3 HwcTimer_Wednesday1 = no data stored
+- ctlv3 HwcTimer_Wednesday2 = no data stored
+- ctlv3 HwcTimer_Wednesday = no data stored
+- ctlv3 HydraulicScheme = 8
+- ctlv3 HydraulicScheme = no data stored
+- ctlv3 Installer1 = no data stored
+- ctlv3 Installer1 = no data stored
+- ctlv3 Installer2 = no data stored
+- ctlv3 Installer2 = no data stored
+- ctlv3 KeyCodeforConfigMenu = no data stored
+- ctlv3 KeyCodeforConfigMenu = no data stored
+- ctlv3 MaintenanceDate = no data stored
+- ctlv3 MaintenanceDate = no data stored
+- ctlv3 MaintenanceDue = no data stored
+- ctlv3 MaxCylinderChargeTime = 90
+- ctlv3 MaxCylinderChargeTime = no data stored
+- ctlv3 MaxRoomHumidity = 40
+- ctlv3 MaxRoomHumidity = no data stored
+- ctlv3 MultiRelaySetting = circulation
+- ctlv3 MultiRelaySetting = no data stored
+- ctlv3 OutsideTempAvg = 19.8516
+- ctlv3 OutsideTempAvg = no data stored
+- ctlv3 PhoneNumber1 = no data stored
+- ctlv3 PhoneNumber1 = no data stored
+- ctlv3 PhoneNumber2 = no data stored
+- ctlv3 PhoneNumber2 = no data stored
+- 'ctlv3 PrEnergySum =  (ERR: invalid position for 3115b52406020000005c00 / 00)'
+- ctlv3 PrEnergySum = no data stored
+- ctlv3 PrEnergySumHc = 1792
+- ctlv3 PrEnergySumHc = no data stored
+- ctlv3 PrEnergySumHcLastMonth = 15
+- ctlv3 PrEnergySumHcLastMonth = no data stored
+- ctlv3 PrEnergySumHcThisMonth = 3
+- ctlv3 PrEnergySumHcThisMonth = no data stored
+- ctlv3 PrEnergySumHwc = 327
+- ctlv3 PrEnergySumHwc = no data stored
+- ctlv3 PrEnergySumHwcLastMonth = 41
+- ctlv3 PrEnergySumHwcLastMonth = no data stored
+- ctlv3 PrEnergySumHwcThisMonth = 8
+- ctlv3 PrEnergySumHwcThisMonth = no data stored
+- ctlv3 PrFuelSum = no data stored
+- ctlv3 PrFuelSum = no data stored
+- ctlv3 PrFuelSumHc = no data stored
+- ctlv3 PrFuelSumHc = no data stored
+- ctlv3 PrFuelSumHcLastMonth = no data stored
+- ctlv3 PrFuelSumHcLastMonth = no data stored
+- ctlv3 PrFuelSumHcThisMonth = no data stored
+- ctlv3 PrFuelSumHcThisMonth = no data stored
+- ctlv3 PrFuelSumHwc = no data stored
+- ctlv3 PrFuelSumHwc = no data stored
+- ctlv3 PrFuelSumHwcLastMonth = no data stored
+- ctlv3 PrFuelSumHwcLastMonth = no data stored
+- ctlv3 PrFuelSumHwcThisMonth = no data stored
+- ctlv3 PrFuelSumHwcThisMonth = no data stored
+- ctlv3 PumpAdditionalTime = no data stored
+- ctlv3 PumpAdditionalTime = no data stored
+- ctlv3 SolarYieldTotal = no data stored
+- ctlv3 SolarYieldTotal = no data stored
+- ctlv3 SystemFlowTemp =  (empty for f115b52406020000004b00 / 0800004b00ffffff7f)
+- ctlv3 Time = no data stored
+- ctlv3 Time = no data stored
+- ctlv3 WaterPressure = 1.9
+- ctlv3 YieldTotal = 5277
+- ctlv3 YieldTotal = no data stored
+- ctlv3 Z1ActualRoomTempDesired = 0.0
+- ctlv3 Z1ActualRoomTempDesired = no data stored
+- ctlv3 Z1BankHolidayEndPeriod = no data stored
+- ctlv3 Z1BankHolidayEndPeriod = no data stored
+- ctlv3 Z1BankHolidayStartPeriod = no data stored
+- ctlv3 Z1BankHolidayStartPeriod = no data stored
+- ctlv3 Z1CoolingTemp = 24
+- ctlv3 Z1CoolingTemp = no data stored
+- ctlv3 Z1DayTemp = 19
+- ctlv3 Z1DayTemp = no data stored
+- ctlv3 Z1HolidayEndPeriod = 09.10.2027
+- ctlv3 Z1HolidayEndPeriod = no data stored
+- ctlv3 Z1HolidayStartPeriod = 26.09.2026
+- ctlv3 Z1HolidayStartPeriod = no data stored
+- ctlv3 Z1HolidayTemp = 15
+- ctlv3 Z1HolidayTemp = no data stored
+- ctlv3 Z1Name1 = no data stored
+- ctlv3 Z1Name1 = no data stored
+- ctlv3 Z1Name2 = no data stored
+- ctlv3 Z1Name2 = no data stored
+- ctlv3 Z1NightTemp = 18
+- ctlv3 Z1NightTemp = no data stored
+- ctlv3 Z1OpMode = auto
+- ctlv3 Z1OpMode = no data stored
+- ctlv3 Z1QuickVetoDuration = 3
+- ctlv3 Z1QuickVetoDuration = no data stored
+- ctlv3 Z1QuickVetoEndDate = 07.09.2026
+- ctlv3 Z1QuickVetoEndTime = 04:02:00
+- ctlv3 Z1QuickVetoTemp = 20
+- ctlv3 Z1QuickVetoTemp = no data stored
+- ctlv3 Z1RoomTemp = 21.9125
+- ctlv3 Z1RoomZoneMapping = no data stored
+- ctlv3 Z1RoomZoneMapping = no data stored
+- ctlv3 Z1SFMode = auto
+- ctlv3 Z1SFMode = no data stored
+- ctlv3 Z1Shortname = no data stored
+- ctlv3 Z1Shortname = no data stored
+- ctlv3 Z1Timer_Config = no data stored
+- ctlv3 Z1Timer_Friday0 = no data stored
+- ctlv3 Z1Timer_Friday1 = no data stored
+- ctlv3 Z1Timer_Friday2 = no data stored
+- ctlv3 Z1Timer_Friday = no data stored
+- ctlv3 Z1Timer_Monday0 = no data stored
+- ctlv3 Z1Timer_Monday1 = no data stored
+- ctlv3 Z1Timer_Monday2 = no data stored
+- ctlv3 Z1Timer_Monday = no data stored
+- ctlv3 Z1Timer_Saturday0 = no data stored
+- ctlv3 Z1Timer_Saturday1 = no data stored
+- ctlv3 Z1Timer_Saturday2 = no data stored
+- ctlv3 Z1Timer_Saturday = no data stored
+- ctlv3 Z1Timer_Sunday0 = no data stored
+- ctlv3 Z1Timer_Sunday1 = no data stored
+- ctlv3 Z1Timer_Sunday2 = no data stored
+- ctlv3 Z1Timer_Sunday = no data stored
+- ctlv3 Z1Timer_Thursday0 = no data stored
+- ctlv3 Z1Timer_Thursday1 = no data stored
+- ctlv3 Z1Timer_Thursday2 = no data stored
+- ctlv3 Z1Timer_Thursday = no data stored
+- ctlv3 Z1Timer_Timeframes = no data stored
+- ctlv3 Z1Timer_Tuesday0 = no data stored
+- ctlv3 Z1Timer_Tuesday1 = no data stored
+- ctlv3 Z1Timer_Tuesday2 = no data stored
+- ctlv3 Z1Timer_Tuesday = no data stored
+- ctlv3 Z1Timer_Wednesday0 = no data stored
+- ctlv3 Z1Timer_Wednesday1 = no data stored
+- ctlv3 Z1Timer_Wednesday2 = no data stored
+- ctlv3 Z1Timer_Wednesday = no data stored
+- ctlv3 Z1ValveStatus = no data stored
+- ctlv3 Z1ValveStatus = no data stored
+- ctlv3 Z2ActualRoomTempDesired = no data stored
+- ctlv3 Z2ActualRoomTempDesired = no data stored
+- ctlv3 Z2BankHolidayEndPeriod = no data stored
+- ctlv3 Z2BankHolidayEndPeriod = no data stored
+- ctlv3 Z2BankHolidayStartPeriod = no data stored
+- ctlv3 Z2BankHolidayStartPeriod = no data stored
+- ctlv3 Z2CoolingTemp = no data stored
+- ctlv3 Z2CoolingTemp = no data stored
+- ctlv3 Z2DayTemp = no data stored
+- ctlv3 Z2DayTemp = no data stored
+- ctlv3 Z2HolidayEndPeriod = no data stored
+- ctlv3 Z2HolidayEndPeriod = no data stored
+- ctlv3 Z2HolidayStartPeriod = no data stored
+- ctlv3 Z2HolidayStartPeriod = no data stored
+- ctlv3 Z2HolidayTemp = no data stored
+- ctlv3 Z2HolidayTemp = no data stored
+- ctlv3 Z2Name1 = no data stored
+- ctlv3 Z2Name1 = no data stored
+- ctlv3 Z2Name2 = no data stored
+- ctlv3 Z2Name2 = no data stored
+- ctlv3 Z2NightTemp = no data stored
+- ctlv3 Z2NightTemp = no data stored
+- ctlv3 Z2OpMode = no data stored
+- ctlv3 Z2OpMode = no data stored
+- ctlv3 Z2QuickVetoDuration = no data stored
+- ctlv3 Z2QuickVetoDuration = no data stored
+- ctlv3 Z2QuickVetoEndDate = no data stored
+- ctlv3 Z2QuickVetoEndTime = no data stored
+- ctlv3 Z2QuickVetoTemp = no data stored
+- ctlv3 Z2QuickVetoTemp = no data stored
+- ctlv3 Z2RoomTemp =  (empty for 3115b52406020003010f00 / 0802030f00ffffff7f)
+- ctlv3 Z2RoomZoneMapping = no data stored
+- ctlv3 Z2RoomZoneMapping = no data stored
+- ctlv3 Z2SFMode = no data stored
+- ctlv3 Z2SFMode = no data stored
+- ctlv3 Z2Shortname = no data stored
+- ctlv3 Z2Shortname = no data stored
+- ctlv3 Z2Timer_Config = no data stored
+- ctlv3 Z2Timer_Friday0 = no data stored
+- ctlv3 Z2Timer_Friday1 = no data stored
+- ctlv3 Z2Timer_Friday2 = no data stored
+- ctlv3 Z2Timer_Friday = no data stored
+- ctlv3 Z2Timer_Monday0 = no data stored
+- ctlv3 Z2Timer_Monday1 = no data stored
+- ctlv3 Z2Timer_Monday2 = no data stored
+- ctlv3 Z2Timer_Monday = no data stored
+- ctlv3 Z2Timer_Saturday0 = no data stored
+- ctlv3 Z2Timer_Saturday1 = no data stored
+- ctlv3 Z2Timer_Saturday2 = no data stored
+- ctlv3 Z2Timer_Saturday = no data stored
+- ctlv3 Z2Timer_Sunday0 = no data stored
+- ctlv3 Z2Timer_Sunday1 = no data stored
+- ctlv3 Z2Timer_Sunday2 = no data stored
+- ctlv3 Z2Timer_Sunday = no data stored
+- ctlv3 Z2Timer_Thursday0 = no data stored
+- ctlv3 Z2Timer_Thursday1 = no data stored
+- ctlv3 Z2Timer_Thursday2 = no data stored
+- ctlv3 Z2Timer_Thursday = no data stored
+- ctlv3 Z2Timer_Timeframes = no data stored
+- ctlv3 Z2Timer_Tuesday0 = no data stored
+- ctlv3 Z2Timer_Tuesday1 = no data stored
+- ctlv3 Z2Timer_Tuesday2 = no data stored
+- ctlv3 Z2Timer_Tuesday = no data stored
+- ctlv3 Z2Timer_Wednesday0 = no data stored
+- ctlv3 Z2Timer_Wednesday1 = no data stored
+- ctlv3 Z2Timer_Wednesday2 = no data stored
+- ctlv3 Z2Timer_Wednesday = no data stored
+- ctlv3 Z2ValveStatus = no data stored
+- ctlv3 Z2ValveStatus = no data stored
+- ctlv3 Z3ActualRoomTempDesired = no data stored
+- ctlv3 Z3ActualRoomTempDesired = no data stored
+- ctlv3 Z3BankHolidayEndPeriod = no data stored
+- ctlv3 Z3BankHolidayEndPeriod = no data stored
+- ctlv3 Z3BankHolidayStartPeriod = no data stored
+- ctlv3 Z3BankHolidayStartPeriod = no data stored
+- ctlv3 Z3DayTemp = no data stored
+- ctlv3 Z3DayTemp = no data stored
+- ctlv3 Z3HolidayEndPeriod = no data stored
+- ctlv3 Z3HolidayEndPeriod = no data stored
+- ctlv3 Z3HolidayStartPeriod = no data stored
+- ctlv3 Z3HolidayStartPeriod = no data stored
+- ctlv3 Z3HolidayTemp = no data stored
+- ctlv3 Z3HolidayTemp = no data stored
+- ctlv3 Z3Name1 = no data stored
+- ctlv3 Z3Name1 = no data stored
+- ctlv3 Z3Name2 = no data stored
+- ctlv3 Z3Name2 = no data stored
+- ctlv3 Z3NightTemp = no data stored
+- ctlv3 Z3NightTemp = no data stored
+- ctlv3 Z3OpMode = no data stored
+- ctlv3 Z3OpMode = no data stored
+- ctlv3 Z3QuickVetoDuration = no data stored
+- ctlv3 Z3QuickVetoDuration = no data stored
+- ctlv3 Z3QuickVetoEndDate = no data stored
+- ctlv3 Z3QuickVetoEndTime = no data stored
+- ctlv3 Z3QuickVetoTemp = no data stored
+- ctlv3 Z3QuickVetoTemp = no data stored
+- ctlv3 Z3RoomTemp = no data stored
+- ctlv3 Z3RoomZoneMapping = no data stored
+- ctlv3 Z3RoomZoneMapping = no data stored
+- ctlv3 Z3SFMode = no data stored
+- ctlv3 Z3SFMode = no data stored
+- ctlv3 Z3Shortname = no data stored
+- ctlv3 Z3Shortname = no data stored
+- ctlv3 Z3Timer_Config = no data stored
+- ctlv3 Z3Timer_Friday0 = no data stored
+- ctlv3 Z3Timer_Friday1 = no data stored
+- ctlv3 Z3Timer_Friday2 = no data stored
+- ctlv3 Z3Timer_Friday = no data stored
+- ctlv3 Z3Timer_Monday0 = no data stored
+- ctlv3 Z3Timer_Monday1 = no data stored
+- ctlv3 Z3Timer_Monday2 = no data stored
+- ctlv3 Z3Timer_Monday = no data stored
+- ctlv3 Z3Timer_Saturday0 = no data stored
+- ctlv3 Z3Timer_Saturday1 = no data stored
+- ctlv3 Z3Timer_Saturday2 = no data stored
+- ctlv3 Z3Timer_Saturday = no data stored
+- ctlv3 Z3Timer_Sunday0 = no data stored
+- ctlv3 Z3Timer_Sunday1 = no data stored
+- ctlv3 Z3Timer_Sunday2 = no data stored
+- ctlv3 Z3Timer_Sunday = no data stored
+- ctlv3 Z3Timer_Thursday0 = no data stored
+- ctlv3 Z3Timer_Thursday1 = no data stored
+- ctlv3 Z3Timer_Thursday2 = no data stored
+- ctlv3 Z3Timer_Thursday = no data stored
+- ctlv3 Z3Timer_Timeframes = no data stored
+- ctlv3 Z3Timer_Tuesday0 = no data stored
+- ctlv3 Z3Timer_Tuesday1 = no data stored
+- ctlv3 Z3Timer_Tuesday2 = no data stored
+- ctlv3 Z3Timer_Tuesday = no data stored
+- ctlv3 Z3Timer_Wednesday0 = no data stored
+- ctlv3 Z3Timer_Wednesday1 = no data stored
+- ctlv3 Z3Timer_Wednesday2 = no data stored
+- ctlv3 Z3Timer_Wednesday = no data stored
+- ctlv3 Z3ValveStatus = no data stored
+- ctlv3 Z3ValveStatus = no data stored
+- General Valuerange = no data stored
+- hmu CoolElecConsDay = 0.0
+- hmu CoolElecConsTotal = 0.0
+- hmu CoolEnvYieldDay = 0.0
+- hmu CoolEnvYieldMonth = 0.0
+- hmu CoolEnvYieldTotal = 0.0
+- hmu HcElecConsDay = 133.058
+- hmu HcElecConsTotal = 1.70677e+06
+- hmu HwcElecConsDay = 996.237
+- hmu HwcElecConsTotal = 325181
+- 'hmu SourceTempInput =  (ERR: invalid position for 3108b51a0405ff3222 / 02ff01)'
+- hmux0 AirIntakeTemp = no data stored
+- hmux0 BuildingCircuitFlow = 0
+- hmux0 BuildingPumpHours = no data stored
+- hmux0 BuildingPumpHours = no data stored
+- hmux0 BuildingPumpStarts = no data stored
+- hmux0 BuildingPumpStarts = no data stored
+- hmux0 Clearerrorhistory = no data stored
+- hmux0 CompressorHours = no data stored
+- hmux0 CompressorHours = no data stored
+- hmux0 CompressorHysteresisCooling = no data stored
+- hmux0 CompressorHysteresisHc = no data stored
+- hmux0 CompressorStarts = no data stored
+- hmux0 CompressorStarts = no data stored
+- hmux0 ConsumptionThisYear10 = no data stored
+- hmux0 ConsumptionThisYear11 = no data stored
+- hmux0 ConsumptionThisYear12 = no data stored
+- hmux0 ConsumptionThisYear1 = no data stored
+- hmux0 ConsumptionThisYear2 = no data stored
+- hmux0 ConsumptionThisYear3 = no data stored
+- hmux0 ConsumptionThisYear4 = no data stored
+- hmux0 ConsumptionThisYear5 = no data stored
+- hmux0 ConsumptionThisYear6 = no data stored
+- hmux0 ConsumptionThisYear7 = no data stored
+- hmux0 ConsumptionThisYear8 = no data stored
+- hmux0 ConsumptionThisYear9 = no data stored
+- 'hmux0 ConsumptionTotal =  (ERR: invalid position for 3108b516021802 / 00)'
+- hmux0 CopHc = 3.5
+- hmux0 CopHcMonth = 3.8
+- hmux0 CopHwc = 2.8
+- hmux0 CopHwcMonth = 3.1
+- hmux0 CurrentCompressorUtil = 0.00
+- hmux0 CurrentConsumedPower = 0.0
+- hmux0 Currenterror = -;-;-;-;-
+- hmux0 CurrentYieldPower = 0.0
+- hmux0 DateTime = valid;21:20:39;07.09.2026;23.000
+- hmux0 EEVSteps = no data stored
+- hmux0 EEVSteps = no data stored
+- hmux0 EnableiveMonitorMain =  (empty for f108b503020003 / 0a6400ffffffffffffffff)
+- hmux0 EnableTestCompressorExitTemp = no data stored
+- hmux0 EnableTestCompressorIntakeTemp = no data stored
+- hmux0 EnableTestCompressorSpeed = no data stored
+- hmux0 EnableTestCondensateTemp = no data stored
+- hmux0 EnableTestEEVPosition = no data stored
+- hmux0 EnableTestEEVTemp = no data stored
+- hmux0 EnableTestEvaporationTemp = no data stored
+- hmux0 EnableTestFlowTemp = no data stored
+- hmux0 EnableTestHighPress = no data stored
+- hmux0 EnableTestReturnTemp = no data stored
+- hmux0 EnableTestWaterThroughput = no data stored
+- hmux0 EnergyIntegral = no data stored
+- hmux0 Errorhistory = no data stored
+- hmux0 Fan1Hours = no data stored
+- hmux0 Fan1Hours = no data stored
+- hmux0 Fan1Starts = no data stored
+- hmux0 Fan1Starts = no data stored
+- hmux0 Fan2Hours = no data stored
+- hmux0 Fan2Hours = no data stored
+- hmux0 Fan2Starts = no data stored
+- hmux0 Fan2Starts = no data stored
+- hmux0 FlowPressure = no data stored
+- 'hmux0 FlowTemp =  (ERR: invalid position for 3108b51a0405ff3220 / 02ff01)'
+- hmux0 FourWayValveHours = no data stored
+- hmux0 FourWayValveHours = no data stored
+- hmux0 FourWayValveSwitches = no data stored
+- hmux0 FourWayValveSwitches = no data stored
+- hmux0 FourWayValveSwitchingOperations = no data stored
+- hmux0 FourWayValveSwitchingOperations = no data stored
+- hmux0 HcBivalencePoint = no data stored
+- hmux0 HcModeActive = no data stored
+- hmux0 HeatCurve = no data stored
+- hmux0 Hours = no data stored
+- hmux0 HoursCool = 0
+- hmux0 HoursHc = no data stored
+- hmux0 HoursHwc = no data stored
+- hmux0 HwcBivalencePoint = no data stored
+- hmux0 HwcChargeHysteresis = no data stored
+- hmux0 HwcMode = no data stored
+- hmux0 HwcModeActive = no data stored
+- hmux0 ImmersionHeaterMode = no data stored
+- hmux0 LiveMonitorAirIntakeTemp = no data stored
+- hmux0 LiveMonitorCurrentCompressorUtil = no data stored
+- hmux0 LiveMonitorCurrentConsumedPower = 0.0
+- hmux0 LiveMonitorCurrentSupplyTemp = no data stored
+- hmux0 LiveMonitorCurrentYieldPower = no data stored
+- hmux0 LiveMonitorDesiredSupplyTemp = no data stored
+- hmux0 LiveMonitorMain = no data stored
+- hmux0 MaxFlowTemp = no data stored
+- hmux0 MinFlowTemp = no data stored
+- hmux0 RunDataAirInletTemp = 21.25
+- hmux0 RunDataBuildingCPumpPower = 0.0
+- hmux0 RunDataCompressorInletTemp = 22.6875
+- hmux0 RunDataCompressorOutletTemp = 23.4375
+- hmux0 RunDataCompressorSpeed = 0.0
+- hmux0 RunDataEEVOutletTemp = 21.375
+- hmux0 RunDataEEVPositionAbs = 250
+- hmux0 RunDataElectricPowerConsumption = 6
+- hmux0 RunDataFan1Speed = 0.0
+- hmux0 RunDataFan2Speed = 0.0
+- hmux0 RunDataFlowTemp = no data stored
+- hmux0 RunDataHighPressure = 13.8
+- hmux0 RunDataReturnTemp = 22.2981
+- 'hmux0 RunDataStatuscode =  (ERR: invalid position for 3108b50905540200530d / 040208530d)'
+- hmux0 RunStats4PortValveHours = 50
+- hmux0 RunStats4PortValveSwitches = 387
+- hmux0 RunStatsBuildingCPumpStarts = 358
+- hmux0 RunStatsBuildingPumpHours = 2153
+- hmux0 RunStatsCompressorHc = no data stored
+- hmux0 RunStatsCompressorHours = 1862
+- hmux0 RunStatsCompressorHwc = no data stored
+- hmux0 RunStatsCompressorStarts = 1865
+- hmux0 RunStatsFan1Hours = 1908
+- hmux0 RunStatsFan1Starts = 2178
+- hmux0 RunStatsFan2Hours = 0
+- hmux0 RunStatsFan2Starts = 0
+- hmux0 RunStatsHcHours = 1761
+- hmux0 RunStatsHMUHours = 5433
+- hmux0 RunStatsHwcHours = 136
+- hmux0 SetMode = auto;0.0;-;-;1;1;1;0;0;0
+- hmux0 SourcePressure = no data stored
+- 'hmux0 SourceTempOutput =  (ERR: invalid position for 3108b51a0405ff3227 / 02ff01)'
+- hmux0 StatBuildingPumpHours = no data stored
+- hmux0 StatBuildingPumpStarts = no data stored
+- hmux0 StatCompressorHours = no data stored
+- hmux0 StatCompressorStarts = no data stored
+- hmux0 State = no data stored
+- hmux0 StatEEVSteps = no data stored
+- hmux0 StatFan1Hours = no data stored
+- hmux0 StatFan1Starts = no data stored
+- hmux0 StatFourWayValveHours = no data stored
+- hmux0 StatFourWayValveSwitchingOperations = no data stored
+- hmux0 Status01 = 26.0;22.0;23.047;-;41.5;off
+- hmux0 Status02 = no data stored
+- hmux0 Status16 = no data stored
+- hmux0 Status = no data stored
+- hmux0 StatusCirPump = off
+- hmux0 SummerSwitchOffTemp = no data stored
+- hmux0 TargetFlowTemp = no data stored
+- hmux0 TargetTempHc = no data stored
+- hmux0 TargetTempHwc = no data stored
+- hmux0 TestAirIntakeTemp = no data stored
+- hmux0 TestBuildingPumpPower = no data stored
+- hmux0 TestBuildingWaterPress = no data stored
+- hmux0 TestCompressorExitTemp = no data stored
+- hmux0 TestCompressorInletTemp = no data stored
+- hmux0 TestCompressorSpeed = no data stored
+- hmux0 TestCondensateTemp = no data stored
+- hmux0 TestCondensateTrayHeater = no data stored
+- hmux0 TestCondensorInletTemp = no data stored
+- hmux0 TestCondensorOutletTemp = no data stored
+- hmux0 TestCylinderTemp = no data stored
+- hmux0 TestDCFStatus = no data stored
+- hmux0 TestEEVOutletTemp = no data stored
+- hmux0 TestEEVPosition = no data stored
+- hmux0 TestEEVTemp = no data stored
+- hmux0 TestEvaporationTemp = no data stored
+- hmux0 TestFan1 = no data stored
+- hmux0 TestFan2 = no data stored
+- hmux0 TestFlowTemp = no data stored
+- hmux0 TestFlowTempImmersionHeater = no data stored
+- hmux0 TestFourWayValve = no data stored
+- hmux0 TestHeatingCoilCompressor = no data stored
+- hmux0 TestHighPress = no data stored
+- hmux0 TestHighPressureSwitch = no data stored
+- hmux0 TestImmersionHeaterSafetyCutOut = no data stored
+- hmux0 TestLockoutContactS20 = no data stored
+- hmux0 TestLockoutContactS21 = no data stored
+- hmux0 TestLowPress = no data stored
+- hmux0 TestMA1Output = no data stored
+- hmux0 TestMIInput = no data stored
+- hmux0 TestMO2Output = no data stored
+- hmux0 TestMO3Output = no data stored
+- hmux0 TestOutdoorTemp = no data stored
+- hmux0 TestOverheatingActualValue = no data stored
+- hmux0 TestOverheatingTargetValue = no data stored
+- hmux0 TestPrioritySwitchingValve = no data stored
+- hmux0 TestReturnTemp = no data stored
+- hmux0 TestSubcoolingActualValue = no data stored
+- hmux0 TestSubcoolingTargetValue = no data stored
+- hmux0 TestSystemTemp = no data stored
+- hmux0 TestTempSwitchCompressorOutlet = no data stored
+- hmux0 TestWaterThroughput = no data stored
+- hmux0 TotalEnergyUsage = 2031
+- hmux0 YieldCoolDay = 0.0
+- hmux0 YieldHc = 4662
+- hmux0 YieldHcDay = 0.0
+- hmux0 YieldHcMonth = 10.3
+- hmux0 YieldHwc = 616
+- hmux0 YieldHwcDay = 1.9
+- hmux0 YieldHwcMonth = 20.7
+- hmux0 YieldThisYear10 = no data stored
+- hmux0 YieldThisYear11 = no data stored
+- hmux0 YieldThisYear12 = no data stored
+- hmux0 YieldThisYear1 = no data stored
+- hmux0 YieldThisYear2 = no data stored
+- hmux0 YieldThisYear3 = no data stored
+- hmux0 YieldThisYear4 = no data stored
+- hmux0 YieldThisYear5 = no data stored
+- hmux0 YieldThisYear6 = no data stored
+- hmux0 YieldThisYear7 = no data stored
+- hmux0 YieldThisYear8 = no data stored
+- hmux0 YieldThisYear9 = no data stored
+- 'hmux0 YieldTotal =  (ERR: invalid position for 3108b516021801 / 00)'
+- Memory Eeprom = no data stored
+- Memory Eeprom = no data stored
+- Memory Ram = no data stored
+- Memory Ram = no data stored
+- sc Clearerrorhistory = no data stored
+- sc Col = no data stored
+- sc ColKickPumpTime = no data stored
+- sc ColKickTempDelta = no data stored
+- sc CollPump = no data stored
+- sc Currenterror = no data stored
+- sc D1Temp = no data stored
+- sc D2Temp = no data stored
+- sc Date = no data stored
+- sc EDFunction = no data stored
+- sc EDFunction = no data stored
+- sc EnableScProtection = no data stored
+- sc EnableScProtection = no data stored
+- sc Errorhistory = no data stored
+- sc FlowRate = no data stored
+- sc FlowRate = no data stored
+- sc FrostProtectionEnabled = no data stored
+- sc FrostProtectionLimit = no data stored
+- sc Hc1PumpKol1PP1Port = no data stored
+- sc Hc2aLegPumpP2Port = no data stored
+- sc Hc2zPort = no data stored
+- sc HydraulicScheme = no data stored
+- sc InitCircuit = no data stored
+- sc Iotest = no data stored
+- sc Ioteststop = no data stored
+- sc IsInBoostMode = no data stored
+- sc KickFunction = no data stored
+- sc KickFunction = no data stored
+- sc LpZpMaPort = no data stored
+- sc MAPreferredStorage = no data stored
+- sc MAPreferredStorage = no data stored
+- sc MaximalTemp2 = no data stored
+- sc MaximalTemp2 = no data stored
+- sc MaximalTemp = no data stored
+- sc MaximalTemp = no data stored
+- sc MultifunctionOutput = no data stored
+- sc OMultifunction = no data stored
+- sc OMultifunction = no data stored
+- sc PumpAntiLockingFlags = no data stored
+- sc QuickVetoStart = no data stored
+- sc ResetSolGain = no data stored
+- sc ResetSolGain = no data stored
+- sc RuntimeCollPump = no data stored
+- sc RuntimeCollPumpSeconds = no data stored
+- sc ScProtectionHysteresis = no data stored
+- sc ScProtectionLimit = no data stored
+- sc ScProtectionLimit = no data stored
+- sc ScProtectionTime = no data stored
+- sc SolCollPumpDcIntegrator = no data stored
+- sc SolCollPumpED = no data stored
+- sc SolGain = no data stored
+- sc SolOperationMode = no data stored
+- sc SP1 = no data stored
+- sc SP2 = no data stored
+- sc SumSolGain = no data stored
+- sc SumSolGainDayBefore = no data stored
+- sc SystemMode = no data stored
+- sc TempDifferenceOff2 = no data stored
+- sc TempDifferenceOff2 = no data stored
+- sc TempDifferenceOff = no data stored
+- sc TempDifferenceOff = no data stored
+- sc TempDifferenceOffTD12 = no data stored
+- sc TempDifferenceOffTD12 = no data stored
+- sc TempDifferenceOn2 = no data stored
+- sc TempDifferenceOn2 = no data stored
+- sc TempDifferenceOn = no data stored
+- sc TempDifferenceOn = no data stored
+- sc TempDifferenceOnTD12 = no data stored
+- sc TempDifferenceOnTD12 = no data stored
+- sc Time = no data stored
+- sc Weekday = no data stored
+- sc YieldLastYear = no data stored
+- 'sc YieldThisYear =  (ERR: invalid position for 31ecb509030d3f00 / 00)'
+- Scan Id = no data stored
+- scan.04  = Vaillant;NETX3;0129;0404
+- scan.08  = Vaillant;HMUX0;0303;0504
+- scan.15  = Vaillant;CTLV3;0808;8004
+- Scan.15 Id = 21;25;41;0010045478;0953;051794;N2
+- scan.76  = Vaillant;VWZIO;0303;0504
+- Scan.76 Id = 21;25;47;0010039571;3110;005964;N6
+- scan.ec  = Vaillant;SOL00;0808;8004
+- Scan.ec Id = 21;25;41;0010045478;0953;051794;N2
+- scan.f6  = Vaillant;NETX3;0129;0404
+- vwzio EnableTestHwcTemp = no data stored
+- vwzio EnableTestOutdoorTemp = no data stored
+- vwzio EnableTestThreeWayValve = no data stored
+- vwzio TestHwcTemp = no data stored
+- vwzio TestOutdoorTemp = no data stored
+- vwzio TestThreeWayValve = no data stored
+- ''

--- a/tests/fixtures/community/arotherm_pro7_quiet_off_heating_discovery.yaml
+++ b/tests/fixtures/community/arotherm_pro7_quiet_off_heating_discovery.yaml
@@ -1,0 +1,14058 @@
+# Discovery dump for vaillant_ebus
+# Review this file for sensitive information before sharing
+metadata:
+  timestamp: '2026-09-08T20:25:40.796980'
+  ebusd_version: ebusd 26.1.26.1
+  register_count: 762
+  grab_duration: 20
+  dump_version: 3
+raw_find_lines:
+- bai SetModeOverride = 0;40.0;-;-;-;0;1;1;0;0;0;0
+- Broadcast Datetime = no data stored
+- Broadcast Error = no data stored
+- Broadcast HwcStatus = no data stored
+- Broadcast Id = no data stored
+- Broadcast IdAnswer = no data stored
+- Broadcast IdQuery = no data stored
+- Broadcast Load = no data stored
+- Broadcast Outsidetemp = 15.906
+- Broadcast Queryexistence =  (empty for 31fe07fe00 / )
+- Broadcast Signoflife = no data stored
+- Broadcast Vdatetime = 20:23:59;08.09.2026
+- Broadcast Vdatetime = no data stored
+- 'ctlv2 Hc1DewPointTemp =  (ERR: invalid position for 3115b52406020002002300 / 00)'
+- 'ctlv2 Hc1FlowTempCalc =  (ERR: invalid position for 3115b52406020002002000 / 050102200001)'
+- 'ctlv2 Hc1Humidity =  (ERR: invalid position for 3115b52406020002002200 / 00)'
+- 'ctlv2 Hc1MixerPosition =  (ERR: invalid position for 3115b52406020002002100 / 00)'
+- 'ctlv2 Hc1PumpHours =  (ERR: invalid position for 3115b52406020002002400 / 00)'
+- 'ctlv2 Hc1PumpStarts =  (ERR: invalid position for 3115b52406020002002500 / 00)'
+- 'ctlv2 Hc2DewPointTemp =  (ERR: invalid position for 3115b52406020002012300 / 00)'
+- 'ctlv2 Hc2FlowTempCalc =  (ERR: invalid position for 3115b52406020002012000 / 050002200000)'
+- 'ctlv2 Hc2Humidity =  (ERR: invalid position for 3115b52406020002012200 / 00)'
+- 'ctlv2 Hc2MixerPosition =  (ERR: invalid position for 3115b52406020002012100 / 00)'
+- 'ctlv2 Hc2PumpHours =  (ERR: invalid position for 3115b52406020002012400 / 00)'
+- 'ctlv2 Hc2PumpStarts =  (ERR: invalid position for 3115b52406020002012500 / 00)'
+- ctlv2 ManualCoolingEndDate = 01.01.2015
+- ctlv2 ManualCoolingEndDate = no data stored
+- ctlv2 ManualCoolingStartDate = 01.01.2019
+- ctlv2 ManualCoolingStartDate = no data stored
+- ctlv2 z1RoomHumidity = 67
+- ctlv3 AdaptHeatCurve = yes
+- ctlv3 AdaptHeatCurve = no data stored
+- ctlv3 CcTimer_Config = 03 01 01 00 00 00 ff ff 00
+- ctlv3 CcTimer_Friday0 = no data stored
+- ctlv3 CcTimer_Friday1 = no data stored
+- ctlv3 CcTimer_Friday2 = no data stored
+- ctlv3 CcTimer_Friday = no data stored
+- ctlv3 CcTimer_Monday0 = no data stored
+- ctlv3 CcTimer_Monday1 = no data stored
+- ctlv3 CcTimer_Monday2 = no data stored
+- ctlv3 CcTimer_Monday = no data stored
+- ctlv3 CcTimer_Saturday0 = no data stored
+- ctlv3 CcTimer_Saturday1 = no data stored
+- ctlv3 CcTimer_Saturday2 = no data stored
+- ctlv3 CcTimer_Saturday = no data stored
+- ctlv3 CcTimer_Sunday0 = no data stored
+- ctlv3 CcTimer_Sunday1 = no data stored
+- ctlv3 CcTimer_Sunday2 = no data stored
+- ctlv3 CcTimer_Sunday = no data stored
+- ctlv3 CcTimer_Thursday0 = no data stored
+- ctlv3 CcTimer_Thursday1 = no data stored
+- ctlv3 CcTimer_Thursday2 = no data stored
+- ctlv3 CcTimer_Thursday = no data stored
+- ctlv3 CcTimer_Timeframes = 0;0;0;0;0;0;0
+- ctlv3 CcTimer_Tuesday0 = no data stored
+- ctlv3 CcTimer_Tuesday1 = no data stored
+- ctlv3 CcTimer_Tuesday2 = no data stored
+- ctlv3 CcTimer_Tuesday = no data stored
+- ctlv3 CcTimer_Wednesday0 = no data stored
+- ctlv3 CcTimer_Wednesday1 = no data stored
+- ctlv3 CcTimer_Wednesday2 = no data stored
+- ctlv3 CcTimer_Wednesday = no data stored
+- ctlv3 Clearerrorhistory = no data stored
+- ctlv3 ContinuousHeating = -26
+- ctlv3 ContinuousHeating = no data stored
+- ctlv3 Currenterror = -;-;-;-;-
+- ctlv3 CylinderChargeHyst = 7
+- ctlv3 CylinderChargeHyst = no data stored
+- ctlv3 CylinderChargeOffset = 10
+- ctlv3 CylinderChargeOffset = no data stored
+- ctlv3 Date = 08.09.2026
+- ctlv3 Date = no data stored
+- ctlv3 DisplayedOutsideTemp = 15.9062
+- ctlv3 Errorhistory = no data stored
+- ctlv3 FrostOverRideTime = 4
+- ctlv3 FrostOverRideTime = no data stored
+- ctlv3 Hc1ActualFlowTempDesired = 40
+- ctlv3 Hc1AutoOffMode = eco
+- ctlv3 Hc1AutoOffMode = no data stored
+- ctlv3 Hc1CircuitType = mixer
+- ctlv3 Hc1ExcessTemp = 0.0
+- ctlv3 Hc1ExcessTemp = no data stored
+- ctlv3 Hc1FlowTemp = 28.5
+- ctlv3 Hc1HeatCurve = 0.8
+- ctlv3 Hc1HeatCurve = no data stored
+- ctlv3 Hc1HeatCurveAdaption = 0.0
+- ctlv3 Hc1MaxFlowTempDesired = 40
+- ctlv3 Hc1MaxFlowTempDesired = no data stored
+- ctlv3 Hc1MinCoolingTempDesired = 19
+- ctlv3 Hc1MinCoolingTempDesired = no data stored
+- ctlv3 Hc1MinFlowTempDesired = 19
+- ctlv3 Hc1MinFlowTempDesired = no data stored
+- ctlv3 Hc1MixerMovement = 0.0
+- ctlv3 Hc1PumpStatus = 1
+- ctlv3 Hc1PumpStatus = no data stored
+- ctlv3 Hc1RoomTempSwitchOn = thermostat
+- ctlv3 Hc1RoomTempSwitchOn = no data stored
+- ctlv3 Hc1Status = 1
+- ctlv3 Hc1Status = no data stored
+- ctlv3 Hc1SummerTempLimit = 18
+- ctlv3 Hc1SummerTempLimit = no data stored
+- ctlv3 Hc2ActualFlowTempDesired = 0.0
+- ctlv3 Hc2AutoOffMode = eco
+- ctlv3 Hc2AutoOffMode = no data stored
+- ctlv3 Hc2CircuitType = inactive
+- ctlv3 Hc2ExcessTemp = 0.0
+- ctlv3 Hc2ExcessTemp = no data stored
+- ctlv3 Hc2FlowTemp =  (empty for 3115b52406020002010800 / 0800020800ffffff7f)
+- ctlv3 Hc2HeatCurve = 0.6
+- ctlv3 Hc2HeatCurve = no data stored
+- ctlv3 Hc2HeatCurveAdaption = 0.0
+- ctlv3 Hc2MaxFlowTempDesired = 55
+- ctlv3 Hc2MaxFlowTempDesired = no data stored
+- ctlv3 Hc2MinCoolingTempDesired = 20
+- ctlv3 Hc2MinCoolingTempDesired = no data stored
+- ctlv3 Hc2MinFlowTempDesired = 15
+- ctlv3 Hc2MinFlowTempDesired = no data stored
+- ctlv3 Hc2MixerMovement = 0.0
+- ctlv3 Hc2PumpStatus = 0
+- ctlv3 Hc2PumpStatus = no data stored
+- ctlv3 Hc2RoomTempSwitchOn = off
+- ctlv3 Hc2RoomTempSwitchOn = no data stored
+- ctlv3 Hc2Status = 0
+- ctlv3 Hc2Status = no data stored
+- ctlv3 Hc2SummerTempLimit = 16
+- ctlv3 Hc2SummerTempLimit = no data stored
+- ctlv3 Hc3ActualFlowTempDesired = 0.0
+- ctlv3 Hc3AutoOffMode = eco
+- ctlv3 Hc3AutoOffMode = no data stored
+- ctlv3 Hc3CircuitType = inactive
+- ctlv3 Hc3ExcessTemp = 0.0
+- ctlv3 Hc3ExcessTemp = no data stored
+- ctlv3 Hc3FlowTemp =  (empty for 3115b52406020002020800 / 0800020800ffffff7f)
+- ctlv3 Hc3HeatCurve = 1.35
+- ctlv3 Hc3HeatCurve = no data stored
+- ctlv3 Hc3HeatCurveAdaption = 0.0
+- ctlv3 Hc3MaxFlowTempDesired = 55
+- ctlv3 Hc3MaxFlowTempDesired = no data stored
+- ctlv3 Hc3MinCoolingTempDesired = 20
+- ctlv3 Hc3MinCoolingTempDesired = no data stored
+- ctlv3 Hc3MinFlowTempDesired = 15
+- ctlv3 Hc3MinFlowTempDesired = no data stored
+- ctlv3 Hc3MixerMovement = 0.0
+- ctlv3 Hc3PumpStatus = 0
+- ctlv3 Hc3PumpStatus = no data stored
+- ctlv3 Hc3RoomTempSwitchOn = off
+- ctlv3 Hc3RoomTempSwitchOn = no data stored
+- ctlv3 Hc3Status = 0
+- ctlv3 Hc3Status = no data stored
+- ctlv3 Hc3SummerTempLimit = 16
+- ctlv3 Hc3SummerTempLimit = no data stored
+- ctlv3 HcStorageTempBottom =  (empty for f115b5240602000000a000 / 080000a000ffffff7f)
+- ctlv3 HcStorageTempTop =  (empty for f115b52406020000009f00 / 0800009f00ffffff7f)
+- ctlv3 HwcBankHolidayEndPeriod = no data stored
+- ctlv3 HwcBankHolidayEndPeriod = no data stored
+- ctlv3 HwcBankHolidayStartPeriod = no data stored
+- ctlv3 HwcBankHolidayStartPeriod = no data stored
+- ctlv3 HwcFlowTemp = 0.0
+- ctlv3 HwcHolidayEndPeriod = 01.01.2019
+- ctlv3 HwcHolidayEndPeriod = no data stored
+- ctlv3 HwcHolidayStartPeriod = 01.01.2019
+- ctlv3 HwcHolidayStartPeriod = no data stored
+- ctlv3 HwcLockTime = 60
+- ctlv3 HwcLockTime = no data stored
+- ctlv3 HwcMaxFlowTempDesired = 80
+- ctlv3 HwcMaxFlowTempDesired = no data stored
+- ctlv3 HwcOpMode = auto
+- ctlv3 HwcOpMode = no data stored
+- ctlv3 HwcParallelLoading = off
+- ctlv3 HwcParallelLoading = no data stored
+- ctlv3 HwcSFMode = auto
+- ctlv3 HwcSFMode = no data stored
+- ctlv3 HwcStorageTemp =  (empty for 3115b52406020001000500 / 0800010500ffffff7f)
+- ctlv3 HwcStorageTempBottom =  (empty for f115b52406020000009e00 / 0800009e00ffffff7f)
+- ctlv3 HwcStorageTempTop =  (empty for f115b52406020000009d00 / 0800009d00ffffff7f)
+- ctlv3 HwcTempDesired = 55
+- ctlv3 HwcTempDesired = no data stored
+- ctlv3 HwcTimer_Config = no data stored
+- ctlv3 HwcTimer_Friday0 = no data stored
+- ctlv3 HwcTimer_Friday1 = no data stored
+- ctlv3 HwcTimer_Friday2 = no data stored
+- ctlv3 HwcTimer_Friday = no data stored
+- ctlv3 HwcTimer_Monday0 = no data stored
+- ctlv3 HwcTimer_Monday1 = no data stored
+- ctlv3 HwcTimer_Monday2 = no data stored
+- ctlv3 HwcTimer_Monday = no data stored
+- ctlv3 HwcTimer_Saturday0 = no data stored
+- ctlv3 HwcTimer_Saturday1 = no data stored
+- ctlv3 HwcTimer_Saturday2 = no data stored
+- ctlv3 HwcTimer_Saturday = no data stored
+- ctlv3 HwcTimer_Sunday0 = no data stored
+- ctlv3 HwcTimer_Sunday1 = no data stored
+- ctlv3 HwcTimer_Sunday2 = no data stored
+- ctlv3 HwcTimer_Sunday = no data stored
+- ctlv3 HwcTimer_Thursday0 = no data stored
+- ctlv3 HwcTimer_Thursday1 = no data stored
+- ctlv3 HwcTimer_Thursday2 = no data stored
+- ctlv3 HwcTimer_Thursday = no data stored
+- ctlv3 HwcTimer_Timeframes = no data stored
+- ctlv3 HwcTimer_Tuesday0 = no data stored
+- ctlv3 HwcTimer_Tuesday1 = no data stored
+- ctlv3 HwcTimer_Tuesday2 = no data stored
+- ctlv3 HwcTimer_Tuesday = no data stored
+- ctlv3 HwcTimer_Wednesday0 = no data stored
+- ctlv3 HwcTimer_Wednesday1 = no data stored
+- ctlv3 HwcTimer_Wednesday2 = no data stored
+- ctlv3 HwcTimer_Wednesday = no data stored
+- ctlv3 HydraulicScheme = 8
+- ctlv3 HydraulicScheme = no data stored
+- ctlv3 Installer1 = no data stored
+- ctlv3 Installer1 = no data stored
+- ctlv3 Installer2 = no data stored
+- ctlv3 Installer2 = no data stored
+- ctlv3 KeyCodeforConfigMenu = no data stored
+- ctlv3 KeyCodeforConfigMenu = no data stored
+- ctlv3 MaintenanceDate = no data stored
+- ctlv3 MaintenanceDate = no data stored
+- ctlv3 MaintenanceDue = no data stored
+- ctlv3 MaxCylinderChargeTime = 90
+- ctlv3 MaxCylinderChargeTime = no data stored
+- ctlv3 MaxRoomHumidity = 50
+- ctlv3 MaxRoomHumidity = no data stored
+- ctlv3 MultiRelaySetting = 4
+- ctlv3 MultiRelaySetting = no data stored
+- ctlv3 OutsideTempAvg = 18.3398
+- ctlv3 OutsideTempAvg = no data stored
+- ctlv3 PhoneNumber1 = no data stored
+- ctlv3 PhoneNumber1 = no data stored
+- ctlv3 PhoneNumber2 = no data stored
+- ctlv3 PhoneNumber2 = no data stored
+- 'ctlv3 PrEnergySum =  (ERR: invalid position for 3115b52406020000005c00 / 00)'
+- ctlv3 PrEnergySum = no data stored
+- ctlv3 PrEnergySumHc = 17
+- ctlv3 PrEnergySumHc = no data stored
+- ctlv3 PrEnergySumHcLastMonth = 11
+- ctlv3 PrEnergySumHcLastMonth = no data stored
+- ctlv3 PrEnergySumHcThisMonth = 2
+- ctlv3 PrEnergySumHcThisMonth = no data stored
+- ctlv3 PrEnergySumHwc = 0
+- ctlv3 PrEnergySumHwc = no data stored
+- ctlv3 PrEnergySumHwcLastMonth = 0
+- ctlv3 PrEnergySumHwcLastMonth = no data stored
+- ctlv3 PrEnergySumHwcThisMonth = 0
+- ctlv3 PrEnergySumHwcThisMonth = no data stored
+- ctlv3 PrFuelSum = no data stored
+- ctlv3 PrFuelSum = no data stored
+- ctlv3 PrFuelSumHc = no data stored
+- ctlv3 PrFuelSumHc = no data stored
+- ctlv3 PrFuelSumHcLastMonth = no data stored
+- ctlv3 PrFuelSumHcLastMonth = no data stored
+- ctlv3 PrFuelSumHcThisMonth = no data stored
+- ctlv3 PrFuelSumHcThisMonth = no data stored
+- ctlv3 PrFuelSumHwc = no data stored
+- ctlv3 PrFuelSumHwc = no data stored
+- ctlv3 PrFuelSumHwcLastMonth = no data stored
+- ctlv3 PrFuelSumHwcLastMonth = no data stored
+- ctlv3 PrFuelSumHwcThisMonth = no data stored
+- ctlv3 PrFuelSumHwcThisMonth = no data stored
+- ctlv3 PumpAdditionalTime = no data stored
+- ctlv3 PumpAdditionalTime = no data stored
+- ctlv3 SolarYieldTotal = no data stored
+- ctlv3 SolarYieldTotal = no data stored
+- ctlv3 SystemFlowTemp =  (empty for f115b52406020000004b00 / 0800004b00ffffff7f)
+- ctlv3 Time = 19:41:52
+- ctlv3 Time = no data stored
+- ctlv3 WaterPressure = 2
+- ctlv3 YieldTotal = 6
+- ctlv3 YieldTotal = no data stored
+- ctlv3 Z1ActualRoomTempDesired = 26
+- ctlv3 Z1ActualRoomTempDesired = no data stored
+- ctlv3 Z1BankHolidayEndPeriod = no data stored
+- ctlv3 Z1BankHolidayEndPeriod = no data stored
+- ctlv3 Z1BankHolidayStartPeriod = no data stored
+- ctlv3 Z1BankHolidayStartPeriod = no data stored
+- ctlv3 Z1CoolingTemp = 23
+- ctlv3 Z1CoolingTemp = no data stored
+- ctlv3 Z1DayTemp = 26
+- ctlv3 Z1DayTemp = no data stored
+- ctlv3 Z1HolidayEndPeriod = 01.01.2019
+- ctlv3 Z1HolidayEndPeriod = no data stored
+- ctlv3 Z1HolidayStartPeriod = 01.01.2019
+- ctlv3 Z1HolidayStartPeriod = no data stored
+- ctlv3 Z1HolidayTemp = 15
+- ctlv3 Z1HolidayTemp = no data stored
+- 'ctlv3 Z1Name1 = Zone '
+- ctlv3 Z1Name1 = no data stored
+- 'ctlv3 Z1Name2 =  (ERR: invalid position for f115b52406020003001800 / 06030318003100)'
+- ctlv3 Z1Name2 = no data stored
+- ctlv3 Z1NightTemp = 15
+- ctlv3 Z1NightTemp = no data stored
+- ctlv3 Z1OpMode = day
+- ctlv3 Z1OpMode = no data stored
+- ctlv3 Z1QuickVetoDuration = 3
+- ctlv3 Z1QuickVetoDuration = no data stored
+- ctlv3 Z1QuickVetoEndDate = 01.01.2019
+- ctlv3 Z1QuickVetoEndTime = 00:00:00
+- ctlv3 Z1QuickVetoTemp = 21
+- ctlv3 Z1QuickVetoTemp = no data stored
+- ctlv3 Z1RoomTemp = 22.475
+- ctlv3 Z1RoomZoneMapping = VRC700
+- ctlv3 Z1RoomZoneMapping = no data stored
+- ctlv3 Z1SFMode = auto
+- ctlv3 Z1SFMode = no data stored
+- ctlv3 Z1Shortname = no data stored
+- ctlv3 Z1Shortname = no data stored
+- ctlv3 Z1Timer_Config = no data stored
+- ctlv3 Z1Timer_Friday0 = 06:00;22:00;20.0
+- ctlv3 Z1Timer_Friday1 = no data stored
+- ctlv3 Z1Timer_Friday2 = no data stored
+- ctlv3 Z1Timer_Friday = no data stored
+- ctlv3 Z1Timer_Monday0 = 06:00;22:00;20.0
+- ctlv3 Z1Timer_Monday1 = no data stored
+- ctlv3 Z1Timer_Monday2 = no data stored
+- ctlv3 Z1Timer_Monday = no data stored
+- ctlv3 Z1Timer_Saturday0 = 07:30;23:30;20.0
+- ctlv3 Z1Timer_Saturday1 = no data stored
+- ctlv3 Z1Timer_Saturday2 = no data stored
+- ctlv3 Z1Timer_Saturday = no data stored
+- ctlv3 Z1Timer_Sunday0 = 07:30;22:00;20.0
+- ctlv3 Z1Timer_Sunday1 = no data stored
+- ctlv3 Z1Timer_Sunday2 = no data stored
+- ctlv3 Z1Timer_Sunday = no data stored
+- ctlv3 Z1Timer_Thursday0 = 06:00;22:00;20.0
+- ctlv3 Z1Timer_Thursday1 = no data stored
+- ctlv3 Z1Timer_Thursday2 = no data stored
+- ctlv3 Z1Timer_Thursday = no data stored
+- ctlv3 Z1Timer_Timeframes = 1;1;1;1;1;1;1
+- ctlv3 Z1Timer_Tuesday0 = 06:00;22:00;20.0
+- ctlv3 Z1Timer_Tuesday1 = no data stored
+- ctlv3 Z1Timer_Tuesday2 = no data stored
+- ctlv3 Z1Timer_Tuesday = no data stored
+- ctlv3 Z1Timer_Wednesday0 = 06:00;22:00;20.0
+- ctlv3 Z1Timer_Wednesday1 = no data stored
+- ctlv3 Z1Timer_Wednesday2 = no data stored
+- ctlv3 Z1Timer_Wednesday = no data stored
+- ctlv3 Z1ValveStatus = no data stored
+- ctlv3 Z1ValveStatus = no data stored
+- ctlv3 Z2ActualRoomTempDesired = no data stored
+- ctlv3 Z2ActualRoomTempDesired = no data stored
+- ctlv3 Z2BankHolidayEndPeriod = no data stored
+- ctlv3 Z2BankHolidayEndPeriod = no data stored
+- ctlv3 Z2BankHolidayStartPeriod = no data stored
+- ctlv3 Z2BankHolidayStartPeriod = no data stored
+- ctlv3 Z2CoolingTemp = no data stored
+- ctlv3 Z2CoolingTemp = no data stored
+- ctlv3 Z2DayTemp = no data stored
+- ctlv3 Z2DayTemp = no data stored
+- ctlv3 Z2HolidayEndPeriod = no data stored
+- ctlv3 Z2HolidayEndPeriod = no data stored
+- ctlv3 Z2HolidayStartPeriod = no data stored
+- ctlv3 Z2HolidayStartPeriod = no data stored
+- ctlv3 Z2HolidayTemp = no data stored
+- ctlv3 Z2HolidayTemp = no data stored
+- ctlv3 Z2Name1 = no data stored
+- ctlv3 Z2Name1 = no data stored
+- ctlv3 Z2Name2 = no data stored
+- ctlv3 Z2Name2 = no data stored
+- ctlv3 Z2NightTemp = no data stored
+- ctlv3 Z2NightTemp = no data stored
+- ctlv3 Z2OpMode = no data stored
+- ctlv3 Z2OpMode = no data stored
+- ctlv3 Z2QuickVetoDuration = no data stored
+- ctlv3 Z2QuickVetoDuration = no data stored
+- ctlv3 Z2QuickVetoEndDate = no data stored
+- ctlv3 Z2QuickVetoEndTime = no data stored
+- ctlv3 Z2QuickVetoTemp = no data stored
+- ctlv3 Z2QuickVetoTemp = no data stored
+- ctlv3 Z2RoomTemp =  (empty for 3115b52406020003010f00 / 0802030f00ffffff7f)
+- ctlv3 Z2RoomZoneMapping = none
+- ctlv3 Z2RoomZoneMapping = no data stored
+- ctlv3 Z2SFMode = no data stored
+- ctlv3 Z2SFMode = no data stored
+- ctlv3 Z2Shortname = no data stored
+- ctlv3 Z2Shortname = no data stored
+- ctlv3 Z2Timer_Config = no data stored
+- ctlv3 Z2Timer_Friday0 = no data stored
+- ctlv3 Z2Timer_Friday1 = no data stored
+- ctlv3 Z2Timer_Friday2 = no data stored
+- ctlv3 Z2Timer_Friday = no data stored
+- ctlv3 Z2Timer_Monday0 = no data stored
+- ctlv3 Z2Timer_Monday1 = no data stored
+- ctlv3 Z2Timer_Monday2 = no data stored
+- ctlv3 Z2Timer_Monday = no data stored
+- ctlv3 Z2Timer_Saturday0 = no data stored
+- ctlv3 Z2Timer_Saturday1 = no data stored
+- ctlv3 Z2Timer_Saturday2 = no data stored
+- ctlv3 Z2Timer_Saturday = no data stored
+- ctlv3 Z2Timer_Sunday0 = no data stored
+- ctlv3 Z2Timer_Sunday1 = no data stored
+- ctlv3 Z2Timer_Sunday2 = no data stored
+- ctlv3 Z2Timer_Sunday = no data stored
+- ctlv3 Z2Timer_Thursday0 = no data stored
+- ctlv3 Z2Timer_Thursday1 = no data stored
+- ctlv3 Z2Timer_Thursday2 = no data stored
+- ctlv3 Z2Timer_Thursday = no data stored
+- ctlv3 Z2Timer_Timeframes = no data stored
+- ctlv3 Z2Timer_Tuesday0 = no data stored
+- ctlv3 Z2Timer_Tuesday1 = no data stored
+- ctlv3 Z2Timer_Tuesday2 = no data stored
+- ctlv3 Z2Timer_Tuesday = no data stored
+- ctlv3 Z2Timer_Wednesday0 = no data stored
+- ctlv3 Z2Timer_Wednesday1 = no data stored
+- ctlv3 Z2Timer_Wednesday2 = no data stored
+- ctlv3 Z2Timer_Wednesday = no data stored
+- ctlv3 Z2ValveStatus = no data stored
+- ctlv3 Z2ValveStatus = no data stored
+- ctlv3 Z3ActualRoomTempDesired = no data stored
+- ctlv3 Z3ActualRoomTempDesired = no data stored
+- ctlv3 Z3BankHolidayEndPeriod = no data stored
+- ctlv3 Z3BankHolidayEndPeriod = no data stored
+- ctlv3 Z3BankHolidayStartPeriod = no data stored
+- ctlv3 Z3BankHolidayStartPeriod = no data stored
+- ctlv3 Z3DayTemp = no data stored
+- ctlv3 Z3DayTemp = no data stored
+- ctlv3 Z3HolidayEndPeriod = no data stored
+- ctlv3 Z3HolidayEndPeriod = no data stored
+- ctlv3 Z3HolidayStartPeriod = no data stored
+- ctlv3 Z3HolidayStartPeriod = no data stored
+- ctlv3 Z3HolidayTemp = no data stored
+- ctlv3 Z3HolidayTemp = no data stored
+- ctlv3 Z3Name1 = no data stored
+- ctlv3 Z3Name1 = no data stored
+- ctlv3 Z3Name2 = no data stored
+- ctlv3 Z3Name2 = no data stored
+- ctlv3 Z3NightTemp = no data stored
+- ctlv3 Z3NightTemp = no data stored
+- ctlv3 Z3OpMode = no data stored
+- ctlv3 Z3OpMode = no data stored
+- ctlv3 Z3QuickVetoDuration = no data stored
+- ctlv3 Z3QuickVetoDuration = no data stored
+- ctlv3 Z3QuickVetoEndDate = no data stored
+- ctlv3 Z3QuickVetoEndTime = no data stored
+- ctlv3 Z3QuickVetoTemp = no data stored
+- ctlv3 Z3QuickVetoTemp = no data stored
+- ctlv3 Z3RoomTemp = no data stored
+- ctlv3 Z3RoomZoneMapping = none
+- ctlv3 Z3RoomZoneMapping = no data stored
+- ctlv3 Z3SFMode = no data stored
+- ctlv3 Z3SFMode = no data stored
+- ctlv3 Z3Shortname = no data stored
+- ctlv3 Z3Shortname = no data stored
+- ctlv3 Z3Timer_Config = no data stored
+- ctlv3 Z3Timer_Friday0 = no data stored
+- ctlv3 Z3Timer_Friday1 = no data stored
+- ctlv3 Z3Timer_Friday2 = no data stored
+- ctlv3 Z3Timer_Friday = no data stored
+- ctlv3 Z3Timer_Monday0 = no data stored
+- ctlv3 Z3Timer_Monday1 = no data stored
+- ctlv3 Z3Timer_Monday2 = no data stored
+- ctlv3 Z3Timer_Monday = no data stored
+- ctlv3 Z3Timer_Saturday0 = no data stored
+- ctlv3 Z3Timer_Saturday1 = no data stored
+- ctlv3 Z3Timer_Saturday2 = no data stored
+- ctlv3 Z3Timer_Saturday = no data stored
+- ctlv3 Z3Timer_Sunday0 = no data stored
+- ctlv3 Z3Timer_Sunday1 = no data stored
+- ctlv3 Z3Timer_Sunday2 = no data stored
+- ctlv3 Z3Timer_Sunday = no data stored
+- ctlv3 Z3Timer_Thursday0 = no data stored
+- ctlv3 Z3Timer_Thursday1 = no data stored
+- ctlv3 Z3Timer_Thursday2 = no data stored
+- ctlv3 Z3Timer_Thursday = no data stored
+- ctlv3 Z3Timer_Timeframes = no data stored
+- ctlv3 Z3Timer_Tuesday0 = no data stored
+- ctlv3 Z3Timer_Tuesday1 = no data stored
+- ctlv3 Z3Timer_Tuesday2 = no data stored
+- ctlv3 Z3Timer_Tuesday = no data stored
+- ctlv3 Z3Timer_Wednesday0 = no data stored
+- ctlv3 Z3Timer_Wednesday1 = no data stored
+- ctlv3 Z3Timer_Wednesday2 = no data stored
+- ctlv3 Z3Timer_Wednesday = no data stored
+- ctlv3 Z3ValveStatus = no data stored
+- ctlv3 Z3ValveStatus = no data stored
+- General Valuerange = no data stored
+- hmu CoolElecConsDay = 0.0
+- hmu CoolElecConsTotal = 32200
+- hmu CoolEnvYieldDay = 0.0
+- hmu CoolEnvYieldMonth = 0.0
+- hmu CoolEnvYieldTotal = 0.0
+- hmu HcElecConsDay = 123.189
+- hmu HcElecConsTotal = 10760.2
+- hmu HwcElecConsDay = 0.0
+- hmu HwcElecConsTotal = 0.0
+- 'hmu SourceTempInput =  (ERR: invalid position for 3108b51a0405ff3222 / 02ff01)'
+- Memory Eeprom = no data stored
+- Memory Eeprom = no data stored
+- Memory Ram = no data stored
+- Memory Ram = no data stored
+- Scan Id = no data stored
+- scan.04  = Vaillant;NETX3;0129;0404
+- scan.08  = Vaillant;HMUX0;0406;0504
+- scan.15  = Vaillant;CTLV3;0808;8004
+- Scan.15 Id = 21;25;45;0020260913;0953;026479;N3
+- scan.76  = Vaillant;VWZIO;0406;0504
+- Scan.76 Id = 21;26;03;8000035574;0001;005739;N8
+- scan.f6  = Vaillant;NETX3;0129;0404
+- Scan.f6 Id = 21;26;10;0020292012;0933;049007;N4
+- vwzio EnableTestHwcTemp = no data stored
+- vwzio EnableTestOutdoorTemp = no data stored
+- vwzio EnableTestThreeWayValve = no data stored
+- vwzio TestHwcTemp = no data stored
+- vwzio TestOutdoorTemp = no data stored
+- vwzio TestThreeWayValve = no data stored
+- ''
+before_registers:
+- circuit: Broadcast
+  name: Datetime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Error
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: Broadcast
+  name: HwcStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Id
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: IdAnswer
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: IdQuery
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Load
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Outsidetemp
+  fields:
+  - value
+  values:
+  - '15.906'
+  writable: false
+  has_data: true
+- circuit: Broadcast
+  name: Queryexistence
+  fields:
+  - value
+  values:
+  - (empty for 31fe07fe00 / )
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Signoflife
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Vdatetime
+  fields:
+  - value
+  values:
+  - 20:23:59;08.09.2026
+  writable: false
+  has_data: true
+- circuit: Broadcast
+  name: Vdatetime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: WaterPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: General
+  name: Valuerange
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Eeprom
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Eeprom
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Ram
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Ram
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Scan
+  name: Id
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Scan.15
+  name: Id
+  fields:
+  - value
+  values:
+  - 21;25;45;0020260913;0953;026479;N3
+  writable: false
+  has_data: true
+- circuit: Scan.76
+  name: Id
+  fields:
+  - value
+  values:
+  - 21;26;03;8000035574;0001;005739;N8
+  writable: false
+  has_data: true
+- circuit: Scan.f6
+  name: Id
+  fields:
+  - value
+  values:
+  - 21;26;10;0020292012;0933;049007;N4
+  writable: false
+  has_data: true
+- circuit: bai
+  name: ActiveStages
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: bai
+  name: FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: bai
+  name: FlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: bai
+  name: HeatingStage1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: bai
+  name: HeatingStage3
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: bai
+  name: PrEnergySumHc1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: bai
+  name: PrEnergySumHwc1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: bai
+  name: SetModeOverride
+  fields:
+  - value
+  values:
+  - 0;40.0;-;-;-;0;1;1;0;0;0;0
+  writable: false
+  has_data: true
+- circuit: bai
+  name: StorageTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: bai
+  name: StorageTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: bai
+  name: WaterPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: AdaptHeatCurve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: CcTimer_Config
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: CcTimer_Timeframes
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: ContinuousHeating
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: CylinderChargeHyst
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: CylinderChargeOffset
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Date
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: DisplayedOutsideTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: FrostOverRideTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1AutoOffMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1CircuitType
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1CoolingEnabled
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1CoolingFlowTempMin
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1DewPointMonitoring
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1DewPointOffset
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1DewPointTemp
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002300 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1ExcessTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1FlowTempCalc
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002000 / 050102200001)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1HeatCurve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1Humidity
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002200 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MixerMovement
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MixerPosition
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002100 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1PumpHours
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002400 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1PumpStarts
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002500 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1PumpStatus
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1RoomTempModulation
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1Status
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1SummerTempLimit
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2AutoOffMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2CircuitType
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2DewPointTemp
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012300 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2ExcessTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2FlowTempCalc
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012000 / 050002200000)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2HeatCurve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2Humidity
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012200 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MixerMovement
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MixerPosition
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012100 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2PumpHours
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012400 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2PumpStarts
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012500 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2PumpStatus
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2Status
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2SummerTempLimit
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3AutoOffMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3CircuitType
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3ExcessTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3HeatCurve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MixerMovement
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3PumpStatus
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3Status
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3SummerTempLimit
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HcStorageTempBottom
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: ctlv2
+  name: HcStorageTempTop
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: ctlv2
+  name: HwcFlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcLockTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcMaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcOpMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcParallelLoading
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcSFMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcSfMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcStorageTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcStorageTempBottom
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcStorageTempTop
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HydraulicScheme
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: ManualCoolingEndDate
+  fields:
+  - value
+  values:
+  - 01.01.2015
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: ManualCoolingEndDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: ManualCoolingStartDate
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: ManualCoolingStartDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: MaxCylinderChargeTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: MaxRoomHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: MultiRelaySetting
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: OutsideTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: OutsideTempAvg
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySum
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHcLastMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHcThisMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHwcLastMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHwcThisMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: SystemFlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: WaterPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingManualTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingOpMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingSetbackTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1DayTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1HolidayTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1NightTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1OpMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoDuration
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoEndDate
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoEndTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1RoomTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1SFMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z2RoomTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: z1RoomHumidity
+  fields:
+  - value
+  values:
+  - '67'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: AdaptHeatCurve
+  fields:
+  - value
+  values:
+  - 'yes'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: AdaptHeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Config
+  fields:
+  - value
+  values:
+  - 03 01 01 00 00 00 ff ff 00
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CcTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Friday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Friday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Friday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Monday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Monday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Monday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Saturday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Saturday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Saturday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Sunday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Sunday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Sunday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Thursday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Timeframes
+  fields:
+  - value
+  values:
+  - 0;0;0;0;0;0;0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CcTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Tuesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Wednesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Clearerrorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: ContinuousHeating
+  fields:
+  - value
+  values:
+  - '-26'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: ContinuousHeating
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - -;-;-;-;-
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CylinderChargeHyst
+  fields:
+  - value
+  values:
+  - '7'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CylinderChargeHyst
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CylinderChargeOffset
+  fields:
+  - value
+  values:
+  - '10'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CylinderChargeOffset
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Date
+  fields:
+  - value
+  values:
+  - 08.09.2026
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Date
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: DisplayedOutsideTemp
+  fields:
+  - value
+  values:
+  - '15.9062'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: FrostOverRideTime
+  fields:
+  - value
+  values:
+  - '4'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: FrostOverRideTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - '40'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1AutoOffMode
+  fields:
+  - value
+  values:
+  - eco
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1AutoOffMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1CircuitType
+  fields:
+  - value
+  values:
+  - mixer
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1ExcessTemp
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1ExcessTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1FlowTemp
+  fields:
+  - value
+  values:
+  - '28.5'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1HeatCurve
+  fields:
+  - value
+  values:
+  - '0.8'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1HeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '40'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - '19'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - '19'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1MixerMovement
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1PumpStatus
+  fields:
+  - value
+  values:
+  - '1'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1PumpStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - thermostat
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1Status
+  fields:
+  - value
+  values:
+  - '1'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1SummerTempLimit
+  fields:
+  - value
+  values:
+  - '18'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1SummerTempLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2AutoOffMode
+  fields:
+  - value
+  values:
+  - eco
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2AutoOffMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2CircuitType
+  fields:
+  - value
+  values:
+  - inactive
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2ExcessTemp
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2ExcessTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2FlowTemp
+  fields:
+  - value
+  values:
+  - (empty for 3115b52406020002010800 / 0800020800ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2HeatCurve
+  fields:
+  - value
+  values:
+  - '0.6'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2HeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '55'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - '20'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - '15'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2MixerMovement
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2PumpStatus
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2PumpStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'off'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2Status
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2SummerTempLimit
+  fields:
+  - value
+  values:
+  - '16'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2SummerTempLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3AutoOffMode
+  fields:
+  - value
+  values:
+  - eco
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3AutoOffMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3CircuitType
+  fields:
+  - value
+  values:
+  - inactive
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3ExcessTemp
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3ExcessTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3FlowTemp
+  fields:
+  - value
+  values:
+  - (empty for 3115b52406020002020800 / 0800020800ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3HeatCurve
+  fields:
+  - value
+  values:
+  - '1.35'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3HeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '55'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - '20'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - '15'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3MixerMovement
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3PumpStatus
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3PumpStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'off'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3Status
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3SummerTempLimit
+  fields:
+  - value
+  values:
+  - '16'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3SummerTempLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HcStorageTempBottom
+  fields:
+  - value
+  values:
+  - (empty for f115b5240602000000a000 / 080000a000ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HcStorageTempTop
+  fields:
+  - value
+  values:
+  - (empty for f115b52406020000009f00 / 0800009f00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcBankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcBankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcBankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcBankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcFlowTemp
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcLockTime
+  fields:
+  - value
+  values:
+  - '60'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcLockTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcMaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '80'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcMaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcOpMode
+  fields:
+  - value
+  values:
+  - auto
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcOpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcParallelLoading
+  fields:
+  - value
+  values:
+  - 'off'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcParallelLoading
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcSFMode
+  fields:
+  - value
+  values:
+  - auto
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcSFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcStorageTemp
+  fields:
+  - value
+  values:
+  - (empty for 3115b52406020001000500 / 0800010500ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcStorageTempBottom
+  fields:
+  - value
+  values:
+  - (empty for f115b52406020000009e00 / 0800009e00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcStorageTempTop
+  fields:
+  - value
+  values:
+  - (empty for f115b52406020000009d00 / 0800009d00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTempDesired
+  fields:
+  - value
+  values:
+  - '55'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Config
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Friday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Friday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Friday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Monday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Monday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Monday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Saturday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Saturday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Saturday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Sunday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Sunday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Sunday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Thursday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Timeframes
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Tuesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Wednesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HydraulicScheme
+  fields:
+  - value
+  values:
+  - '8'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HydraulicScheme
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Installer1
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Installer1
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Installer2
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Installer2
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: KeyCodeforConfigMenu
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: KeyCodeforConfigMenu
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: MaintenanceDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: MaintenanceDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: MaintenanceDue
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: MaxCylinderChargeTime
+  fields:
+  - value
+  values:
+  - '90'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: MaxCylinderChargeTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: MaxRoomHumidity
+  fields:
+  - value
+  values:
+  - '50'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: MaxRoomHumidity
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: MultiRelaySetting
+  fields:
+  - value
+  values:
+  - '4'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: MultiRelaySetting
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: OutsideTempAvg
+  fields:
+  - value
+  values:
+  - '18.3398'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: OutsideTempAvg
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PhoneNumber1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PhoneNumber1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PhoneNumber2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PhoneNumber2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySum
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020000005c00 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHc
+  fields:
+  - value
+  values:
+  - '17'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: PrEnergySumHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHcLastMonth
+  fields:
+  - value
+  values:
+  - '11'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: PrEnergySumHcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHcThisMonth
+  fields:
+  - value
+  values:
+  - '2'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: PrEnergySumHcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHwc
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: PrEnergySumHwc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHwcLastMonth
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: PrEnergySumHwcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHwcThisMonth
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: PrEnergySumHwcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHwc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHwc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHwcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHwcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHwcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHwcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PumpAdditionalTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PumpAdditionalTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: SolarYieldTotal
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: SolarYieldTotal
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: SystemFlowTemp
+  fields:
+  - value
+  values:
+  - (empty for f115b52406020000004b00 / 0800004b00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Time
+  fields:
+  - value
+  values:
+  - '19:41:52'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Time
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: WaterPressure
+  fields:
+  - value
+  values:
+  - '2'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: YieldTotal
+  fields:
+  - value
+  values:
+  - '6'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: YieldTotal
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - '26'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1CoolingTemp
+  fields:
+  - value
+  values:
+  - '23'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1CoolingTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1DayTemp
+  fields:
+  - value
+  values:
+  - '26'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1HolidayTemp
+  fields:
+  - value
+  values:
+  - '15'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Name1
+  fields:
+  - value
+  values:
+  - Zone
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Name2
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for f115b52406020003001800 / 06030318003100)'
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1NightTemp
+  fields:
+  - value
+  values:
+  - '15'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1OpMode
+  fields:
+  - value
+  values:
+  - day
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1QuickVetoDuration
+  fields:
+  - value
+  values:
+  - '3'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1QuickVetoEndDate
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1QuickVetoEndTime
+  fields:
+  - value
+  values:
+  - 00:00:00
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1QuickVetoTemp
+  fields:
+  - value
+  values:
+  - '21'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1RoomTemp
+  fields:
+  - value
+  values:
+  - '22.475'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1SFMode
+  fields:
+  - value
+  values:
+  - auto
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Config
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Friday0
+  fields:
+  - value
+  values:
+  - 06:00;22:00;20.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Friday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Friday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Monday0
+  fields:
+  - value
+  values:
+  - 06:00;22:00;20.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Monday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Monday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Saturday0
+  fields:
+  - value
+  values:
+  - 07:30;23:30;20.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Saturday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Saturday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Sunday0
+  fields:
+  - value
+  values:
+  - 07:30;22:00;20.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Sunday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Sunday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Thursday0
+  fields:
+  - value
+  values:
+  - 06:00;22:00;20.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Timeframes
+  fields:
+  - value
+  values:
+  - 1;1;1;1;1;1;1
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Tuesday0
+  fields:
+  - value
+  values:
+  - 06:00;22:00;20.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Wednesday0
+  fields:
+  - value
+  values:
+  - 06:00;22:00;20.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2CoolingTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2CoolingTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2QuickVetoEndDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2QuickVetoEndTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2RoomTemp
+  fields:
+  - value
+  values:
+  - (empty for 3115b52406020003010f00 / 0802030f00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z2RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Config
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Friday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Friday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Friday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Monday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Monday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Monday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Saturday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Saturday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Saturday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Sunday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Sunday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Sunday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Thursday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Timeframes
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Tuesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Wednesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3QuickVetoEndDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3QuickVetoEndTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3RoomTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z3RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Config
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Friday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Friday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Friday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Monday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Monday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Monday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Saturday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Saturday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Saturday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Sunday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Sunday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Sunday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Thursday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Timeframes
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Tuesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Wednesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: BuildingCircuitFlow
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: BuildingCircuitPumpSpeed
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: CompressorHc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: CompressorHwc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHwc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: ConsumptionTotal
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CoolElecConsDay
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CoolElecConsTotal
+  fields:
+  - value
+  values:
+  - '32200'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CoolEnvYieldDay
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CoolEnvYieldMonth
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CoolEnvYieldTotal
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CopCooling
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CopCoolingMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CopHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CopHcMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CopHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CopHwcMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CurrentCompressorUtil
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CurrentConsumedPower
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CurrentYieldPower
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: DateTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: FlowTemperature
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: HcElecConsDay
+  fields:
+  - value
+  values:
+  - '123.189'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: HcElecConsTotal
+  fields:
+  - value
+  values:
+  - '10760.2'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: HoursCool
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: HwcElecConsDay
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: HwcElecConsTotal
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: LiveMonitorCurrentConsumedPower
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: PowerConsumptionHmu
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunDataAirInletTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataBuildingCPumpPower
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataCompressorInletTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataCompressorOutletTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataCompressorSpeed
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataEEVOutletTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataEEVPositionAbs
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataElectricPowerConsumption
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataFan1Speed
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataFan2Speed
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataHighPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataLowPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunDataReturnTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataStatuscode
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStats4PortValveHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStats4PortValveSwitches
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsBuildingCPumpStarts
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsBuildingPumpHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunStatsCompressorHc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunStatsCompressorHwc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHwc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorStarts
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsFan1Hours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsFan1Starts
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsFan2Hours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsFan2Starts
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsHMUHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsHcHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsHwcHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: SourceTempInput
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: SourceTempOutput
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatElectricEnergySum
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatElectricEnergySumCool
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatElectricEnergySumHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatElectricEnergySumHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatEnvironmentEnergySum
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatEnvironmentEnergySumCool
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatEnvironmentEnergySumHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatEnvironmentEnergySumHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatSolarEnergySum
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatSolarEnergySumHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatSolarEnergySumHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.pumpstate
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.temp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.temp_1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.temp_2
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: Status01.temp_3
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: Status01.temp_4
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: StatusCirPump
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: SupplyTempWeighted
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: TotalEnergyUsage
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldCoolDay
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldCooling
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldCoolingMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldHcDay
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldHcMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldHwcDay
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldHwcMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmux0
+  name: Status01
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmux0
+  name: Status01.pumpstate
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmux0
+  name: Status01.temp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmux0
+  name: Status01.temp_1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmux0
+  name: Status01.temp_2
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmux0
+  name: Status01.temp_3
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmux0
+  name: Status01.temp_4
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: v32
+  name: BypassPosition
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: ExhaustAirHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: ExhaustAirTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: FanHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: FlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: FlowTempMax
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: HcHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: HoursTillService
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: HwcHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: HwcTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: v32
+  name: Maintenancedata_HwcTempMax
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: v32
+  name: MaxAirHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: MinAirHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: OutdoorstempSensor
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: v32
+  name: OutsideAirTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: PumpHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: PumpPower
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: ReturnTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: ReturnTempMax
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: Status02.hwcmode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: Status02.temp0
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: Status02.temp0_1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: Status02.temp1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: Status02.temp1_1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: StorageLoadPumpHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: StorageTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: StorageTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: SupplyAirTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: VentilationLevelDay
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: VentilationLevelNight
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldToday
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldTotal
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldYear
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Clearerrorhistory
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Mc1Operation
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Mc2Operation
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Mc3Operation
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: SensorData1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: SensorData2
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: SetActorState
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vwz
+  name: TestHwcTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: vwz
+  name: TestOutdoorTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: vwz
+  name: TestThreeWayValve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: vwzio
+  name: EnableTestHwcTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: EnableTestOutdoorTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: EnableTestThreeWayValve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: TestHwcTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: TestOutdoorTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: TestThreeWayValve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+grab:
+- '[grab] grab started'
+- '3108b516081001ffff02052835 / 0b0100070205283500000000 = 1: hmu CoolEnvYieldDay'
+- '3108b516081000ffff02050000 / 0b0000070205283500000000 = 1: hmu CoolEnvYieldTotal'
+- '3108b516081002ffff02052835 / 0b0200070205213500000000 = 1: hmu CoolEnvYieldMonth'
+- '3108b516081001ffff03032835 / 0b01000003032835840c4643 = 1: hmu HcElecConsDay'
+- '3108b516081000ffff03030000 / 0b00000003032835314c2946 = 1: hmu HcElecConsTotal'
+- '3108b516081001ffff03052835 / 0b0100060305283500000000 = 1: hmu CoolElecConsDay'
+- '3108b516081000ffff03040000 / 0b0000030304283500000000 = 1: hmu HwcElecConsTotal'
+- '3108b516081001ffff03042835 / 0b0100030304283500000000 = 1: hmu HwcElecConsDay'
+- '3108b516081000ffff03050000 / 0b00000603052835ff8ffb46 = 1: hmu CoolElecConsTotal'
+- '10feb516080059242008090226 = 1: Broadcast Vdatetime'
+- '10feb5160301db0f = 1: Broadcast Outsidetemp'
+- 1008b5040100 / 0a0301252008090226db0f = 1
+- 1008b5110100 / 09e501147a040900007a = 1
+- 1008b5110101 / 093d32db0fffff0100ff = 2
+- 1076b5110101 / 093132db0fffff0000ff = 2
+- 10feb505025c00 = 1
+- f108b5160114 / 090107d7af4400000000 = 1
+- f176b5160114 / 09000000a04000000000 = 1
+- 0304b511010e / 0116 = 1
+- '1008b51009000050ffffff060000 / 0101 = 3: bai SetModeOverride'
+- 1008b507020950 / 026500 = 1
+- f108b503020001 / 0affffffffffffffffffff = 1
+- f108b503020002 / 0affffffffffffffffffff = 1
+- f108b503020004 / 0affffffffffffffffffff = 1
+- f108b503020005 / 0affffffffffffffffffff = 1
+- f115b503020002 / 0affffffffffffffffffff = 1
+- f176b503020001 / 0affffffffffffffffffff = 1
+- 'f115b503020001 / 0affffffffffffffffffff = 1: ctlv3 Currenterror'
+- 1076b512030f0001 / 07008000880114ff = 2
+- 1076b51009000000ffffff050000 / 0101 = 3
+- f115b52406020003001b00 / 0601031b000000 = 1
+- '3115b52406020002012300 / 00 = 1: ctlv2 Hc2DewPointTemp'
+- '3115b52406020002002100 / 00 = 1: ctlv2 Hc1MixerPosition'
+- '3115b52406020002012400 / 00 = 1: ctlv2 Hc2PumpHours'
+- '3115b52406020002012500 / 00 = 1: ctlv2 Hc2PumpStarts'
+- '[grab stop] grab stopped'
+labeled_telegrams:
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081001ffff02052835
+  resp: 0b0100070205283500000000
+  count: '1'
+  label: hmu CoolEnvYieldDay
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081000ffff02050000
+  resp: 0b0000070205283500000000
+  count: '1'
+  label: hmu CoolEnvYieldTotal
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081002ffff02052835
+  resp: 0b0200070205213500000000
+  count: '1'
+  label: hmu CoolEnvYieldMonth
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081001ffff03032835
+  resp: 0b01000003032835840c4643
+  count: '1'
+  label: hmu HcElecConsDay
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081000ffff03030000
+  resp: 0b00000003032835314c2946
+  count: '1'
+  label: hmu HcElecConsTotal
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081001ffff03052835
+  resp: 0b0100060305283500000000
+  count: '1'
+  label: hmu CoolElecConsDay
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081000ffff03040000
+  resp: 0b0000030304283500000000
+  count: '1'
+  label: hmu HwcElecConsTotal
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081001ffff03042835
+  resp: 0b0100030304283500000000
+  count: '1'
+  label: hmu HwcElecConsDay
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081000ffff03050000
+  resp: 0b00000603052835ff8ffb46
+  count: '1'
+  label: hmu CoolElecConsTotal
+- msgid: b516
+  master: '10'
+  slave: fe
+  sub: 080059242008090226
+  resp: null
+  count: '1'
+  label: Broadcast Vdatetime
+- msgid: b516
+  master: '10'
+  slave: fe
+  sub: 0301db0f
+  resp: null
+  count: '1'
+  label: Broadcast Outsidetemp
+- msgid: b510
+  master: '10'
+  slave: 08
+  sub: 09000050ffffff060000
+  resp: '0101'
+  count: '3'
+  label: bai SetModeOverride
+- msgid: b503
+  master: f1
+  slave: '15'
+  sub: '020001'
+  resp: 0affffffffffffffffffff
+  count: '1'
+  label: ctlv3 Currenterror
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020002012300'
+  resp: '00'
+  count: '1'
+  label: ctlv2 Hc2DewPointTemp
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020002002100'
+  resp: '00'
+  count: '1'
+  label: ctlv2 Hc1MixerPosition
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020002012400'
+  resp: '00'
+  count: '1'
+  label: ctlv2 Hc2PumpHours
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020002012500'
+  resp: '00'
+  count: '1'
+  label: ctlv2 Hc2PumpStarts
+unknown_telegrams:
+- msgid: b504
+  master: '10'
+  slave: 08
+  sub: '0100'
+  resp: 0a0301252008090226db0f
+  count: '1'
+  label: null
+- msgid: b511
+  master: '10'
+  slave: 08
+  sub: '0100'
+  resp: 09e501147a040900007a
+  count: '1'
+  label: null
+- msgid: b511
+  master: '10'
+  slave: 08
+  sub: '0101'
+  resp: 093d32db0fffff0100ff
+  count: '2'
+  label: null
+- msgid: b511
+  master: '10'
+  slave: '76'
+  sub: '0101'
+  resp: 093132db0fffff0000ff
+  count: '2'
+  label: null
+- msgid: b505
+  master: '10'
+  slave: fe
+  sub: 025c00
+  resp: null
+  count: '1'
+  label: null
+- msgid: b516
+  master: f1
+  slave: 08
+  sub: '0114'
+  resp: 090107d7af4400000000
+  count: '1'
+  label: null
+- msgid: b516
+  master: f1
+  slave: '76'
+  sub: '0114'
+  resp: 09000000a04000000000
+  count: '1'
+  label: null
+- msgid: b507
+  master: '10'
+  slave: 08
+  sub: 020950
+  resp: '026500'
+  count: '1'
+  label: null
+- msgid: b503
+  master: f1
+  slave: 08
+  sub: '020001'
+  resp: 0affffffffffffffffffff
+  count: '1'
+  label: null
+- msgid: b503
+  master: f1
+  slave: 08
+  sub: '020002'
+  resp: 0affffffffffffffffffff
+  count: '1'
+  label: null
+- msgid: b503
+  master: f1
+  slave: 08
+  sub: '020004'
+  resp: 0affffffffffffffffffff
+  count: '1'
+  label: null
+- msgid: b503
+  master: f1
+  slave: 08
+  sub: '020005'
+  resp: 0affffffffffffffffffff
+  count: '1'
+  label: null
+- msgid: b503
+  master: f1
+  slave: '15'
+  sub: '020002'
+  resp: 0affffffffffffffffffff
+  count: '1'
+  label: null
+- msgid: b503
+  master: f1
+  slave: '76'
+  sub: '020001'
+  resp: 0affffffffffffffffffff
+  count: '1'
+  label: null
+- msgid: b512
+  master: '10'
+  slave: '76'
+  sub: 030f0001
+  resp: 07008000880114ff
+  count: '2'
+  label: null
+- msgid: b510
+  master: '10'
+  slave: '76'
+  sub: 09000000ffffff050000
+  resp: '0101'
+  count: '3'
+  label: null
+- msgid: b524
+  master: f1
+  slave: '15'
+  sub: 06020003001b00
+  resp: 0601031b000000
+  count: '1'
+  label: null
+after_registers:
+- circuit: Broadcast
+  name: Datetime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Error
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: Broadcast
+  name: HwcStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Id
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: IdAnswer
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: IdQuery
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Load
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Outsidetemp
+  fields:
+  - value
+  values:
+  - '15.855'
+  writable: false
+  has_data: true
+- circuit: Broadcast
+  name: Queryexistence
+  fields:
+  - value
+  values:
+  - (empty for 31fe07fe00 / )
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Signoflife
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Vdatetime
+  fields:
+  - value
+  values:
+  - 20:24:59;08.09.2026
+  writable: false
+  has_data: true
+- circuit: Broadcast
+  name: Vdatetime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: WaterPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: General
+  name: Valuerange
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Eeprom
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Eeprom
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Ram
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Ram
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Scan
+  name: Id
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Scan.15
+  name: Id
+  fields:
+  - value
+  values:
+  - 21;25;45;0020260913;0953;026479;N3
+  writable: false
+  has_data: true
+- circuit: Scan.76
+  name: Id
+  fields:
+  - value
+  values:
+  - 21;26;03;8000035574;0001;005739;N8
+  writable: false
+  has_data: true
+- circuit: Scan.f6
+  name: Id
+  fields:
+  - value
+  values:
+  - 21;26;10;0020292012;0933;049007;N4
+  writable: false
+  has_data: true
+- circuit: bai
+  name: ActiveStages
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: bai
+  name: FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: bai
+  name: FlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: bai
+  name: HeatingStage1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: bai
+  name: HeatingStage3
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: bai
+  name: PrEnergySumHc1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: bai
+  name: PrEnergySumHwc1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: bai
+  name: SetModeOverride
+  fields:
+  - value
+  values:
+  - 0;40.0;-;-;-;0;1;1;0;0;0;0
+  writable: false
+  has_data: true
+- circuit: bai
+  name: StorageTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: bai
+  name: StorageTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: bai
+  name: WaterPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: AdaptHeatCurve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: CcTimer_Config
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: CcTimer_Timeframes
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: ContinuousHeating
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: CylinderChargeHyst
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: CylinderChargeOffset
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Date
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: DisplayedOutsideTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: FrostOverRideTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1AutoOffMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1CircuitType
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1CoolingEnabled
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1CoolingFlowTempMin
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1DewPointMonitoring
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1DewPointOffset
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1DewPointTemp
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002300 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1ExcessTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1FlowTempCalc
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002000 / 050102200001)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1HeatCurve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1Humidity
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002200 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MixerMovement
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MixerPosition
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002100 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1PumpHours
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002400 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1PumpStarts
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002500 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1PumpStatus
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1RoomTempModulation
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1Status
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1SummerTempLimit
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2AutoOffMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2CircuitType
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2DewPointTemp
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012300 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2ExcessTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2FlowTempCalc
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012000 / 050002200000)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2HeatCurve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2Humidity
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012200 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MixerMovement
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MixerPosition
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012100 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2PumpHours
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012400 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2PumpStarts
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012500 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2PumpStatus
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2Status
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2SummerTempLimit
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3AutoOffMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3CircuitType
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3ExcessTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3HeatCurve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MixerMovement
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3PumpStatus
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3Status
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3SummerTempLimit
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HcStorageTempBottom
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: ctlv2
+  name: HcStorageTempTop
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: ctlv2
+  name: HwcFlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcLockTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcMaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcOpMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcParallelLoading
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcSFMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcSfMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcStorageTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcStorageTempBottom
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcStorageTempTop
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HydraulicScheme
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: ManualCoolingEndDate
+  fields:
+  - value
+  values:
+  - 01.01.2015
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: ManualCoolingEndDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: ManualCoolingStartDate
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: ManualCoolingStartDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: MaxCylinderChargeTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: MaxRoomHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: MultiRelaySetting
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: OutsideTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: OutsideTempAvg
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySum
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHcLastMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHcThisMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHwcLastMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHwcThisMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: SystemFlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: WaterPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingManualTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingOpMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingSetbackTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1DayTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1HolidayTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1NightTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1OpMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoDuration
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoEndDate
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoEndTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1RoomTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1SFMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z2RoomTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: z1RoomHumidity
+  fields:
+  - value
+  values:
+  - '67'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: AdaptHeatCurve
+  fields:
+  - value
+  values:
+  - 'yes'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: AdaptHeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Config
+  fields:
+  - value
+  values:
+  - 03 01 01 00 00 00 ff ff 00
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CcTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Friday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Friday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Friday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Monday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Monday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Monday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Saturday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Saturday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Saturday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Sunday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Sunday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Sunday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Thursday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Timeframes
+  fields:
+  - value
+  values:
+  - 0;0;0;0;0;0;0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CcTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Tuesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Wednesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Clearerrorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: ContinuousHeating
+  fields:
+  - value
+  values:
+  - '-26'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: ContinuousHeating
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - -;-;-;-;-
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CylinderChargeHyst
+  fields:
+  - value
+  values:
+  - '7'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CylinderChargeHyst
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CylinderChargeOffset
+  fields:
+  - value
+  values:
+  - '10'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CylinderChargeOffset
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Date
+  fields:
+  - value
+  values:
+  - 08.09.2026
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Date
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: DisplayedOutsideTemp
+  fields:
+  - value
+  values:
+  - '15.9062'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: FrostOverRideTime
+  fields:
+  - value
+  values:
+  - '4'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: FrostOverRideTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - '40'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1AutoOffMode
+  fields:
+  - value
+  values:
+  - eco
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1AutoOffMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1CircuitType
+  fields:
+  - value
+  values:
+  - mixer
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1ExcessTemp
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1ExcessTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1FlowTemp
+  fields:
+  - value
+  values:
+  - '28.5'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1HeatCurve
+  fields:
+  - value
+  values:
+  - '0.8'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1HeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '40'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - '19'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - '19'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1MixerMovement
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1PumpStatus
+  fields:
+  - value
+  values:
+  - '1'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1PumpStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - thermostat
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1Status
+  fields:
+  - value
+  values:
+  - '1'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1SummerTempLimit
+  fields:
+  - value
+  values:
+  - '18'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1SummerTempLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2AutoOffMode
+  fields:
+  - value
+  values:
+  - eco
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2AutoOffMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2CircuitType
+  fields:
+  - value
+  values:
+  - inactive
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2ExcessTemp
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2ExcessTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2FlowTemp
+  fields:
+  - value
+  values:
+  - (empty for 3115b52406020002010800 / 0800020800ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2HeatCurve
+  fields:
+  - value
+  values:
+  - '0.6'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2HeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '55'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - '20'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - '15'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2MixerMovement
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2PumpStatus
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2PumpStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'off'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2Status
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2SummerTempLimit
+  fields:
+  - value
+  values:
+  - '16'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2SummerTempLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3AutoOffMode
+  fields:
+  - value
+  values:
+  - eco
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3AutoOffMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3CircuitType
+  fields:
+  - value
+  values:
+  - inactive
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3ExcessTemp
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3ExcessTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3FlowTemp
+  fields:
+  - value
+  values:
+  - (empty for 3115b52406020002020800 / 0800020800ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3HeatCurve
+  fields:
+  - value
+  values:
+  - '1.35'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3HeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '55'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - '20'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - '15'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3MixerMovement
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3PumpStatus
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3PumpStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'off'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3Status
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3SummerTempLimit
+  fields:
+  - value
+  values:
+  - '16'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3SummerTempLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HcStorageTempBottom
+  fields:
+  - value
+  values:
+  - (empty for f115b5240602000000a000 / 080000a000ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HcStorageTempTop
+  fields:
+  - value
+  values:
+  - (empty for f115b52406020000009f00 / 0800009f00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcBankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcBankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcBankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcBankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcFlowTemp
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcLockTime
+  fields:
+  - value
+  values:
+  - '60'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcLockTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcMaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '80'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcMaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcOpMode
+  fields:
+  - value
+  values:
+  - auto
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcOpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcParallelLoading
+  fields:
+  - value
+  values:
+  - 'off'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcParallelLoading
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcSFMode
+  fields:
+  - value
+  values:
+  - auto
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcSFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcStorageTemp
+  fields:
+  - value
+  values:
+  - (empty for 3115b52406020001000500 / 0800010500ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcStorageTempBottom
+  fields:
+  - value
+  values:
+  - (empty for f115b52406020000009e00 / 0800009e00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcStorageTempTop
+  fields:
+  - value
+  values:
+  - (empty for f115b52406020000009d00 / 0800009d00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTempDesired
+  fields:
+  - value
+  values:
+  - '55'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Config
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Friday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Friday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Friday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Monday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Monday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Monday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Saturday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Saturday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Saturday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Sunday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Sunday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Sunday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Thursday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Timeframes
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Tuesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Wednesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HydraulicScheme
+  fields:
+  - value
+  values:
+  - '8'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HydraulicScheme
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Installer1
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Installer1
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Installer2
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Installer2
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: KeyCodeforConfigMenu
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: KeyCodeforConfigMenu
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: MaintenanceDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: MaintenanceDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: MaintenanceDue
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: MaxCylinderChargeTime
+  fields:
+  - value
+  values:
+  - '90'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: MaxCylinderChargeTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: MaxRoomHumidity
+  fields:
+  - value
+  values:
+  - '50'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: MaxRoomHumidity
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: MultiRelaySetting
+  fields:
+  - value
+  values:
+  - '4'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: MultiRelaySetting
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: OutsideTempAvg
+  fields:
+  - value
+  values:
+  - '18.3398'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: OutsideTempAvg
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PhoneNumber1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PhoneNumber1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PhoneNumber2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PhoneNumber2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySum
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020000005c00 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHc
+  fields:
+  - value
+  values:
+  - '17'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: PrEnergySumHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHcLastMonth
+  fields:
+  - value
+  values:
+  - '11'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: PrEnergySumHcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHcThisMonth
+  fields:
+  - value
+  values:
+  - '2'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: PrEnergySumHcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHwc
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: PrEnergySumHwc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHwcLastMonth
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: PrEnergySumHwcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHwcThisMonth
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: PrEnergySumHwcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHwc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHwc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHwcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHwcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHwcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHwcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PumpAdditionalTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PumpAdditionalTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: SolarYieldTotal
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: SolarYieldTotal
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: SystemFlowTemp
+  fields:
+  - value
+  values:
+  - (empty for f115b52406020000004b00 / 0800004b00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Time
+  fields:
+  - value
+  values:
+  - '19:41:52'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Time
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: WaterPressure
+  fields:
+  - value
+  values:
+  - '2'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: YieldTotal
+  fields:
+  - value
+  values:
+  - '6'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: YieldTotal
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - '26'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1CoolingTemp
+  fields:
+  - value
+  values:
+  - '23'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1CoolingTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1DayTemp
+  fields:
+  - value
+  values:
+  - '26'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1HolidayTemp
+  fields:
+  - value
+  values:
+  - '15'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Name1
+  fields:
+  - value
+  values:
+  - Zone
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Name2
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for f115b52406020003001800 / 06030318003100)'
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1NightTemp
+  fields:
+  - value
+  values:
+  - '15'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1OpMode
+  fields:
+  - value
+  values:
+  - day
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1QuickVetoDuration
+  fields:
+  - value
+  values:
+  - '3'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1QuickVetoEndDate
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1QuickVetoEndTime
+  fields:
+  - value
+  values:
+  - 00:00:00
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1QuickVetoTemp
+  fields:
+  - value
+  values:
+  - '21'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1RoomTemp
+  fields:
+  - value
+  values:
+  - '22.475'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1SFMode
+  fields:
+  - value
+  values:
+  - auto
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Config
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Friday0
+  fields:
+  - value
+  values:
+  - 06:00;22:00;20.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Friday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Friday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Monday0
+  fields:
+  - value
+  values:
+  - 06:00;22:00;20.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Monday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Monday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Saturday0
+  fields:
+  - value
+  values:
+  - 07:30;23:30;20.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Saturday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Saturday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Sunday0
+  fields:
+  - value
+  values:
+  - 07:30;22:00;20.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Sunday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Sunday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Thursday0
+  fields:
+  - value
+  values:
+  - 06:00;22:00;20.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Timeframes
+  fields:
+  - value
+  values:
+  - 1;1;1;1;1;1;1
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Tuesday0
+  fields:
+  - value
+  values:
+  - 06:00;22:00;20.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Wednesday0
+  fields:
+  - value
+  values:
+  - 06:00;22:00;20.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2CoolingTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2CoolingTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2QuickVetoEndDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2QuickVetoEndTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2RoomTemp
+  fields:
+  - value
+  values:
+  - (empty for 3115b52406020003010f00 / 0802030f00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z2RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Config
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Friday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Friday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Friday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Monday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Monday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Monday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Saturday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Saturday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Saturday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Sunday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Sunday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Sunday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Thursday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Timeframes
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Tuesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Wednesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3QuickVetoEndDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3QuickVetoEndTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3RoomTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z3RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Config
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Friday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Friday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Friday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Monday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Monday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Monday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Saturday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Saturday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Saturday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Sunday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Sunday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Sunday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Thursday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Timeframes
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Tuesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Wednesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: BuildingCircuitFlow
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: BuildingCircuitPumpSpeed
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: CompressorHc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: CompressorHwc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHwc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: ConsumptionTotal
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CoolElecConsDay
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CoolElecConsTotal
+  fields:
+  - value
+  values:
+  - '32200'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CoolEnvYieldDay
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CoolEnvYieldMonth
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CoolEnvYieldTotal
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CopCooling
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CopCoolingMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CopHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CopHcMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CopHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CopHwcMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CurrentCompressorUtil
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CurrentConsumedPower
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CurrentYieldPower
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: DateTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: FlowTemperature
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: HcElecConsDay
+  fields:
+  - value
+  values:
+  - '198.049'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: HcElecConsTotal
+  fields:
+  - value
+  values:
+  - '10835'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: HoursCool
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: HwcElecConsDay
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: HwcElecConsTotal
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: LiveMonitorCurrentConsumedPower
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: PowerConsumptionHmu
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunDataAirInletTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataBuildingCPumpPower
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataCompressorInletTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataCompressorOutletTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataCompressorSpeed
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataEEVOutletTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataEEVPositionAbs
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataElectricPowerConsumption
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataFan1Speed
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataFan2Speed
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataHighPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataLowPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunDataReturnTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataStatuscode
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStats4PortValveHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStats4PortValveSwitches
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsBuildingCPumpStarts
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsBuildingPumpHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunStatsCompressorHc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunStatsCompressorHwc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHwc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorStarts
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsFan1Hours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsFan1Starts
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsFan2Hours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsFan2Starts
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsHMUHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsHcHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsHwcHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: SourceTempInput
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: SourceTempOutput
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatElectricEnergySum
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatElectricEnergySumCool
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatElectricEnergySumHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatElectricEnergySumHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatEnvironmentEnergySum
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatEnvironmentEnergySumCool
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatEnvironmentEnergySumHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatEnvironmentEnergySumHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatSolarEnergySum
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatSolarEnergySumHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatSolarEnergySumHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.pumpstate
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.temp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.temp_1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.temp_2
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: Status01.temp_3
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: Status01.temp_4
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: StatusCirPump
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: SupplyTempWeighted
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: TotalEnergyUsage
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldCoolDay
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldCooling
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldCoolingMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldHcDay
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldHcMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldHwcDay
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldHwcMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmux0
+  name: Status01
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmux0
+  name: Status01.pumpstate
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmux0
+  name: Status01.temp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmux0
+  name: Status01.temp_1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmux0
+  name: Status01.temp_2
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmux0
+  name: Status01.temp_3
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmux0
+  name: Status01.temp_4
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: v32
+  name: BypassPosition
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: ExhaustAirHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: ExhaustAirTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: FanHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: FlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: FlowTempMax
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: HcHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: HoursTillService
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: HwcHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: HwcTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: v32
+  name: Maintenancedata_HwcTempMax
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: v32
+  name: MaxAirHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: MinAirHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: OutdoorstempSensor
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: v32
+  name: OutsideAirTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: PumpHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: PumpPower
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: ReturnTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: ReturnTempMax
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: Status02.hwcmode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: Status02.temp0
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: Status02.temp0_1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: Status02.temp1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: Status02.temp1_1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: StorageLoadPumpHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: StorageTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: StorageTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: SupplyAirTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: VentilationLevelDay
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: VentilationLevelNight
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldToday
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldTotal
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldYear
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Clearerrorhistory
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Mc1Operation
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Mc2Operation
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Mc3Operation
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: SensorData1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: SensorData2
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: SetActorState
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vwz
+  name: TestHwcTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: vwz
+  name: TestOutdoorTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: vwz
+  name: TestThreeWayValve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: vwzio
+  name: EnableTestHwcTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: EnableTestOutdoorTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: EnableTestThreeWayValve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: TestHwcTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: TestOutdoorTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: TestThreeWayValve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+raw_find_lines_after:
+- bai SetModeOverride = 0;40.0;-;-;-;0;1;1;0;0;0;0
+- Broadcast Datetime = no data stored
+- Broadcast Error = no data stored
+- Broadcast HwcStatus = no data stored
+- Broadcast Id = no data stored
+- Broadcast IdAnswer = no data stored
+- Broadcast IdQuery = no data stored
+- Broadcast Load = no data stored
+- Broadcast Outsidetemp = 15.855
+- Broadcast Queryexistence =  (empty for 31fe07fe00 / )
+- Broadcast Signoflife = no data stored
+- Broadcast Vdatetime = 20:24:59;08.09.2026
+- Broadcast Vdatetime = no data stored
+- 'ctlv2 Hc1DewPointTemp =  (ERR: invalid position for 3115b52406020002002300 / 00)'
+- 'ctlv2 Hc1FlowTempCalc =  (ERR: invalid position for 3115b52406020002002000 / 050102200001)'
+- 'ctlv2 Hc1Humidity =  (ERR: invalid position for 3115b52406020002002200 / 00)'
+- 'ctlv2 Hc1MixerPosition =  (ERR: invalid position for 3115b52406020002002100 / 00)'
+- 'ctlv2 Hc1PumpHours =  (ERR: invalid position for 3115b52406020002002400 / 00)'
+- 'ctlv2 Hc1PumpStarts =  (ERR: invalid position for 3115b52406020002002500 / 00)'
+- 'ctlv2 Hc2DewPointTemp =  (ERR: invalid position for 3115b52406020002012300 / 00)'
+- 'ctlv2 Hc2FlowTempCalc =  (ERR: invalid position for 3115b52406020002012000 / 050002200000)'
+- 'ctlv2 Hc2Humidity =  (ERR: invalid position for 3115b52406020002012200 / 00)'
+- 'ctlv2 Hc2MixerPosition =  (ERR: invalid position for 3115b52406020002012100 / 00)'
+- 'ctlv2 Hc2PumpHours =  (ERR: invalid position for 3115b52406020002012400 / 00)'
+- 'ctlv2 Hc2PumpStarts =  (ERR: invalid position for 3115b52406020002012500 / 00)'
+- ctlv2 ManualCoolingEndDate = 01.01.2015
+- ctlv2 ManualCoolingEndDate = no data stored
+- ctlv2 ManualCoolingStartDate = 01.01.2019
+- ctlv2 ManualCoolingStartDate = no data stored
+- ctlv2 z1RoomHumidity = 67
+- ctlv3 AdaptHeatCurve = yes
+- ctlv3 AdaptHeatCurve = no data stored
+- ctlv3 CcTimer_Config = 03 01 01 00 00 00 ff ff 00
+- ctlv3 CcTimer_Friday0 = no data stored
+- ctlv3 CcTimer_Friday1 = no data stored
+- ctlv3 CcTimer_Friday2 = no data stored
+- ctlv3 CcTimer_Friday = no data stored
+- ctlv3 CcTimer_Monday0 = no data stored
+- ctlv3 CcTimer_Monday1 = no data stored
+- ctlv3 CcTimer_Monday2 = no data stored
+- ctlv3 CcTimer_Monday = no data stored
+- ctlv3 CcTimer_Saturday0 = no data stored
+- ctlv3 CcTimer_Saturday1 = no data stored
+- ctlv3 CcTimer_Saturday2 = no data stored
+- ctlv3 CcTimer_Saturday = no data stored
+- ctlv3 CcTimer_Sunday0 = no data stored
+- ctlv3 CcTimer_Sunday1 = no data stored
+- ctlv3 CcTimer_Sunday2 = no data stored
+- ctlv3 CcTimer_Sunday = no data stored
+- ctlv3 CcTimer_Thursday0 = no data stored
+- ctlv3 CcTimer_Thursday1 = no data stored
+- ctlv3 CcTimer_Thursday2 = no data stored
+- ctlv3 CcTimer_Thursday = no data stored
+- ctlv3 CcTimer_Timeframes = 0;0;0;0;0;0;0
+- ctlv3 CcTimer_Tuesday0 = no data stored
+- ctlv3 CcTimer_Tuesday1 = no data stored
+- ctlv3 CcTimer_Tuesday2 = no data stored
+- ctlv3 CcTimer_Tuesday = no data stored
+- ctlv3 CcTimer_Wednesday0 = no data stored
+- ctlv3 CcTimer_Wednesday1 = no data stored
+- ctlv3 CcTimer_Wednesday2 = no data stored
+- ctlv3 CcTimer_Wednesday = no data stored
+- ctlv3 Clearerrorhistory = no data stored
+- ctlv3 ContinuousHeating = -26
+- ctlv3 ContinuousHeating = no data stored
+- ctlv3 Currenterror = -;-;-;-;-
+- ctlv3 CylinderChargeHyst = 7
+- ctlv3 CylinderChargeHyst = no data stored
+- ctlv3 CylinderChargeOffset = 10
+- ctlv3 CylinderChargeOffset = no data stored
+- ctlv3 Date = 08.09.2026
+- ctlv3 Date = no data stored
+- ctlv3 DisplayedOutsideTemp = 15.9062
+- ctlv3 Errorhistory = no data stored
+- ctlv3 FrostOverRideTime = 4
+- ctlv3 FrostOverRideTime = no data stored
+- ctlv3 Hc1ActualFlowTempDesired = 40
+- ctlv3 Hc1AutoOffMode = eco
+- ctlv3 Hc1AutoOffMode = no data stored
+- ctlv3 Hc1CircuitType = mixer
+- ctlv3 Hc1ExcessTemp = 0.0
+- ctlv3 Hc1ExcessTemp = no data stored
+- ctlv3 Hc1FlowTemp = 28.5
+- ctlv3 Hc1HeatCurve = 0.8
+- ctlv3 Hc1HeatCurve = no data stored
+- ctlv3 Hc1HeatCurveAdaption = 0.0
+- ctlv3 Hc1MaxFlowTempDesired = 40
+- ctlv3 Hc1MaxFlowTempDesired = no data stored
+- ctlv3 Hc1MinCoolingTempDesired = 19
+- ctlv3 Hc1MinCoolingTempDesired = no data stored
+- ctlv3 Hc1MinFlowTempDesired = 19
+- ctlv3 Hc1MinFlowTempDesired = no data stored
+- ctlv3 Hc1MixerMovement = 0.0
+- ctlv3 Hc1PumpStatus = 1
+- ctlv3 Hc1PumpStatus = no data stored
+- ctlv3 Hc1RoomTempSwitchOn = thermostat
+- ctlv3 Hc1RoomTempSwitchOn = no data stored
+- ctlv3 Hc1Status = 1
+- ctlv3 Hc1Status = no data stored
+- ctlv3 Hc1SummerTempLimit = 18
+- ctlv3 Hc1SummerTempLimit = no data stored
+- ctlv3 Hc2ActualFlowTempDesired = 0.0
+- ctlv3 Hc2AutoOffMode = eco
+- ctlv3 Hc2AutoOffMode = no data stored
+- ctlv3 Hc2CircuitType = inactive
+- ctlv3 Hc2ExcessTemp = 0.0
+- ctlv3 Hc2ExcessTemp = no data stored
+- ctlv3 Hc2FlowTemp =  (empty for 3115b52406020002010800 / 0800020800ffffff7f)
+- ctlv3 Hc2HeatCurve = 0.6
+- ctlv3 Hc2HeatCurve = no data stored
+- ctlv3 Hc2HeatCurveAdaption = 0.0
+- ctlv3 Hc2MaxFlowTempDesired = 55
+- ctlv3 Hc2MaxFlowTempDesired = no data stored
+- ctlv3 Hc2MinCoolingTempDesired = 20
+- ctlv3 Hc2MinCoolingTempDesired = no data stored
+- ctlv3 Hc2MinFlowTempDesired = 15
+- ctlv3 Hc2MinFlowTempDesired = no data stored
+- ctlv3 Hc2MixerMovement = 0.0
+- ctlv3 Hc2PumpStatus = 0
+- ctlv3 Hc2PumpStatus = no data stored
+- ctlv3 Hc2RoomTempSwitchOn = off
+- ctlv3 Hc2RoomTempSwitchOn = no data stored
+- ctlv3 Hc2Status = 0
+- ctlv3 Hc2Status = no data stored
+- ctlv3 Hc2SummerTempLimit = 16
+- ctlv3 Hc2SummerTempLimit = no data stored
+- ctlv3 Hc3ActualFlowTempDesired = 0.0
+- ctlv3 Hc3AutoOffMode = eco
+- ctlv3 Hc3AutoOffMode = no data stored
+- ctlv3 Hc3CircuitType = inactive
+- ctlv3 Hc3ExcessTemp = 0.0
+- ctlv3 Hc3ExcessTemp = no data stored
+- ctlv3 Hc3FlowTemp =  (empty for 3115b52406020002020800 / 0800020800ffffff7f)
+- ctlv3 Hc3HeatCurve = 1.35
+- ctlv3 Hc3HeatCurve = no data stored
+- ctlv3 Hc3HeatCurveAdaption = 0.0
+- ctlv3 Hc3MaxFlowTempDesired = 55
+- ctlv3 Hc3MaxFlowTempDesired = no data stored
+- ctlv3 Hc3MinCoolingTempDesired = 20
+- ctlv3 Hc3MinCoolingTempDesired = no data stored
+- ctlv3 Hc3MinFlowTempDesired = 15
+- ctlv3 Hc3MinFlowTempDesired = no data stored
+- ctlv3 Hc3MixerMovement = 0.0
+- ctlv3 Hc3PumpStatus = 0
+- ctlv3 Hc3PumpStatus = no data stored
+- ctlv3 Hc3RoomTempSwitchOn = off
+- ctlv3 Hc3RoomTempSwitchOn = no data stored
+- ctlv3 Hc3Status = 0
+- ctlv3 Hc3Status = no data stored
+- ctlv3 Hc3SummerTempLimit = 16
+- ctlv3 Hc3SummerTempLimit = no data stored
+- ctlv3 HcStorageTempBottom =  (empty for f115b5240602000000a000 / 080000a000ffffff7f)
+- ctlv3 HcStorageTempTop =  (empty for f115b52406020000009f00 / 0800009f00ffffff7f)
+- ctlv3 HwcBankHolidayEndPeriod = no data stored
+- ctlv3 HwcBankHolidayEndPeriod = no data stored
+- ctlv3 HwcBankHolidayStartPeriod = no data stored
+- ctlv3 HwcBankHolidayStartPeriod = no data stored
+- ctlv3 HwcFlowTemp = 0.0
+- ctlv3 HwcHolidayEndPeriod = 01.01.2019
+- ctlv3 HwcHolidayEndPeriod = no data stored
+- ctlv3 HwcHolidayStartPeriod = 01.01.2019
+- ctlv3 HwcHolidayStartPeriod = no data stored
+- ctlv3 HwcLockTime = 60
+- ctlv3 HwcLockTime = no data stored
+- ctlv3 HwcMaxFlowTempDesired = 80
+- ctlv3 HwcMaxFlowTempDesired = no data stored
+- ctlv3 HwcOpMode = auto
+- ctlv3 HwcOpMode = no data stored
+- ctlv3 HwcParallelLoading = off
+- ctlv3 HwcParallelLoading = no data stored
+- ctlv3 HwcSFMode = auto
+- ctlv3 HwcSFMode = no data stored
+- ctlv3 HwcStorageTemp =  (empty for 3115b52406020001000500 / 0800010500ffffff7f)
+- ctlv3 HwcStorageTempBottom =  (empty for f115b52406020000009e00 / 0800009e00ffffff7f)
+- ctlv3 HwcStorageTempTop =  (empty for f115b52406020000009d00 / 0800009d00ffffff7f)
+- ctlv3 HwcTempDesired = 55
+- ctlv3 HwcTempDesired = no data stored
+- ctlv3 HwcTimer_Config = no data stored
+- ctlv3 HwcTimer_Friday0 = no data stored
+- ctlv3 HwcTimer_Friday1 = no data stored
+- ctlv3 HwcTimer_Friday2 = no data stored
+- ctlv3 HwcTimer_Friday = no data stored
+- ctlv3 HwcTimer_Monday0 = no data stored
+- ctlv3 HwcTimer_Monday1 = no data stored
+- ctlv3 HwcTimer_Monday2 = no data stored
+- ctlv3 HwcTimer_Monday = no data stored
+- ctlv3 HwcTimer_Saturday0 = no data stored
+- ctlv3 HwcTimer_Saturday1 = no data stored
+- ctlv3 HwcTimer_Saturday2 = no data stored
+- ctlv3 HwcTimer_Saturday = no data stored
+- ctlv3 HwcTimer_Sunday0 = no data stored
+- ctlv3 HwcTimer_Sunday1 = no data stored
+- ctlv3 HwcTimer_Sunday2 = no data stored
+- ctlv3 HwcTimer_Sunday = no data stored
+- ctlv3 HwcTimer_Thursday0 = no data stored
+- ctlv3 HwcTimer_Thursday1 = no data stored
+- ctlv3 HwcTimer_Thursday2 = no data stored
+- ctlv3 HwcTimer_Thursday = no data stored
+- ctlv3 HwcTimer_Timeframes = no data stored
+- ctlv3 HwcTimer_Tuesday0 = no data stored
+- ctlv3 HwcTimer_Tuesday1 = no data stored
+- ctlv3 HwcTimer_Tuesday2 = no data stored
+- ctlv3 HwcTimer_Tuesday = no data stored
+- ctlv3 HwcTimer_Wednesday0 = no data stored
+- ctlv3 HwcTimer_Wednesday1 = no data stored
+- ctlv3 HwcTimer_Wednesday2 = no data stored
+- ctlv3 HwcTimer_Wednesday = no data stored
+- ctlv3 HydraulicScheme = 8
+- ctlv3 HydraulicScheme = no data stored
+- ctlv3 Installer1 = no data stored
+- ctlv3 Installer1 = no data stored
+- ctlv3 Installer2 = no data stored
+- ctlv3 Installer2 = no data stored
+- ctlv3 KeyCodeforConfigMenu = no data stored
+- ctlv3 KeyCodeforConfigMenu = no data stored
+- ctlv3 MaintenanceDate = no data stored
+- ctlv3 MaintenanceDate = no data stored
+- ctlv3 MaintenanceDue = no data stored
+- ctlv3 MaxCylinderChargeTime = 90
+- ctlv3 MaxCylinderChargeTime = no data stored
+- ctlv3 MaxRoomHumidity = 50
+- ctlv3 MaxRoomHumidity = no data stored
+- ctlv3 MultiRelaySetting = 4
+- ctlv3 MultiRelaySetting = no data stored
+- ctlv3 OutsideTempAvg = 18.3398
+- ctlv3 OutsideTempAvg = no data stored
+- ctlv3 PhoneNumber1 = no data stored
+- ctlv3 PhoneNumber1 = no data stored
+- ctlv3 PhoneNumber2 = no data stored
+- ctlv3 PhoneNumber2 = no data stored
+- 'ctlv3 PrEnergySum =  (ERR: invalid position for 3115b52406020000005c00 / 00)'
+- ctlv3 PrEnergySum = no data stored
+- ctlv3 PrEnergySumHc = 17
+- ctlv3 PrEnergySumHc = no data stored
+- ctlv3 PrEnergySumHcLastMonth = 11
+- ctlv3 PrEnergySumHcLastMonth = no data stored
+- ctlv3 PrEnergySumHcThisMonth = 2
+- ctlv3 PrEnergySumHcThisMonth = no data stored
+- ctlv3 PrEnergySumHwc = 0
+- ctlv3 PrEnergySumHwc = no data stored
+- ctlv3 PrEnergySumHwcLastMonth = 0
+- ctlv3 PrEnergySumHwcLastMonth = no data stored
+- ctlv3 PrEnergySumHwcThisMonth = 0
+- ctlv3 PrEnergySumHwcThisMonth = no data stored
+- ctlv3 PrFuelSum = no data stored
+- ctlv3 PrFuelSum = no data stored
+- ctlv3 PrFuelSumHc = no data stored
+- ctlv3 PrFuelSumHc = no data stored
+- ctlv3 PrFuelSumHcLastMonth = no data stored
+- ctlv3 PrFuelSumHcLastMonth = no data stored
+- ctlv3 PrFuelSumHcThisMonth = no data stored
+- ctlv3 PrFuelSumHcThisMonth = no data stored
+- ctlv3 PrFuelSumHwc = no data stored
+- ctlv3 PrFuelSumHwc = no data stored
+- ctlv3 PrFuelSumHwcLastMonth = no data stored
+- ctlv3 PrFuelSumHwcLastMonth = no data stored
+- ctlv3 PrFuelSumHwcThisMonth = no data stored
+- ctlv3 PrFuelSumHwcThisMonth = no data stored
+- ctlv3 PumpAdditionalTime = no data stored
+- ctlv3 PumpAdditionalTime = no data stored
+- ctlv3 SolarYieldTotal = no data stored
+- ctlv3 SolarYieldTotal = no data stored
+- ctlv3 SystemFlowTemp =  (empty for f115b52406020000004b00 / 0800004b00ffffff7f)
+- ctlv3 Time = 19:41:52
+- ctlv3 Time = no data stored
+- ctlv3 WaterPressure = 2
+- ctlv3 YieldTotal = 6
+- ctlv3 YieldTotal = no data stored
+- ctlv3 Z1ActualRoomTempDesired = 26
+- ctlv3 Z1ActualRoomTempDesired = no data stored
+- ctlv3 Z1BankHolidayEndPeriod = no data stored
+- ctlv3 Z1BankHolidayEndPeriod = no data stored
+- ctlv3 Z1BankHolidayStartPeriod = no data stored
+- ctlv3 Z1BankHolidayStartPeriod = no data stored
+- ctlv3 Z1CoolingTemp = 23
+- ctlv3 Z1CoolingTemp = no data stored
+- ctlv3 Z1DayTemp = 26
+- ctlv3 Z1DayTemp = no data stored
+- ctlv3 Z1HolidayEndPeriod = 01.01.2019
+- ctlv3 Z1HolidayEndPeriod = no data stored
+- ctlv3 Z1HolidayStartPeriod = 01.01.2019
+- ctlv3 Z1HolidayStartPeriod = no data stored
+- ctlv3 Z1HolidayTemp = 15
+- ctlv3 Z1HolidayTemp = no data stored
+- 'ctlv3 Z1Name1 = Zone '
+- ctlv3 Z1Name1 = no data stored
+- 'ctlv3 Z1Name2 =  (ERR: invalid position for f115b52406020003001800 / 06030318003100)'
+- ctlv3 Z1Name2 = no data stored
+- ctlv3 Z1NightTemp = 15
+- ctlv3 Z1NightTemp = no data stored
+- ctlv3 Z1OpMode = day
+- ctlv3 Z1OpMode = no data stored
+- ctlv3 Z1QuickVetoDuration = 3
+- ctlv3 Z1QuickVetoDuration = no data stored
+- ctlv3 Z1QuickVetoEndDate = 01.01.2019
+- ctlv3 Z1QuickVetoEndTime = 00:00:00
+- ctlv3 Z1QuickVetoTemp = 21
+- ctlv3 Z1QuickVetoTemp = no data stored
+- ctlv3 Z1RoomTemp = 22.475
+- ctlv3 Z1RoomZoneMapping = VRC700
+- ctlv3 Z1RoomZoneMapping = no data stored
+- ctlv3 Z1SFMode = auto
+- ctlv3 Z1SFMode = no data stored
+- ctlv3 Z1Shortname = no data stored
+- ctlv3 Z1Shortname = no data stored
+- ctlv3 Z1Timer_Config = no data stored
+- ctlv3 Z1Timer_Friday0 = 06:00;22:00;20.0
+- ctlv3 Z1Timer_Friday1 = no data stored
+- ctlv3 Z1Timer_Friday2 = no data stored
+- ctlv3 Z1Timer_Friday = no data stored
+- ctlv3 Z1Timer_Monday0 = 06:00;22:00;20.0
+- ctlv3 Z1Timer_Monday1 = no data stored
+- ctlv3 Z1Timer_Monday2 = no data stored
+- ctlv3 Z1Timer_Monday = no data stored
+- ctlv3 Z1Timer_Saturday0 = 07:30;23:30;20.0
+- ctlv3 Z1Timer_Saturday1 = no data stored
+- ctlv3 Z1Timer_Saturday2 = no data stored
+- ctlv3 Z1Timer_Saturday = no data stored
+- ctlv3 Z1Timer_Sunday0 = 07:30;22:00;20.0
+- ctlv3 Z1Timer_Sunday1 = no data stored
+- ctlv3 Z1Timer_Sunday2 = no data stored
+- ctlv3 Z1Timer_Sunday = no data stored
+- ctlv3 Z1Timer_Thursday0 = 06:00;22:00;20.0
+- ctlv3 Z1Timer_Thursday1 = no data stored
+- ctlv3 Z1Timer_Thursday2 = no data stored
+- ctlv3 Z1Timer_Thursday = no data stored
+- ctlv3 Z1Timer_Timeframes = 1;1;1;1;1;1;1
+- ctlv3 Z1Timer_Tuesday0 = 06:00;22:00;20.0
+- ctlv3 Z1Timer_Tuesday1 = no data stored
+- ctlv3 Z1Timer_Tuesday2 = no data stored
+- ctlv3 Z1Timer_Tuesday = no data stored
+- ctlv3 Z1Timer_Wednesday0 = 06:00;22:00;20.0
+- ctlv3 Z1Timer_Wednesday1 = no data stored
+- ctlv3 Z1Timer_Wednesday2 = no data stored
+- ctlv3 Z1Timer_Wednesday = no data stored
+- ctlv3 Z1ValveStatus = no data stored
+- ctlv3 Z1ValveStatus = no data stored
+- ctlv3 Z2ActualRoomTempDesired = no data stored
+- ctlv3 Z2ActualRoomTempDesired = no data stored
+- ctlv3 Z2BankHolidayEndPeriod = no data stored
+- ctlv3 Z2BankHolidayEndPeriod = no data stored
+- ctlv3 Z2BankHolidayStartPeriod = no data stored
+- ctlv3 Z2BankHolidayStartPeriod = no data stored
+- ctlv3 Z2CoolingTemp = no data stored
+- ctlv3 Z2CoolingTemp = no data stored
+- ctlv3 Z2DayTemp = no data stored
+- ctlv3 Z2DayTemp = no data stored
+- ctlv3 Z2HolidayEndPeriod = no data stored
+- ctlv3 Z2HolidayEndPeriod = no data stored
+- ctlv3 Z2HolidayStartPeriod = no data stored
+- ctlv3 Z2HolidayStartPeriod = no data stored
+- ctlv3 Z2HolidayTemp = no data stored
+- ctlv3 Z2HolidayTemp = no data stored
+- ctlv3 Z2Name1 = no data stored
+- ctlv3 Z2Name1 = no data stored
+- ctlv3 Z2Name2 = no data stored
+- ctlv3 Z2Name2 = no data stored
+- ctlv3 Z2NightTemp = no data stored
+- ctlv3 Z2NightTemp = no data stored
+- ctlv3 Z2OpMode = no data stored
+- ctlv3 Z2OpMode = no data stored
+- ctlv3 Z2QuickVetoDuration = no data stored
+- ctlv3 Z2QuickVetoDuration = no data stored
+- ctlv3 Z2QuickVetoEndDate = no data stored
+- ctlv3 Z2QuickVetoEndTime = no data stored
+- ctlv3 Z2QuickVetoTemp = no data stored
+- ctlv3 Z2QuickVetoTemp = no data stored
+- ctlv3 Z2RoomTemp =  (empty for 3115b52406020003010f00 / 0802030f00ffffff7f)
+- ctlv3 Z2RoomZoneMapping = none
+- ctlv3 Z2RoomZoneMapping = no data stored
+- ctlv3 Z2SFMode = no data stored
+- ctlv3 Z2SFMode = no data stored
+- ctlv3 Z2Shortname = no data stored
+- ctlv3 Z2Shortname = no data stored
+- ctlv3 Z2Timer_Config = no data stored
+- ctlv3 Z2Timer_Friday0 = no data stored
+- ctlv3 Z2Timer_Friday1 = no data stored
+- ctlv3 Z2Timer_Friday2 = no data stored
+- ctlv3 Z2Timer_Friday = no data stored
+- ctlv3 Z2Timer_Monday0 = no data stored
+- ctlv3 Z2Timer_Monday1 = no data stored
+- ctlv3 Z2Timer_Monday2 = no data stored
+- ctlv3 Z2Timer_Monday = no data stored
+- ctlv3 Z2Timer_Saturday0 = no data stored
+- ctlv3 Z2Timer_Saturday1 = no data stored
+- ctlv3 Z2Timer_Saturday2 = no data stored
+- ctlv3 Z2Timer_Saturday = no data stored
+- ctlv3 Z2Timer_Sunday0 = no data stored
+- ctlv3 Z2Timer_Sunday1 = no data stored
+- ctlv3 Z2Timer_Sunday2 = no data stored
+- ctlv3 Z2Timer_Sunday = no data stored
+- ctlv3 Z2Timer_Thursday0 = no data stored
+- ctlv3 Z2Timer_Thursday1 = no data stored
+- ctlv3 Z2Timer_Thursday2 = no data stored
+- ctlv3 Z2Timer_Thursday = no data stored
+- ctlv3 Z2Timer_Timeframes = no data stored
+- ctlv3 Z2Timer_Tuesday0 = no data stored
+- ctlv3 Z2Timer_Tuesday1 = no data stored
+- ctlv3 Z2Timer_Tuesday2 = no data stored
+- ctlv3 Z2Timer_Tuesday = no data stored
+- ctlv3 Z2Timer_Wednesday0 = no data stored
+- ctlv3 Z2Timer_Wednesday1 = no data stored
+- ctlv3 Z2Timer_Wednesday2 = no data stored
+- ctlv3 Z2Timer_Wednesday = no data stored
+- ctlv3 Z2ValveStatus = no data stored
+- ctlv3 Z2ValveStatus = no data stored
+- ctlv3 Z3ActualRoomTempDesired = no data stored
+- ctlv3 Z3ActualRoomTempDesired = no data stored
+- ctlv3 Z3BankHolidayEndPeriod = no data stored
+- ctlv3 Z3BankHolidayEndPeriod = no data stored
+- ctlv3 Z3BankHolidayStartPeriod = no data stored
+- ctlv3 Z3BankHolidayStartPeriod = no data stored
+- ctlv3 Z3DayTemp = no data stored
+- ctlv3 Z3DayTemp = no data stored
+- ctlv3 Z3HolidayEndPeriod = no data stored
+- ctlv3 Z3HolidayEndPeriod = no data stored
+- ctlv3 Z3HolidayStartPeriod = no data stored
+- ctlv3 Z3HolidayStartPeriod = no data stored
+- ctlv3 Z3HolidayTemp = no data stored
+- ctlv3 Z3HolidayTemp = no data stored
+- ctlv3 Z3Name1 = no data stored
+- ctlv3 Z3Name1 = no data stored
+- ctlv3 Z3Name2 = no data stored
+- ctlv3 Z3Name2 = no data stored
+- ctlv3 Z3NightTemp = no data stored
+- ctlv3 Z3NightTemp = no data stored
+- ctlv3 Z3OpMode = no data stored
+- ctlv3 Z3OpMode = no data stored
+- ctlv3 Z3QuickVetoDuration = no data stored
+- ctlv3 Z3QuickVetoDuration = no data stored
+- ctlv3 Z3QuickVetoEndDate = no data stored
+- ctlv3 Z3QuickVetoEndTime = no data stored
+- ctlv3 Z3QuickVetoTemp = no data stored
+- ctlv3 Z3QuickVetoTemp = no data stored
+- ctlv3 Z3RoomTemp = no data stored
+- ctlv3 Z3RoomZoneMapping = none
+- ctlv3 Z3RoomZoneMapping = no data stored
+- ctlv3 Z3SFMode = no data stored
+- ctlv3 Z3SFMode = no data stored
+- ctlv3 Z3Shortname = no data stored
+- ctlv3 Z3Shortname = no data stored
+- ctlv3 Z3Timer_Config = no data stored
+- ctlv3 Z3Timer_Friday0 = no data stored
+- ctlv3 Z3Timer_Friday1 = no data stored
+- ctlv3 Z3Timer_Friday2 = no data stored
+- ctlv3 Z3Timer_Friday = no data stored
+- ctlv3 Z3Timer_Monday0 = no data stored
+- ctlv3 Z3Timer_Monday1 = no data stored
+- ctlv3 Z3Timer_Monday2 = no data stored
+- ctlv3 Z3Timer_Monday = no data stored
+- ctlv3 Z3Timer_Saturday0 = no data stored
+- ctlv3 Z3Timer_Saturday1 = no data stored
+- ctlv3 Z3Timer_Saturday2 = no data stored
+- ctlv3 Z3Timer_Saturday = no data stored
+- ctlv3 Z3Timer_Sunday0 = no data stored
+- ctlv3 Z3Timer_Sunday1 = no data stored
+- ctlv3 Z3Timer_Sunday2 = no data stored
+- ctlv3 Z3Timer_Sunday = no data stored
+- ctlv3 Z3Timer_Thursday0 = no data stored
+- ctlv3 Z3Timer_Thursday1 = no data stored
+- ctlv3 Z3Timer_Thursday2 = no data stored
+- ctlv3 Z3Timer_Thursday = no data stored
+- ctlv3 Z3Timer_Timeframes = no data stored
+- ctlv3 Z3Timer_Tuesday0 = no data stored
+- ctlv3 Z3Timer_Tuesday1 = no data stored
+- ctlv3 Z3Timer_Tuesday2 = no data stored
+- ctlv3 Z3Timer_Tuesday = no data stored
+- ctlv3 Z3Timer_Wednesday0 = no data stored
+- ctlv3 Z3Timer_Wednesday1 = no data stored
+- ctlv3 Z3Timer_Wednesday2 = no data stored
+- ctlv3 Z3Timer_Wednesday = no data stored
+- ctlv3 Z3ValveStatus = no data stored
+- ctlv3 Z3ValveStatus = no data stored
+- General Valuerange = no data stored
+- hmu CoolElecConsDay = 0.0
+- hmu CoolElecConsTotal = 32200
+- hmu CoolEnvYieldDay = 0.0
+- hmu CoolEnvYieldMonth = 0.0
+- hmu CoolEnvYieldTotal = 0.0
+- hmu HcElecConsDay = 198.049
+- hmu HcElecConsTotal = 10835
+- hmu HwcElecConsDay = 0.0
+- hmu HwcElecConsTotal = 0.0
+- 'hmu SourceTempInput =  (ERR: invalid position for 3108b51a0405ff3222 / 02ff01)'
+- Memory Eeprom = no data stored
+- Memory Eeprom = no data stored
+- Memory Ram = no data stored
+- Memory Ram = no data stored
+- Scan Id = no data stored
+- scan.04  = Vaillant;NETX3;0129;0404
+- scan.08  = Vaillant;HMUX0;0406;0504
+- scan.15  = Vaillant;CTLV3;0808;8004
+- Scan.15 Id = 21;25;45;0020260913;0953;026479;N3
+- scan.76  = Vaillant;VWZIO;0406;0504
+- Scan.76 Id = 21;26;03;8000035574;0001;005739;N8
+- scan.f6  = Vaillant;NETX3;0129;0404
+- Scan.f6 Id = 21;26;10;0020292012;0933;049007;N4
+- vwzio EnableTestHwcTemp = no data stored
+- vwzio EnableTestOutdoorTemp = no data stored
+- vwzio EnableTestThreeWayValve = no data stored
+- vwzio TestHwcTemp = no data stored
+- vwzio TestOutdoorTemp = no data stored
+- vwzio TestThreeWayValve = no data stored
+- ''

--- a/tests/fixtures/community/arotherm_pro7_quiet_off_idle_discovery.yaml
+++ b/tests/fixtures/community/arotherm_pro7_quiet_off_idle_discovery.yaml
@@ -1,0 +1,15378 @@
+# Discovery dump for vaillant_ebus
+# Review this file for sensitive information before sharing
+metadata:
+  timestamp: '2026-09-08T20:14:17.179554'
+  ebusd_version: ebusd 26.1.26.1
+  register_count: 762
+  grab_duration: 10
+  dump_version: 3
+raw_find_lines:
+- bai SetModeOverride = 0;0.0;-;-;-;1;1;1;0;0;0;0
+- Broadcast Datetime = no data stored
+- Broadcast Error = no data stored
+- Broadcast HwcStatus = no data stored
+- Broadcast Id = no data stored
+- Broadcast IdAnswer = no data stored
+- Broadcast IdQuery = no data stored
+- Broadcast Load = no data stored
+- Broadcast Outsidetemp = 15.957
+- Broadcast Queryexistence =  (empty for 31fe07fe00 / )
+- Broadcast Signoflife = no data stored
+- Broadcast Vdatetime = 20:13:01;08.09.2026
+- Broadcast Vdatetime = no data stored
+- 'ctlv2 Hc1DewPointTemp =  (ERR: invalid position for 3115b52406020002002300 / 00)'
+- 'ctlv2 Hc1FlowTempCalc =  (ERR: invalid position for 3115b52406020002002000 / 050102200001)'
+- 'ctlv2 Hc1Humidity =  (ERR: invalid position for 3115b52406020002002200 / 00)'
+- 'ctlv2 Hc1MixerPosition =  (ERR: invalid position for 3115b52406020002002100 / 00)'
+- 'ctlv2 Hc1PumpHours =  (ERR: invalid position for 3115b52406020002002400 / 00)'
+- 'ctlv2 Hc1PumpStarts =  (ERR: invalid position for 3115b52406020002002500 / 00)'
+- 'ctlv2 Hc2DewPointTemp =  (ERR: invalid position for 3115b52406020002012300 / 00)'
+- 'ctlv2 Hc2FlowTempCalc =  (ERR: invalid position for 3115b52406020002012000 / 050002200000)'
+- 'ctlv2 Hc2Humidity =  (ERR: invalid position for 3115b52406020002012200 / 00)'
+- 'ctlv2 Hc2MixerPosition =  (ERR: invalid position for 3115b52406020002012100 / 00)'
+- 'ctlv2 Hc2PumpHours =  (ERR: invalid position for 3115b52406020002012400 / 00)'
+- 'ctlv2 Hc2PumpStarts =  (ERR: invalid position for 3115b52406020002012500 / 00)'
+- ctlv2 ManualCoolingEndDate = 01.01.2015
+- ctlv2 ManualCoolingEndDate = no data stored
+- ctlv2 ManualCoolingStartDate = 01.01.2019
+- ctlv2 ManualCoolingStartDate = no data stored
+- ctlv2 z1RoomHumidity = 67
+- ctlv3 AdaptHeatCurve = yes
+- ctlv3 AdaptHeatCurve = no data stored
+- ctlv3 CcTimer_Config = 03 01 01 00 00 00 ff ff 00
+- ctlv3 CcTimer_Friday0 = no data stored
+- ctlv3 CcTimer_Friday1 = no data stored
+- ctlv3 CcTimer_Friday2 = no data stored
+- ctlv3 CcTimer_Friday = no data stored
+- ctlv3 CcTimer_Monday0 = no data stored
+- ctlv3 CcTimer_Monday1 = no data stored
+- ctlv3 CcTimer_Monday2 = no data stored
+- ctlv3 CcTimer_Monday = no data stored
+- ctlv3 CcTimer_Saturday0 = no data stored
+- ctlv3 CcTimer_Saturday1 = no data stored
+- ctlv3 CcTimer_Saturday2 = no data stored
+- ctlv3 CcTimer_Saturday = no data stored
+- ctlv3 CcTimer_Sunday0 = no data stored
+- ctlv3 CcTimer_Sunday1 = no data stored
+- ctlv3 CcTimer_Sunday2 = no data stored
+- ctlv3 CcTimer_Sunday = no data stored
+- ctlv3 CcTimer_Thursday0 = no data stored
+- ctlv3 CcTimer_Thursday1 = no data stored
+- ctlv3 CcTimer_Thursday2 = no data stored
+- ctlv3 CcTimer_Thursday = no data stored
+- ctlv3 CcTimer_Timeframes = 0;0;0;0;0;0;0
+- ctlv3 CcTimer_Tuesday0 = no data stored
+- ctlv3 CcTimer_Tuesday1 = no data stored
+- ctlv3 CcTimer_Tuesday2 = no data stored
+- ctlv3 CcTimer_Tuesday = no data stored
+- ctlv3 CcTimer_Wednesday0 = no data stored
+- ctlv3 CcTimer_Wednesday1 = no data stored
+- ctlv3 CcTimer_Wednesday2 = no data stored
+- ctlv3 CcTimer_Wednesday = no data stored
+- ctlv3 Clearerrorhistory = no data stored
+- ctlv3 ContinuousHeating = -26
+- ctlv3 ContinuousHeating = no data stored
+- ctlv3 Currenterror = -;-;-;-;-
+- ctlv3 CylinderChargeHyst = 7
+- ctlv3 CylinderChargeHyst = no data stored
+- ctlv3 CylinderChargeOffset = 10
+- ctlv3 CylinderChargeOffset = no data stored
+- ctlv3 Date = 08.09.2026
+- ctlv3 Date = no data stored
+- ctlv3 DisplayedOutsideTemp = 16.0078
+- ctlv3 Errorhistory = no data stored
+- ctlv3 FrostOverRideTime = 4
+- ctlv3 FrostOverRideTime = no data stored
+- ctlv3 Hc1ActualFlowTempDesired = 0.0
+- ctlv3 Hc1AutoOffMode = eco
+- ctlv3 Hc1AutoOffMode = no data stored
+- ctlv3 Hc1CircuitType = mixer
+- ctlv3 Hc1ExcessTemp = 0.0
+- ctlv3 Hc1ExcessTemp = no data stored
+- ctlv3 Hc1FlowTemp = 17.5
+- ctlv3 Hc1HeatCurve = 0.8
+- ctlv3 Hc1HeatCurve = no data stored
+- ctlv3 Hc1HeatCurveAdaption = 0.0
+- ctlv3 Hc1MaxFlowTempDesired = 40
+- ctlv3 Hc1MaxFlowTempDesired = no data stored
+- ctlv3 Hc1MinCoolingTempDesired = 19
+- ctlv3 Hc1MinCoolingTempDesired = no data stored
+- ctlv3 Hc1MinFlowTempDesired = 19
+- ctlv3 Hc1MinFlowTempDesired = no data stored
+- ctlv3 Hc1MixerMovement = 0.0
+- ctlv3 Hc1PumpStatus = 0
+- ctlv3 Hc1PumpStatus = no data stored
+- ctlv3 Hc1RoomTempSwitchOn = thermostat
+- ctlv3 Hc1RoomTempSwitchOn = no data stored
+- ctlv3 Hc1Status = 0
+- ctlv3 Hc1Status = no data stored
+- ctlv3 Hc1SummerTempLimit = 18
+- ctlv3 Hc1SummerTempLimit = no data stored
+- ctlv3 Hc2ActualFlowTempDesired = 0.0
+- ctlv3 Hc2AutoOffMode = eco
+- ctlv3 Hc2AutoOffMode = no data stored
+- ctlv3 Hc2CircuitType = inactive
+- ctlv3 Hc2ExcessTemp = 0.0
+- ctlv3 Hc2ExcessTemp = no data stored
+- ctlv3 Hc2FlowTemp =  (empty for 3115b52406020002010800 / 0800020800ffffff7f)
+- ctlv3 Hc2HeatCurve = 0.6
+- ctlv3 Hc2HeatCurve = no data stored
+- ctlv3 Hc2HeatCurveAdaption = 0.0
+- ctlv3 Hc2MaxFlowTempDesired = 55
+- ctlv3 Hc2MaxFlowTempDesired = no data stored
+- ctlv3 Hc2MinCoolingTempDesired = 20
+- ctlv3 Hc2MinCoolingTempDesired = no data stored
+- ctlv3 Hc2MinFlowTempDesired = 15
+- ctlv3 Hc2MinFlowTempDesired = no data stored
+- ctlv3 Hc2MixerMovement = 0.0
+- ctlv3 Hc2PumpStatus = 0
+- ctlv3 Hc2PumpStatus = no data stored
+- ctlv3 Hc2RoomTempSwitchOn = off
+- ctlv3 Hc2RoomTempSwitchOn = no data stored
+- ctlv3 Hc2Status = 0
+- ctlv3 Hc2Status = no data stored
+- ctlv3 Hc2SummerTempLimit = 16
+- ctlv3 Hc2SummerTempLimit = no data stored
+- ctlv3 Hc3ActualFlowTempDesired = 0.0
+- ctlv3 Hc3AutoOffMode = eco
+- ctlv3 Hc3AutoOffMode = no data stored
+- ctlv3 Hc3CircuitType = inactive
+- ctlv3 Hc3ExcessTemp = 0.0
+- ctlv3 Hc3ExcessTemp = no data stored
+- ctlv3 Hc3FlowTemp =  (empty for 3115b52406020002020800 / 0800020800ffffff7f)
+- ctlv3 Hc3HeatCurve = 1.35
+- ctlv3 Hc3HeatCurve = no data stored
+- ctlv3 Hc3HeatCurveAdaption = 0.0
+- ctlv3 Hc3MaxFlowTempDesired = 55
+- ctlv3 Hc3MaxFlowTempDesired = no data stored
+- ctlv3 Hc3MinCoolingTempDesired = 20
+- ctlv3 Hc3MinCoolingTempDesired = no data stored
+- ctlv3 Hc3MinFlowTempDesired = 15
+- ctlv3 Hc3MinFlowTempDesired = no data stored
+- ctlv3 Hc3MixerMovement = 0.0
+- ctlv3 Hc3PumpStatus = 0
+- ctlv3 Hc3PumpStatus = no data stored
+- ctlv3 Hc3RoomTempSwitchOn = off
+- ctlv3 Hc3RoomTempSwitchOn = no data stored
+- ctlv3 Hc3Status = 0
+- ctlv3 Hc3Status = no data stored
+- ctlv3 Hc3SummerTempLimit = 16
+- ctlv3 Hc3SummerTempLimit = no data stored
+- ctlv3 HcStorageTempBottom =  (empty for f115b5240602000000a000 / 080000a000ffffff7f)
+- ctlv3 HcStorageTempTop =  (empty for f115b52406020000009f00 / 0800009f00ffffff7f)
+- ctlv3 HwcBankHolidayEndPeriod = no data stored
+- ctlv3 HwcBankHolidayEndPeriod = no data stored
+- ctlv3 HwcBankHolidayStartPeriod = no data stored
+- ctlv3 HwcBankHolidayStartPeriod = no data stored
+- ctlv3 HwcFlowTemp = 0.0
+- ctlv3 HwcHolidayEndPeriod = 01.01.2019
+- ctlv3 HwcHolidayEndPeriod = no data stored
+- ctlv3 HwcHolidayStartPeriod = 01.01.2019
+- ctlv3 HwcHolidayStartPeriod = no data stored
+- ctlv3 HwcLockTime = 60
+- ctlv3 HwcLockTime = no data stored
+- ctlv3 HwcMaxFlowTempDesired = 80
+- ctlv3 HwcMaxFlowTempDesired = no data stored
+- ctlv3 HwcOpMode = auto
+- ctlv3 HwcOpMode = no data stored
+- ctlv3 HwcParallelLoading = off
+- ctlv3 HwcParallelLoading = no data stored
+- ctlv3 HwcSFMode = auto
+- ctlv3 HwcSFMode = no data stored
+- ctlv3 HwcStorageTemp =  (empty for 3115b52406020001000500 / 0800010500ffffff7f)
+- ctlv3 HwcStorageTempBottom =  (empty for f115b52406020000009e00 / 0800009e00ffffff7f)
+- ctlv3 HwcStorageTempTop =  (empty for f115b52406020000009d00 / 0800009d00ffffff7f)
+- ctlv3 HwcTempDesired = 55
+- ctlv3 HwcTempDesired = no data stored
+- ctlv3 HwcTimer_Config = no data stored
+- ctlv3 HwcTimer_Friday0 = no data stored
+- ctlv3 HwcTimer_Friday1 = no data stored
+- ctlv3 HwcTimer_Friday2 = no data stored
+- ctlv3 HwcTimer_Friday = no data stored
+- ctlv3 HwcTimer_Monday0 = no data stored
+- ctlv3 HwcTimer_Monday1 = no data stored
+- ctlv3 HwcTimer_Monday2 = no data stored
+- ctlv3 HwcTimer_Monday = no data stored
+- ctlv3 HwcTimer_Saturday0 = no data stored
+- ctlv3 HwcTimer_Saturday1 = no data stored
+- ctlv3 HwcTimer_Saturday2 = no data stored
+- ctlv3 HwcTimer_Saturday = no data stored
+- ctlv3 HwcTimer_Sunday0 = no data stored
+- ctlv3 HwcTimer_Sunday1 = no data stored
+- ctlv3 HwcTimer_Sunday2 = no data stored
+- ctlv3 HwcTimer_Sunday = no data stored
+- ctlv3 HwcTimer_Thursday0 = no data stored
+- ctlv3 HwcTimer_Thursday1 = no data stored
+- ctlv3 HwcTimer_Thursday2 = no data stored
+- ctlv3 HwcTimer_Thursday = no data stored
+- ctlv3 HwcTimer_Timeframes = no data stored
+- ctlv3 HwcTimer_Tuesday0 = no data stored
+- ctlv3 HwcTimer_Tuesday1 = no data stored
+- ctlv3 HwcTimer_Tuesday2 = no data stored
+- ctlv3 HwcTimer_Tuesday = no data stored
+- ctlv3 HwcTimer_Wednesday0 = no data stored
+- ctlv3 HwcTimer_Wednesday1 = no data stored
+- ctlv3 HwcTimer_Wednesday2 = no data stored
+- ctlv3 HwcTimer_Wednesday = no data stored
+- ctlv3 HydraulicScheme = 8
+- ctlv3 HydraulicScheme = no data stored
+- ctlv3 Installer1 = no data stored
+- ctlv3 Installer1 = no data stored
+- ctlv3 Installer2 = no data stored
+- ctlv3 Installer2 = no data stored
+- ctlv3 KeyCodeforConfigMenu = no data stored
+- ctlv3 KeyCodeforConfigMenu = no data stored
+- ctlv3 MaintenanceDate = no data stored
+- ctlv3 MaintenanceDate = no data stored
+- ctlv3 MaintenanceDue = no data stored
+- ctlv3 MaxCylinderChargeTime = 90
+- ctlv3 MaxCylinderChargeTime = no data stored
+- ctlv3 MaxRoomHumidity = 50
+- ctlv3 MaxRoomHumidity = no data stored
+- ctlv3 MultiRelaySetting = 4
+- ctlv3 MultiRelaySetting = no data stored
+- ctlv3 OutsideTempAvg = 18.3398
+- ctlv3 OutsideTempAvg = no data stored
+- ctlv3 PhoneNumber1 = no data stored
+- ctlv3 PhoneNumber1 = no data stored
+- ctlv3 PhoneNumber2 = no data stored
+- ctlv3 PhoneNumber2 = no data stored
+- 'ctlv3 PrEnergySum =  (ERR: invalid position for 3115b52406020000005c00 / 00)'
+- ctlv3 PrEnergySum = no data stored
+- ctlv3 PrEnergySumHc = 17
+- ctlv3 PrEnergySumHc = no data stored
+- ctlv3 PrEnergySumHcLastMonth = 11
+- ctlv3 PrEnergySumHcLastMonth = no data stored
+- ctlv3 PrEnergySumHcThisMonth = 2
+- ctlv3 PrEnergySumHcThisMonth = no data stored
+- ctlv3 PrEnergySumHwc = 0
+- ctlv3 PrEnergySumHwc = no data stored
+- ctlv3 PrEnergySumHwcLastMonth = 0
+- ctlv3 PrEnergySumHwcLastMonth = no data stored
+- ctlv3 PrEnergySumHwcThisMonth = 0
+- ctlv3 PrEnergySumHwcThisMonth = no data stored
+- ctlv3 PrFuelSum = no data stored
+- ctlv3 PrFuelSum = no data stored
+- ctlv3 PrFuelSumHc = no data stored
+- ctlv3 PrFuelSumHc = no data stored
+- ctlv3 PrFuelSumHcLastMonth = no data stored
+- ctlv3 PrFuelSumHcLastMonth = no data stored
+- ctlv3 PrFuelSumHcThisMonth = no data stored
+- ctlv3 PrFuelSumHcThisMonth = no data stored
+- ctlv3 PrFuelSumHwc = no data stored
+- ctlv3 PrFuelSumHwc = no data stored
+- ctlv3 PrFuelSumHwcLastMonth = no data stored
+- ctlv3 PrFuelSumHwcLastMonth = no data stored
+- ctlv3 PrFuelSumHwcThisMonth = no data stored
+- ctlv3 PrFuelSumHwcThisMonth = no data stored
+- ctlv3 PumpAdditionalTime = no data stored
+- ctlv3 PumpAdditionalTime = no data stored
+- ctlv3 SolarYieldTotal = no data stored
+- ctlv3 SolarYieldTotal = no data stored
+- ctlv3 SystemFlowTemp =  (empty for f115b52406020000004b00 / 0800004b00ffffff7f)
+- ctlv3 Time = 19:41:52
+- ctlv3 Time = no data stored
+- ctlv3 WaterPressure = 1.8
+- ctlv3 YieldTotal = 6
+- ctlv3 YieldTotal = no data stored
+- ctlv3 Z1ActualRoomTempDesired = 16
+- ctlv3 Z1ActualRoomTempDesired = no data stored
+- ctlv3 Z1BankHolidayEndPeriod = no data stored
+- ctlv3 Z1BankHolidayEndPeriod = no data stored
+- ctlv3 Z1BankHolidayStartPeriod = no data stored
+- ctlv3 Z1BankHolidayStartPeriod = no data stored
+- ctlv3 Z1CoolingTemp = 23
+- ctlv3 Z1CoolingTemp = no data stored
+- ctlv3 Z1DayTemp = 16
+- ctlv3 Z1DayTemp = no data stored
+- ctlv3 Z1HolidayEndPeriod = 01.01.2019
+- ctlv3 Z1HolidayEndPeriod = no data stored
+- ctlv3 Z1HolidayStartPeriod = 01.01.2019
+- ctlv3 Z1HolidayStartPeriod = no data stored
+- ctlv3 Z1HolidayTemp = 15
+- ctlv3 Z1HolidayTemp = no data stored
+- 'ctlv3 Z1Name1 = Zone '
+- ctlv3 Z1Name1 = no data stored
+- 'ctlv3 Z1Name2 =  (ERR: invalid position for f115b52406020003001800 / 06030318003100)'
+- ctlv3 Z1Name2 = no data stored
+- ctlv3 Z1NightTemp = 15
+- ctlv3 Z1NightTemp = no data stored
+- ctlv3 Z1OpMode = day
+- ctlv3 Z1OpMode = no data stored
+- ctlv3 Z1QuickVetoDuration = 3
+- ctlv3 Z1QuickVetoDuration = no data stored
+- ctlv3 Z1QuickVetoEndDate = 01.01.2019
+- ctlv3 Z1QuickVetoEndTime = 00:00:00
+- ctlv3 Z1QuickVetoTemp = 21
+- ctlv3 Z1QuickVetoTemp = no data stored
+- ctlv3 Z1RoomTemp = 22.475
+- ctlv3 Z1RoomZoneMapping = VRC700
+- ctlv3 Z1RoomZoneMapping = no data stored
+- ctlv3 Z1SFMode = auto
+- ctlv3 Z1SFMode = no data stored
+- ctlv3 Z1Shortname = no data stored
+- ctlv3 Z1Shortname = no data stored
+- ctlv3 Z1Timer_Config = no data stored
+- ctlv3 Z1Timer_Friday0 = 06:00;22:00;20.0
+- ctlv3 Z1Timer_Friday1 = no data stored
+- ctlv3 Z1Timer_Friday2 = no data stored
+- ctlv3 Z1Timer_Friday = no data stored
+- ctlv3 Z1Timer_Monday0 = 06:00;22:00;20.0
+- ctlv3 Z1Timer_Monday1 = no data stored
+- ctlv3 Z1Timer_Monday2 = no data stored
+- ctlv3 Z1Timer_Monday = no data stored
+- ctlv3 Z1Timer_Saturday0 = 07:30;23:30;20.0
+- ctlv3 Z1Timer_Saturday1 = no data stored
+- ctlv3 Z1Timer_Saturday2 = no data stored
+- ctlv3 Z1Timer_Saturday = no data stored
+- ctlv3 Z1Timer_Sunday0 = 07:30;22:00;20.0
+- ctlv3 Z1Timer_Sunday1 = no data stored
+- ctlv3 Z1Timer_Sunday2 = no data stored
+- ctlv3 Z1Timer_Sunday = no data stored
+- ctlv3 Z1Timer_Thursday0 = 06:00;22:00;20.0
+- ctlv3 Z1Timer_Thursday1 = no data stored
+- ctlv3 Z1Timer_Thursday2 = no data stored
+- ctlv3 Z1Timer_Thursday = no data stored
+- ctlv3 Z1Timer_Timeframes = 1;1;1;1;1;1;1
+- ctlv3 Z1Timer_Tuesday0 = 06:00;22:00;20.0
+- ctlv3 Z1Timer_Tuesday1 = no data stored
+- ctlv3 Z1Timer_Tuesday2 = no data stored
+- ctlv3 Z1Timer_Tuesday = no data stored
+- ctlv3 Z1Timer_Wednesday0 = 06:00;22:00;20.0
+- ctlv3 Z1Timer_Wednesday1 = no data stored
+- ctlv3 Z1Timer_Wednesday2 = no data stored
+- ctlv3 Z1Timer_Wednesday = no data stored
+- ctlv3 Z1ValveStatus = no data stored
+- ctlv3 Z1ValveStatus = no data stored
+- ctlv3 Z2ActualRoomTempDesired = no data stored
+- ctlv3 Z2ActualRoomTempDesired = no data stored
+- ctlv3 Z2BankHolidayEndPeriod = no data stored
+- ctlv3 Z2BankHolidayEndPeriod = no data stored
+- ctlv3 Z2BankHolidayStartPeriod = no data stored
+- ctlv3 Z2BankHolidayStartPeriod = no data stored
+- ctlv3 Z2CoolingTemp = no data stored
+- ctlv3 Z2CoolingTemp = no data stored
+- ctlv3 Z2DayTemp = no data stored
+- ctlv3 Z2DayTemp = no data stored
+- ctlv3 Z2HolidayEndPeriod = no data stored
+- ctlv3 Z2HolidayEndPeriod = no data stored
+- ctlv3 Z2HolidayStartPeriod = no data stored
+- ctlv3 Z2HolidayStartPeriod = no data stored
+- ctlv3 Z2HolidayTemp = no data stored
+- ctlv3 Z2HolidayTemp = no data stored
+- ctlv3 Z2Name1 = no data stored
+- ctlv3 Z2Name1 = no data stored
+- ctlv3 Z2Name2 = no data stored
+- ctlv3 Z2Name2 = no data stored
+- ctlv3 Z2NightTemp = no data stored
+- ctlv3 Z2NightTemp = no data stored
+- ctlv3 Z2OpMode = no data stored
+- ctlv3 Z2OpMode = no data stored
+- ctlv3 Z2QuickVetoDuration = no data stored
+- ctlv3 Z2QuickVetoDuration = no data stored
+- ctlv3 Z2QuickVetoEndDate = no data stored
+- ctlv3 Z2QuickVetoEndTime = no data stored
+- ctlv3 Z2QuickVetoTemp = no data stored
+- ctlv3 Z2QuickVetoTemp = no data stored
+- ctlv3 Z2RoomTemp =  (empty for 3115b52406020003010f00 / 0802030f00ffffff7f)
+- ctlv3 Z2RoomZoneMapping = none
+- ctlv3 Z2RoomZoneMapping = no data stored
+- ctlv3 Z2SFMode = no data stored
+- ctlv3 Z2SFMode = no data stored
+- ctlv3 Z2Shortname = no data stored
+- ctlv3 Z2Shortname = no data stored
+- ctlv3 Z2Timer_Config = no data stored
+- ctlv3 Z2Timer_Friday0 = no data stored
+- ctlv3 Z2Timer_Friday1 = no data stored
+- ctlv3 Z2Timer_Friday2 = no data stored
+- ctlv3 Z2Timer_Friday = no data stored
+- ctlv3 Z2Timer_Monday0 = no data stored
+- ctlv3 Z2Timer_Monday1 = no data stored
+- ctlv3 Z2Timer_Monday2 = no data stored
+- ctlv3 Z2Timer_Monday = no data stored
+- ctlv3 Z2Timer_Saturday0 = no data stored
+- ctlv3 Z2Timer_Saturday1 = no data stored
+- ctlv3 Z2Timer_Saturday2 = no data stored
+- ctlv3 Z2Timer_Saturday = no data stored
+- ctlv3 Z2Timer_Sunday0 = no data stored
+- ctlv3 Z2Timer_Sunday1 = no data stored
+- ctlv3 Z2Timer_Sunday2 = no data stored
+- ctlv3 Z2Timer_Sunday = no data stored
+- ctlv3 Z2Timer_Thursday0 = no data stored
+- ctlv3 Z2Timer_Thursday1 = no data stored
+- ctlv3 Z2Timer_Thursday2 = no data stored
+- ctlv3 Z2Timer_Thursday = no data stored
+- ctlv3 Z2Timer_Timeframes = no data stored
+- ctlv3 Z2Timer_Tuesday0 = no data stored
+- ctlv3 Z2Timer_Tuesday1 = no data stored
+- ctlv3 Z2Timer_Tuesday2 = no data stored
+- ctlv3 Z2Timer_Tuesday = no data stored
+- ctlv3 Z2Timer_Wednesday0 = no data stored
+- ctlv3 Z2Timer_Wednesday1 = no data stored
+- ctlv3 Z2Timer_Wednesday2 = no data stored
+- ctlv3 Z2Timer_Wednesday = no data stored
+- ctlv3 Z2ValveStatus = no data stored
+- ctlv3 Z2ValveStatus = no data stored
+- ctlv3 Z3ActualRoomTempDesired = no data stored
+- ctlv3 Z3ActualRoomTempDesired = no data stored
+- ctlv3 Z3BankHolidayEndPeriod = no data stored
+- ctlv3 Z3BankHolidayEndPeriod = no data stored
+- ctlv3 Z3BankHolidayStartPeriod = no data stored
+- ctlv3 Z3BankHolidayStartPeriod = no data stored
+- ctlv3 Z3DayTemp = no data stored
+- ctlv3 Z3DayTemp = no data stored
+- ctlv3 Z3HolidayEndPeriod = no data stored
+- ctlv3 Z3HolidayEndPeriod = no data stored
+- ctlv3 Z3HolidayStartPeriod = no data stored
+- ctlv3 Z3HolidayStartPeriod = no data stored
+- ctlv3 Z3HolidayTemp = no data stored
+- ctlv3 Z3HolidayTemp = no data stored
+- ctlv3 Z3Name1 = no data stored
+- ctlv3 Z3Name1 = no data stored
+- ctlv3 Z3Name2 = no data stored
+- ctlv3 Z3Name2 = no data stored
+- ctlv3 Z3NightTemp = no data stored
+- ctlv3 Z3NightTemp = no data stored
+- ctlv3 Z3OpMode = no data stored
+- ctlv3 Z3OpMode = no data stored
+- ctlv3 Z3QuickVetoDuration = no data stored
+- ctlv3 Z3QuickVetoDuration = no data stored
+- ctlv3 Z3QuickVetoEndDate = no data stored
+- ctlv3 Z3QuickVetoEndTime = no data stored
+- ctlv3 Z3QuickVetoTemp = no data stored
+- ctlv3 Z3QuickVetoTemp = no data stored
+- ctlv3 Z3RoomTemp = no data stored
+- ctlv3 Z3RoomZoneMapping = none
+- ctlv3 Z3RoomZoneMapping = no data stored
+- ctlv3 Z3SFMode = no data stored
+- ctlv3 Z3SFMode = no data stored
+- ctlv3 Z3Shortname = no data stored
+- ctlv3 Z3Shortname = no data stored
+- ctlv3 Z3Timer_Config = no data stored
+- ctlv3 Z3Timer_Friday0 = no data stored
+- ctlv3 Z3Timer_Friday1 = no data stored
+- ctlv3 Z3Timer_Friday2 = no data stored
+- ctlv3 Z3Timer_Friday = no data stored
+- ctlv3 Z3Timer_Monday0 = no data stored
+- ctlv3 Z3Timer_Monday1 = no data stored
+- ctlv3 Z3Timer_Monday2 = no data stored
+- ctlv3 Z3Timer_Monday = no data stored
+- ctlv3 Z3Timer_Saturday0 = no data stored
+- ctlv3 Z3Timer_Saturday1 = no data stored
+- ctlv3 Z3Timer_Saturday2 = no data stored
+- ctlv3 Z3Timer_Saturday = no data stored
+- ctlv3 Z3Timer_Sunday0 = no data stored
+- ctlv3 Z3Timer_Sunday1 = no data stored
+- ctlv3 Z3Timer_Sunday2 = no data stored
+- ctlv3 Z3Timer_Sunday = no data stored
+- ctlv3 Z3Timer_Thursday0 = no data stored
+- ctlv3 Z3Timer_Thursday1 = no data stored
+- ctlv3 Z3Timer_Thursday2 = no data stored
+- ctlv3 Z3Timer_Thursday = no data stored
+- ctlv3 Z3Timer_Timeframes = no data stored
+- ctlv3 Z3Timer_Tuesday0 = no data stored
+- ctlv3 Z3Timer_Tuesday1 = no data stored
+- ctlv3 Z3Timer_Tuesday2 = no data stored
+- ctlv3 Z3Timer_Tuesday = no data stored
+- ctlv3 Z3Timer_Wednesday0 = no data stored
+- ctlv3 Z3Timer_Wednesday1 = no data stored
+- ctlv3 Z3Timer_Wednesday2 = no data stored
+- ctlv3 Z3Timer_Wednesday = no data stored
+- ctlv3 Z3ValveStatus = no data stored
+- ctlv3 Z3ValveStatus = no data stored
+- General Valuerange = no data stored
+- hmu CoolElecConsDay = 0.0
+- hmu CoolElecConsTotal = 32200
+- hmu CoolEnvYieldDay = 0.0
+- hmu CoolEnvYieldMonth = 0.0
+- hmu CoolEnvYieldTotal = 0.0
+- hmu HcElecConsDay = 122.036
+- hmu HcElecConsTotal = 10759
+- hmu HwcElecConsDay = 0.0
+- hmu HwcElecConsTotal = 0.0
+- 'hmu SourceTempInput =  (ERR: invalid position for 3108b51a0405ff3222 / 02ff01)'
+- Memory Eeprom = no data stored
+- Memory Eeprom = no data stored
+- Memory Ram = no data stored
+- Memory Ram = no data stored
+- Scan Id = no data stored
+- scan.04  = Vaillant;NETX3;0129;0404
+- scan.08  = Vaillant;HMUX0;0406;0504
+- scan.15  = Vaillant;CTLV3;0808;8004
+- Scan.15 Id = 21;25;45;0020260913;0953;026479;N3
+- scan.76  = Vaillant;VWZIO;0406;0504
+- Scan.76 Id = 21;26;03;8000035574;0001;005739;N8
+- scan.f6  = Vaillant;NETX3;0129;0404
+- Scan.f6 Id = 21;26;10;0020292012;0933;049007;N4
+- vwzio EnableTestHwcTemp = no data stored
+- vwzio EnableTestOutdoorTemp = no data stored
+- vwzio EnableTestThreeWayValve = no data stored
+- vwzio TestHwcTemp = no data stored
+- vwzio TestOutdoorTemp = no data stored
+- vwzio TestThreeWayValve = no data stored
+- ''
+before_registers:
+- circuit: Broadcast
+  name: Datetime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Error
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: Broadcast
+  name: HwcStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Id
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: IdAnswer
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: IdQuery
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Load
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Outsidetemp
+  fields:
+  - value
+  values:
+  - '15.957'
+  writable: false
+  has_data: true
+- circuit: Broadcast
+  name: Queryexistence
+  fields:
+  - value
+  values:
+  - (empty for 31fe07fe00 / )
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Signoflife
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Vdatetime
+  fields:
+  - value
+  values:
+  - 20:13:01;08.09.2026
+  writable: false
+  has_data: true
+- circuit: Broadcast
+  name: Vdatetime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: WaterPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: General
+  name: Valuerange
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Eeprom
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Eeprom
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Ram
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Ram
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Scan
+  name: Id
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Scan.15
+  name: Id
+  fields:
+  - value
+  values:
+  - 21;25;45;0020260913;0953;026479;N3
+  writable: false
+  has_data: true
+- circuit: Scan.76
+  name: Id
+  fields:
+  - value
+  values:
+  - 21;26;03;8000035574;0001;005739;N8
+  writable: false
+  has_data: true
+- circuit: Scan.f6
+  name: Id
+  fields:
+  - value
+  values:
+  - 21;26;10;0020292012;0933;049007;N4
+  writable: false
+  has_data: true
+- circuit: bai
+  name: ActiveStages
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: bai
+  name: FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: bai
+  name: FlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: bai
+  name: HeatingStage1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: bai
+  name: HeatingStage3
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: bai
+  name: PrEnergySumHc1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: bai
+  name: PrEnergySumHwc1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: bai
+  name: SetModeOverride
+  fields:
+  - value
+  values:
+  - 0;0.0;-;-;-;1;1;1;0;0;0;0
+  writable: false
+  has_data: true
+- circuit: bai
+  name: StorageTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: bai
+  name: StorageTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: bai
+  name: WaterPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: AdaptHeatCurve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: CcTimer_Config
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: CcTimer_Timeframes
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: ContinuousHeating
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: CylinderChargeHyst
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: CylinderChargeOffset
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Date
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: DisplayedOutsideTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: FrostOverRideTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1AutoOffMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1CircuitType
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1CoolingEnabled
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1CoolingFlowTempMin
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1DewPointMonitoring
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1DewPointOffset
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1DewPointTemp
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002300 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1ExcessTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1FlowTempCalc
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002000 / 050102200001)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1HeatCurve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1Humidity
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002200 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MixerMovement
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MixerPosition
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002100 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1PumpHours
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002400 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1PumpStarts
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002500 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1PumpStatus
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1RoomTempModulation
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1Status
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1SummerTempLimit
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2AutoOffMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2CircuitType
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2DewPointTemp
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012300 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2ExcessTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2FlowTempCalc
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012000 / 050002200000)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2HeatCurve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2Humidity
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012200 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MixerMovement
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MixerPosition
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012100 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2PumpHours
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012400 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2PumpStarts
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012500 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2PumpStatus
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2Status
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2SummerTempLimit
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3AutoOffMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3CircuitType
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3ExcessTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3HeatCurve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MixerMovement
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3PumpStatus
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3Status
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3SummerTempLimit
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HcStorageTempBottom
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: ctlv2
+  name: HcStorageTempTop
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: ctlv2
+  name: HwcFlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcLockTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcMaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcOpMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcParallelLoading
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcSFMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcSfMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcStorageTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcStorageTempBottom
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcStorageTempTop
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HydraulicScheme
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: ManualCoolingEndDate
+  fields:
+  - value
+  values:
+  - 01.01.2015
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: ManualCoolingEndDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: ManualCoolingStartDate
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: ManualCoolingStartDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: MaxCylinderChargeTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: MaxRoomHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: MultiRelaySetting
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: OutsideTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: OutsideTempAvg
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySum
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHcLastMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHcThisMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHwcLastMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHwcThisMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: SystemFlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: WaterPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingManualTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingOpMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingSetbackTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1DayTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1HolidayTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1NightTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1OpMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoDuration
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoEndDate
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoEndTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1RoomTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1SFMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z2RoomTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: z1RoomHumidity
+  fields:
+  - value
+  values:
+  - '67'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: AdaptHeatCurve
+  fields:
+  - value
+  values:
+  - 'yes'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: AdaptHeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Config
+  fields:
+  - value
+  values:
+  - 03 01 01 00 00 00 ff ff 00
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CcTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Friday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Friday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Friday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Monday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Monday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Monday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Saturday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Saturday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Saturday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Sunday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Sunday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Sunday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Thursday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Timeframes
+  fields:
+  - value
+  values:
+  - 0;0;0;0;0;0;0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CcTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Tuesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Wednesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Clearerrorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: ContinuousHeating
+  fields:
+  - value
+  values:
+  - '-26'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: ContinuousHeating
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - -;-;-;-;-
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CylinderChargeHyst
+  fields:
+  - value
+  values:
+  - '7'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CylinderChargeHyst
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CylinderChargeOffset
+  fields:
+  - value
+  values:
+  - '10'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CylinderChargeOffset
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Date
+  fields:
+  - value
+  values:
+  - 08.09.2026
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Date
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: DisplayedOutsideTemp
+  fields:
+  - value
+  values:
+  - '16.0078'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: FrostOverRideTime
+  fields:
+  - value
+  values:
+  - '4'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: FrostOverRideTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1AutoOffMode
+  fields:
+  - value
+  values:
+  - eco
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1AutoOffMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1CircuitType
+  fields:
+  - value
+  values:
+  - mixer
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1ExcessTemp
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1ExcessTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1FlowTemp
+  fields:
+  - value
+  values:
+  - '17.5'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1HeatCurve
+  fields:
+  - value
+  values:
+  - '0.8'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1HeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '40'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - '19'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - '19'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1MixerMovement
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1PumpStatus
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1PumpStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - thermostat
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1Status
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1SummerTempLimit
+  fields:
+  - value
+  values:
+  - '18'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1SummerTempLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2AutoOffMode
+  fields:
+  - value
+  values:
+  - eco
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2AutoOffMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2CircuitType
+  fields:
+  - value
+  values:
+  - inactive
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2ExcessTemp
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2ExcessTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2FlowTemp
+  fields:
+  - value
+  values:
+  - (empty for 3115b52406020002010800 / 0800020800ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2HeatCurve
+  fields:
+  - value
+  values:
+  - '0.6'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2HeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '55'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - '20'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - '15'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2MixerMovement
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2PumpStatus
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2PumpStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'off'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2Status
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2SummerTempLimit
+  fields:
+  - value
+  values:
+  - '16'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2SummerTempLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3AutoOffMode
+  fields:
+  - value
+  values:
+  - eco
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3AutoOffMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3CircuitType
+  fields:
+  - value
+  values:
+  - inactive
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3ExcessTemp
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3ExcessTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3FlowTemp
+  fields:
+  - value
+  values:
+  - (empty for 3115b52406020002020800 / 0800020800ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3HeatCurve
+  fields:
+  - value
+  values:
+  - '1.35'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3HeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '55'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - '20'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - '15'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3MixerMovement
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3PumpStatus
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3PumpStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'off'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3Status
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3SummerTempLimit
+  fields:
+  - value
+  values:
+  - '16'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3SummerTempLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HcStorageTempBottom
+  fields:
+  - value
+  values:
+  - (empty for f115b5240602000000a000 / 080000a000ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HcStorageTempTop
+  fields:
+  - value
+  values:
+  - (empty for f115b52406020000009f00 / 0800009f00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcBankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcBankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcBankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcBankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcFlowTemp
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcLockTime
+  fields:
+  - value
+  values:
+  - '60'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcLockTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcMaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '80'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcMaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcOpMode
+  fields:
+  - value
+  values:
+  - auto
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcOpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcParallelLoading
+  fields:
+  - value
+  values:
+  - 'off'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcParallelLoading
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcSFMode
+  fields:
+  - value
+  values:
+  - auto
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcSFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcStorageTemp
+  fields:
+  - value
+  values:
+  - (empty for 3115b52406020001000500 / 0800010500ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcStorageTempBottom
+  fields:
+  - value
+  values:
+  - (empty for f115b52406020000009e00 / 0800009e00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcStorageTempTop
+  fields:
+  - value
+  values:
+  - (empty for f115b52406020000009d00 / 0800009d00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTempDesired
+  fields:
+  - value
+  values:
+  - '55'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Config
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Friday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Friday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Friday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Monday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Monday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Monday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Saturday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Saturday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Saturday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Sunday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Sunday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Sunday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Thursday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Timeframes
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Tuesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Wednesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HydraulicScheme
+  fields:
+  - value
+  values:
+  - '8'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HydraulicScheme
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Installer1
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Installer1
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Installer2
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Installer2
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: KeyCodeforConfigMenu
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: KeyCodeforConfigMenu
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: MaintenanceDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: MaintenanceDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: MaintenanceDue
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: MaxCylinderChargeTime
+  fields:
+  - value
+  values:
+  - '90'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: MaxCylinderChargeTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: MaxRoomHumidity
+  fields:
+  - value
+  values:
+  - '50'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: MaxRoomHumidity
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: MultiRelaySetting
+  fields:
+  - value
+  values:
+  - '4'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: MultiRelaySetting
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: OutsideTempAvg
+  fields:
+  - value
+  values:
+  - '18.3398'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: OutsideTempAvg
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PhoneNumber1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PhoneNumber1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PhoneNumber2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PhoneNumber2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySum
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020000005c00 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHc
+  fields:
+  - value
+  values:
+  - '17'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: PrEnergySumHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHcLastMonth
+  fields:
+  - value
+  values:
+  - '11'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: PrEnergySumHcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHcThisMonth
+  fields:
+  - value
+  values:
+  - '2'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: PrEnergySumHcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHwc
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: PrEnergySumHwc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHwcLastMonth
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: PrEnergySumHwcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHwcThisMonth
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: PrEnergySumHwcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHwc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHwc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHwcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHwcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHwcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHwcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PumpAdditionalTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PumpAdditionalTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: SolarYieldTotal
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: SolarYieldTotal
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: SystemFlowTemp
+  fields:
+  - value
+  values:
+  - (empty for f115b52406020000004b00 / 0800004b00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Time
+  fields:
+  - value
+  values:
+  - '19:41:52'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Time
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: WaterPressure
+  fields:
+  - value
+  values:
+  - '1.8'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: YieldTotal
+  fields:
+  - value
+  values:
+  - '6'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: YieldTotal
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - '16'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1CoolingTemp
+  fields:
+  - value
+  values:
+  - '23'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1CoolingTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1DayTemp
+  fields:
+  - value
+  values:
+  - '16'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1HolidayTemp
+  fields:
+  - value
+  values:
+  - '15'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Name1
+  fields:
+  - value
+  values:
+  - Zone
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Name2
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for f115b52406020003001800 / 06030318003100)'
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1NightTemp
+  fields:
+  - value
+  values:
+  - '15'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1OpMode
+  fields:
+  - value
+  values:
+  - day
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1QuickVetoDuration
+  fields:
+  - value
+  values:
+  - '3'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1QuickVetoEndDate
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1QuickVetoEndTime
+  fields:
+  - value
+  values:
+  - 00:00:00
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1QuickVetoTemp
+  fields:
+  - value
+  values:
+  - '21'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1RoomTemp
+  fields:
+  - value
+  values:
+  - '22.475'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1SFMode
+  fields:
+  - value
+  values:
+  - auto
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Config
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Friday0
+  fields:
+  - value
+  values:
+  - 06:00;22:00;20.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Friday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Friday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Monday0
+  fields:
+  - value
+  values:
+  - 06:00;22:00;20.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Monday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Monday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Saturday0
+  fields:
+  - value
+  values:
+  - 07:30;23:30;20.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Saturday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Saturday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Sunday0
+  fields:
+  - value
+  values:
+  - 07:30;22:00;20.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Sunday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Sunday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Thursday0
+  fields:
+  - value
+  values:
+  - 06:00;22:00;20.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Timeframes
+  fields:
+  - value
+  values:
+  - 1;1;1;1;1;1;1
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Tuesday0
+  fields:
+  - value
+  values:
+  - 06:00;22:00;20.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Wednesday0
+  fields:
+  - value
+  values:
+  - 06:00;22:00;20.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2CoolingTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2CoolingTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2QuickVetoEndDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2QuickVetoEndTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2RoomTemp
+  fields:
+  - value
+  values:
+  - (empty for 3115b52406020003010f00 / 0802030f00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z2RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Config
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Friday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Friday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Friday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Monday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Monday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Monday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Saturday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Saturday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Saturday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Sunday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Sunday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Sunday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Thursday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Timeframes
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Tuesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Wednesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3QuickVetoEndDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3QuickVetoEndTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3RoomTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z3RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Config
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Friday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Friday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Friday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Monday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Monday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Monday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Saturday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Saturday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Saturday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Sunday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Sunday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Sunday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Thursday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Timeframes
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Tuesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Wednesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: BuildingCircuitFlow
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: BuildingCircuitPumpSpeed
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: CompressorHc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: CompressorHwc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHwc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: ConsumptionTotal
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CoolElecConsDay
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CoolElecConsTotal
+  fields:
+  - value
+  values:
+  - '32200'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CoolEnvYieldDay
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CoolEnvYieldMonth
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CoolEnvYieldTotal
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CopCooling
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CopCoolingMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CopHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CopHcMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CopHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CopHwcMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CurrentCompressorUtil
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CurrentConsumedPower
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CurrentYieldPower
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: DateTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: FlowTemperature
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: HcElecConsDay
+  fields:
+  - value
+  values:
+  - '122.036'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: HcElecConsTotal
+  fields:
+  - value
+  values:
+  - '10759'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: HoursCool
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: HwcElecConsDay
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: HwcElecConsTotal
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: LiveMonitorCurrentConsumedPower
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: PowerConsumptionHmu
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunDataAirInletTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataBuildingCPumpPower
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataCompressorInletTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataCompressorOutletTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataCompressorSpeed
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataEEVOutletTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataEEVPositionAbs
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataElectricPowerConsumption
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataFan1Speed
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataFan2Speed
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataHighPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataLowPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunDataReturnTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataStatuscode
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStats4PortValveHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStats4PortValveSwitches
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsBuildingCPumpStarts
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsBuildingPumpHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunStatsCompressorHc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunStatsCompressorHwc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHwc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorStarts
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsFan1Hours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsFan1Starts
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsFan2Hours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsFan2Starts
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsHMUHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsHcHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsHwcHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: SourceTempInput
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: SourceTempOutput
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatElectricEnergySum
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatElectricEnergySumCool
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatElectricEnergySumHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatElectricEnergySumHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatEnvironmentEnergySum
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatEnvironmentEnergySumCool
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatEnvironmentEnergySumHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatEnvironmentEnergySumHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatSolarEnergySum
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatSolarEnergySumHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatSolarEnergySumHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.pumpstate
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.temp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.temp_1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.temp_2
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: Status01.temp_3
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: Status01.temp_4
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: StatusCirPump
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: SupplyTempWeighted
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: TotalEnergyUsage
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldCoolDay
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldCooling
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldCoolingMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldHcDay
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldHcMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldHwcDay
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldHwcMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmux0
+  name: Status01
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmux0
+  name: Status01.pumpstate
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmux0
+  name: Status01.temp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmux0
+  name: Status01.temp_1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmux0
+  name: Status01.temp_2
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmux0
+  name: Status01.temp_3
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmux0
+  name: Status01.temp_4
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: v32
+  name: BypassPosition
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: ExhaustAirHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: ExhaustAirTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: FanHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: FlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: FlowTempMax
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: HcHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: HoursTillService
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: HwcHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: HwcTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: v32
+  name: Maintenancedata_HwcTempMax
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: v32
+  name: MaxAirHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: MinAirHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: OutdoorstempSensor
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: v32
+  name: OutsideAirTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: PumpHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: PumpPower
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: ReturnTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: ReturnTempMax
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: Status02.hwcmode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: Status02.temp0
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: Status02.temp0_1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: Status02.temp1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: Status02.temp1_1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: StorageLoadPumpHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: StorageTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: StorageTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: SupplyAirTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: VentilationLevelDay
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: VentilationLevelNight
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldToday
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldTotal
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldYear
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Clearerrorhistory
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Mc1Operation
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Mc2Operation
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Mc3Operation
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: SensorData1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: SensorData2
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: SetActorState
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vwz
+  name: TestHwcTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: vwz
+  name: TestOutdoorTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: vwz
+  name: TestThreeWayValve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: vwzio
+  name: EnableTestHwcTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: EnableTestOutdoorTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: EnableTestThreeWayValve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: TestHwcTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: TestOutdoorTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: TestThreeWayValve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+grab:
+- '[grab] grab continued'
+- '3104070400 / 0ab54e4554583301290404 = 1: scan.04'
+- 'f108070400 / 0ab5484d55583004060504 = 51: scan.08'
+- '3108b516081001ffff02052835 / 0b0100070205283500000000 = 223: hmu CoolEnvYieldDay'
+- 3108b516081001ffff02052735 / 0b0100070205273500000000 = 264
+- 3108b516081001ffff02052635 / 0b0100070205263500000000 = 265
+- 3108b516081001ffff02052535 / 0b0100070205253500000000 = 160
+- 3108b516081001ffff02052235 / 0b0100070205223500000000 = 1
+- 3108b516081001ffff02052135 / 0b0100070205213500000000 = 1
+- 3108b516081001ffff02051f35 / 0b01000702051f3500000000 = 1
+- 3108b516081001ffff02051b35 / 0b01000702051b3500000000 = 2
+- 3108b516081001ffff02051935 / 0b0100070205193500000000 = 1
+- '3108b516081000ffff02050000 / 0b0000070205283500000000 = 917: hmu CoolEnvYieldTotal'
+- '3108b516081002ffff02052835 / 0b0200070205213500000000 = 222: hmu CoolEnvYieldMonth'
+- 3108b516081002ffff02052735 / 0b0200070205213500000000 = 264
+- 3108b516081002ffff02052635 / 0b0200070205213500000000 = 265
+- 3108b516081002ffff02052535 / 0b0200070205213500000000 = 160
+- 3108b516081002ffff02052235 / 0b0200070205213500000000 = 1
+- 3108b516081002ffff02052135 / 0b0200070205213500000000 = 1
+- 3108b516081002ffff02051f35 / 0b0200070205013500000000 = 1
+- 3108b516081002ffff02051b35 / 0b0200070205013500000000 = 2
+- 3108b516081002ffff02051935 / 0b0200070205013500000000 = 1
+- '3108b516081001ffff03032835 / 0b010000030328353730f542 = 222: hmu HcElecConsDay'
+- 3108b516081001ffff03032735 / 0b0100000303273509881043 = 264
+- 3108b516081001ffff03032635 / 0b010000030326356edf1543 = 265
+- 3108b516081001ffff03032535 / 0b010000030325357f501043 = 159
+- 3108b516081001ffff03032235 / 0b010000030322350819f542 = 1
+- 3108b516081001ffff03032135 / 0b0100000303213502ce0243 = 1
+- 3108b516081001ffff03031f35 / 0b01000003031f35da001d43 = 1
+- 3108b516081001ffff03031b35 / 0b01000003031b35bd5af142 = 2
+- '3108b516081000ffff03030000 / 0b000000030328355e1e2846 = 915: hmu HcElecConsTotal'
+- '3108b516081001ffff03052835 / 0b0100060305283500000000 = 222: hmu CoolElecConsDay'
+- 3108b516081001ffff03052735 / 0b0100060305273500000000 = 264
+- 3108b516081001ffff03052635 / 0b0100060305263500000000 = 265
+- 3108b516081001ffff03052535 / 0b0100060305253585ebd13d = 159
+- 3108b516081001ffff03052235 / 0b0100060305223585ebd13d = 1
+- 3108b516081001ffff03052135 / 0b0100060305213585ebd13d = 1
+- 3108b516081001ffff03051f35 / 0b01000603051f3585ebd13d = 1
+- 3108b516081001ffff03051b35 / 0b01000603051b3585ebd13d = 2
+- '3108b516081000ffff03040000 / 0b0000030304283500000000 = 915: hmu HwcElecConsTotal'
+- '3108b516081001ffff03042835 / 0b0100030304283500000000 = 222: hmu HwcElecConsDay'
+- 3108b516081001ffff03042735 / 0b0100030304273500000000 = 264
+- 3108b516081001ffff03042635 / 0b0100030304263500000000 = 265
+- 3108b516081001ffff03042535 / 0b0100030304253500000000 = 159
+- 3108b516081001ffff03042235 / 0b0100030304223500000000 = 1
+- 3108b516081001ffff03042135 / 0b0100030304213500000000 = 1
+- 3108b516081001ffff03041f35 / 0b01000303041f3500000000 = 1
+- 3108b516081001ffff03041b35 / 0b01000303041b3500000000 = 2
+- '3108b516081000ffff03050000 / 0b00000603052835ff8ffb46 = 917: hmu CoolElecConsTotal'
+- 'f115070400 / 0ab543544c563308088004 = 26: scan.15'
+- 'f115b5090127 / 094e3330303030303030 = 103: Scan.15 Id'
+- 'f176070400 / 0ab556575a494f04060504 = 51: scan.76'
+- 'f176b5090127 / 094e383c3c3c3c3c3c3c = 103: Scan.76 Id'
+- '31f6070400 / 0ab54e4554583301290404 = 1: scan.f6'
+- '31f6b5090127 / 094e34ffffffffffffff = 3: Scan.f6 Id'
+- '31fe07fe00 = 1: Broadcast Queryexistence'
+- '10feb516080001132008090226 = 33045: Broadcast Vdatetime'
+- '10feb5160301f50f = 33047: Broadcast Outsidetemp'
+- 1008b5040100 / 0a0302132008090226f50f = 32978
+- 1008b507010a / 038f8f07 = 552
+- 1008b5110100 / 091a0112000000000000 = 32993
+- 1008b5110101 / 092322f50fffff0000ff = 197864
+- 1008b5160111 / 09020309100934090a09 = 23
+- 1076b5110101 / 092e22f50fffff0000ff = 197896
+- 1076b5160111 / 09020304100434040a04 = 23
+- 10feb505025c00 = 33065
+- 10feb508020900 = 3348
+- 10feb510020600 = 6612
+- '3115b5090124 / 09003231323534353030 = 1: Scan.15 Id'
+- '3176b5090124 / 09003231323630333830 = 1: Scan.76 Id'
+- '31f6b5090124 / 09003231323631303030 = 1: Scan.f6 Id'
+- f108b5090124 / 09003231323632333830 = 24
+- f108b5090125 / 09303030323231373733 = 25
+- f108b5090126 / 09313333353735343638 = 25
+- f108b5090127 / 094e313c3c3c3c3c3c3c = 25
+- f108b5110100 / 091a0112000000000000 = 6817
+- f108b5110101 / 092322f50fffff0000ff = 46323
+- f108b5160114 / 09000000c04000000000 = 32391
+- f108b5310102 / 0416006601 = 24
+- f176b5160114 / 09000000a04000000000 = 32384
+- f176b5310102 / 04c800c800 = 24
+- 0304b511010e / 0116 = 59975
+- '1008b51009000000ffffff070000 / 0101 = 145: bai SetModeOverride'
+- 1008b507020900 / 0220fe = 33038
+- 1008b50702094d / 02aaff = 2
+- 1008b50702094e / 02aeff = 2
+- 1008b512020000 / 00 = 6612
+- 1008b512020464 / 00 = 5
+- 1008b5120204ff / 00 = 6609
+- 1008b513020528 / 0101 = 6607
+- f108b503020001 / 0affffffffffffffffffff = 32998
+- f108b503020002 / 0affffffffffffffffffff = 33006
+- f108b503020003 / 0a6400ffffffffffffffff = 13348
+- f108b503020004 / 0affffffffffffffffffff = 32998
+- f108b503020005 / 0affffffffffffffffffff = 33010
+- f108b509022802 / 0c02000406950100484d555830 = 25
+- f108b511021801 / 09001200000002000000 = 548
+- f108b511021802 / 09000000000000000000 = 549
+- f108b511021803 / 0900e80b00006b000000 = 548
+- f115b503020002 / 0affffffffffffffffffff = 33010
+- f115b531020300 / 0101 = 2
+- f115b531020301 / 0101 = 6600
+- f176b503020001 / 0affffffffffffffffffff = 32954
+- f176b509022802 / 0c0200040695010056575a494f = 25
+- f176b511021801 / 09000000000001000000 = 548
+- f176b511021802 / 09000000000000000000 = 550
+- f176b511021803 / 0101 = 549
+- 'f115b503020001 / 0affffffffffffffffffff = 32996: ctlv3 Currenterror'
+- 1076b512030f0001 / 07008000700112ff = 197874
+- 1076b512030f0101 / 07008000660112ff = 18
+- f108b5310301ffff / 0101 = 24
+- f115b52403000000 / 040000803f = 24
+- f115b52403000100 / 040000803f = 24
+- f115b52403000200 / 0400000000 = 24
+- f115b52403000300 / 0400000000 = 24
+- f115b52403000400 / 0400004040 = 24
+- f115b52403000800 / 0400000000 = 24
+- f115b52403000900 / 0400000000 = 24
+- f115b52403000a00 / 0400000000 = 24
+- f115b52403000b00 / 0400000000 = 23
+- f115b52403000c00 / 0400000000 = 24
+- f115b52403000d00 / 040000803f = 23
+- f115b52403000e00 / 0400000000 = 23
+- f115b52403000f00 / 0400000000 = 24
+- f115b52403001000 / 0400000000 = 24
+- f115b52403001100 / 040000803f = 24
+- f115b52403001200 / 04ffffff7f = 24
+- f115b55503a40001 / 09000101010101010100 = 570
+- f176b5310301ffff / 0101 = 24
+- '3115b55503a30003 / 09030101000000ffff00 = 4912: ctlv3 CcTimer_Config'
+- 'f115b55503a40000 / 09000101010101010100 = 569: ctlv3 Z1Timer_Timeframes'
+- '3115b55503a40003 / 09030000000000000000 = 4912: ctlv3 CcTimer_Timeframes'
+- '1008b51009000000ffffff070000 / 0101 = 197650: bai SetModeOverride'
+- '1008b51009000026ffffff070004 / 0101 = 1: bai SetModeOverride'
+- '1008b5100900004dffffff060000 / 0101 = 11: bai SetModeOverride'
+- '1008b5100900004effffff060000 / 0101 = 11: bai SetModeOverride'
+- '1008b51009000100ffffff000001 / 0101 = 68: bai SetModeOverride'
+- 1008b516081000ffff02002134 / 0b0000ff02002735ff3fce45 = 114
+- 1008b516081002ffff02000135 / 0b0201ff0200013500306645 = 229
+- 1008b516081003ffff02002132 / 0b13ffff0200213200000000 = 230
+- 1076b509040e0f0000 / 00 = 23
+- 1076b509040e130001 / 00 = 23
+- 1076b51009000000ffffff050000 / 0101 = 197842
+- 1076b516081000ffff03052134 / 0b1000ff0305273500000000 = 92
+- 1076b516081002ffff03050135 / 0b1201ff0305013500000000 = 184
+- 1076b516081003ffff03052132 / 0b13ffff0305213200000000 = 182
+- f108b50905540200030b / 060201030bf900 = 3346
+- f108b509055402000d0a / 0802010d0a00000000 = 3350
+- f108b509055402005b0d / 0802015b0d0000c040 = 32902
+- f108b50905540200650b / 050201650b01 = 23
+- f108b509055402008813 / 0e020188136400ffffffffffffffff = 3338
+- f108b509055402008b13 / 0e02018b13ffffffffffffffffffff = 3343
+- f108b50905540200c20b / 080201c20b32000000 = 21
+- f108b50905540200c509 / 080201c50900000000 = 3353
+- f108b50905540200cc10 / 060201cc101601 = 3343
+- f108b50905540200fd0a / 060201fd0a1b01 = 3344
+- 'f108b5100b0017000000000000000000 / 0301ef01 = 25: bai SetModeOverride'
+- f108b516081000ffff49050000 / 0b00000849052835ffe73248 = 6110
+- f108b51a0405000c00 / 020001 = 553
+- f108b51a0405000c4d / 020001 = 552
+- f108b51a0405000c50 / 020001 = 551
+- f108b51a0405000c51 / 020001 = 552
+- f108b51a0405000c52 / 020001 = 552
+- f108b51a0405000c53 / 020001 = 549
+- f108b51a0405000c54 / 020001 = 552
+- f108b51a0405000ca1 / 020001 = 551
+- f115b516081000ffff01000000 / 0b0000ff0100283500000000 = 556
+- f115b524050100ff2700 / 0f0027000000803f0000a0410000003f = 24
+- f115b52406020000006800 / 0800006800ffffff7f = 108608
+- f115b52406020001001500 / 080201150000004442 = 1737
+- f115b52406020002000a00 / 0803020a0000004040 = 1212
+- f115b52406020002030200 / 06020202000000 = 24
+- f115b52406020002040200 / 06020202000000 = 24
+- f115b52406020002050200 / 06020202000000 = 24
+- f115b52406020002060200 / 06020202000000 = 24
+- f115b52406020002070200 / 06020202000000 = 24
+- f115b52406020002080200 / 06020202000000 = 23
+- f115b52406020003002c00 / 0501032c0001 = 178747
+- f115b52406020003011c00 / 0500031c00ff = 48
+- f115b52406020003021c00 / 0500031c00ff = 48
+- f115b52406020003031c00 / 0500031c00ff = 71
+- f115b52406020003041c00 / 0500031c00ff = 72
+- f115b52406020003051c00 / 0500031c00ff = 72
+- f115b52406020003061c00 / 0500031c00ff = 72
+- f115b52406020003071c00 / 0500031c00ff = 72
+- f115b52406020003081c00 / 0500031c00ff = 72
+- f115b55505a500010000 / 070006001400e600 = 572
+- f115b55505a500010100 / 070006001400e600 = 572
+- f115b55505a500010200 / 070006001400e600 = 572
+- f115b55505a500010300 / 070006001400e600 = 568
+- f115b55505a500010400 / 070006001400e600 = 571
+- f115b55505a500010500 / 070006001400e600 = 572
+- f115b55505a500010600 / 070006001400e600 = 571
+- f176b50905540200cc10 / 060201cc101601 = 3344
+- f176b516081000ffff49040000 / 0b0000034904283500000000 = 2193
+- '3108b51a0405ff3222 / 02ff01 = 1355: hmu SourceTempInput'
+- 'f115b55505a500000000 / 070006001600c800 = 567: ctlv3 Z1Timer_Monday0'
+- 'f115b55505a500000100 / 070006001600c800 = 569: ctlv3 Z1Timer_Tuesday0'
+- 'f115b55505a500000200 / 070006001600c800 = 571: ctlv3 Z1Timer_Wednesday0'
+- 'f115b55505a500000300 / 070006001600c800 = 571: ctlv3 Z1Timer_Thursday0'
+- 'f115b55505a500000400 / 070006001600c800 = 570: ctlv3 Z1Timer_Friday0'
+- '[grab stop] grab stopped'
+labeled_telegrams:
+- msgid: '0704'
+  master: '31'
+  slave: '04'
+  sub: '00'
+  resp: 0ab54e4554583301290404
+  count: '1'
+  label: scan.04
+- msgid: '0704'
+  master: f1
+  slave: 08
+  sub: '00'
+  resp: 0ab5484d55583004060504
+  count: '51'
+  label: scan.08
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081001ffff02052835
+  resp: 0b0100070205283500000000
+  count: '223'
+  label: hmu CoolEnvYieldDay
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081000ffff02050000
+  resp: 0b0000070205283500000000
+  count: '917'
+  label: hmu CoolEnvYieldTotal
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081002ffff02052835
+  resp: 0b0200070205213500000000
+  count: '222'
+  label: hmu CoolEnvYieldMonth
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081001ffff03032835
+  resp: 0b010000030328353730f542
+  count: '222'
+  label: hmu HcElecConsDay
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081000ffff03030000
+  resp: 0b000000030328355e1e2846
+  count: '915'
+  label: hmu HcElecConsTotal
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081001ffff03052835
+  resp: 0b0100060305283500000000
+  count: '222'
+  label: hmu CoolElecConsDay
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081000ffff03040000
+  resp: 0b0000030304283500000000
+  count: '915'
+  label: hmu HwcElecConsTotal
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081001ffff03042835
+  resp: 0b0100030304283500000000
+  count: '222'
+  label: hmu HwcElecConsDay
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081000ffff03050000
+  resp: 0b00000603052835ff8ffb46
+  count: '917'
+  label: hmu CoolElecConsTotal
+- msgid: '0704'
+  master: f1
+  slave: '15'
+  sub: '00'
+  resp: 0ab543544c563308088004
+  count: '26'
+  label: scan.15
+- msgid: b509
+  master: f1
+  slave: '15'
+  sub: '0127'
+  resp: 094e3330303030303030
+  count: '103'
+  label: Scan.15 Id
+- msgid: '0704'
+  master: f1
+  slave: '76'
+  sub: '00'
+  resp: 0ab556575a494f04060504
+  count: '51'
+  label: scan.76
+- msgid: b509
+  master: f1
+  slave: '76'
+  sub: '0127'
+  resp: 094e383c3c3c3c3c3c3c
+  count: '103'
+  label: Scan.76 Id
+- msgid: '0704'
+  master: '31'
+  slave: f6
+  sub: '00'
+  resp: 0ab54e4554583301290404
+  count: '1'
+  label: scan.f6
+- msgid: b509
+  master: '31'
+  slave: f6
+  sub: '0127'
+  resp: 094e34ffffffffffffff
+  count: '3'
+  label: Scan.f6 Id
+- msgid: 07fe
+  master: '31'
+  slave: fe
+  sub: '00'
+  resp: null
+  count: '1'
+  label: Broadcast Queryexistence
+- msgid: b516
+  master: '10'
+  slave: fe
+  sub: 080001132008090226
+  resp: null
+  count: '33045'
+  label: Broadcast Vdatetime
+- msgid: b516
+  master: '10'
+  slave: fe
+  sub: 0301f50f
+  resp: null
+  count: '33047'
+  label: Broadcast Outsidetemp
+- msgid: b509
+  master: '31'
+  slave: '15'
+  sub: '0124'
+  resp: 09003231323534353030
+  count: '1'
+  label: Scan.15 Id
+- msgid: b509
+  master: '31'
+  slave: '76'
+  sub: '0124'
+  resp: 09003231323630333830
+  count: '1'
+  label: Scan.76 Id
+- msgid: b509
+  master: '31'
+  slave: f6
+  sub: '0124'
+  resp: 09003231323631303030
+  count: '1'
+  label: Scan.f6 Id
+- msgid: b510
+  master: '10'
+  slave: 08
+  sub: 09000000ffffff070000
+  resp: '0101'
+  count: '145'
+  label: bai SetModeOverride
+- msgid: b503
+  master: f1
+  slave: '15'
+  sub: '020001'
+  resp: 0affffffffffffffffffff
+  count: '32996'
+  label: ctlv3 Currenterror
+- msgid: b555
+  master: '31'
+  slave: '15'
+  sub: 03a30003
+  resp: 09030101000000ffff00
+  count: '4912'
+  label: ctlv3 CcTimer_Config
+- msgid: b555
+  master: f1
+  slave: '15'
+  sub: 03a40000
+  resp: 09000101010101010100
+  count: '569'
+  label: ctlv3 Z1Timer_Timeframes
+- msgid: b555
+  master: '31'
+  slave: '15'
+  sub: 03a40003
+  resp: 09030000000000000000
+  count: '4912'
+  label: ctlv3 CcTimer_Timeframes
+- msgid: b510
+  master: '10'
+  slave: 08
+  sub: 09000000ffffff070000
+  resp: '0101'
+  count: '197650'
+  label: bai SetModeOverride
+- msgid: b510
+  master: '10'
+  slave: 08
+  sub: 09000026ffffff070004
+  resp: '0101'
+  count: '1'
+  label: bai SetModeOverride
+- msgid: b510
+  master: '10'
+  slave: 08
+  sub: 0900004dffffff060000
+  resp: '0101'
+  count: '11'
+  label: bai SetModeOverride
+- msgid: b510
+  master: '10'
+  slave: 08
+  sub: 0900004effffff060000
+  resp: '0101'
+  count: '11'
+  label: bai SetModeOverride
+- msgid: b510
+  master: '10'
+  slave: 08
+  sub: 09000100ffffff000001
+  resp: '0101'
+  count: '68'
+  label: bai SetModeOverride
+- msgid: b510
+  master: f1
+  slave: 08
+  sub: 0b0017000000000000000000
+  resp: 0301ef01
+  count: '25'
+  label: bai SetModeOverride
+- msgid: b51a
+  master: '31'
+  slave: 08
+  sub: 0405ff3222
+  resp: 02ff01
+  count: '1355'
+  label: hmu SourceTempInput
+- msgid: b555
+  master: f1
+  slave: '15'
+  sub: 05a500000000
+  resp: 070006001600c800
+  count: '567'
+  label: ctlv3 Z1Timer_Monday0
+- msgid: b555
+  master: f1
+  slave: '15'
+  sub: 05a500000100
+  resp: 070006001600c800
+  count: '569'
+  label: ctlv3 Z1Timer_Tuesday0
+- msgid: b555
+  master: f1
+  slave: '15'
+  sub: 05a500000200
+  resp: 070006001600c800
+  count: '571'
+  label: ctlv3 Z1Timer_Wednesday0
+- msgid: b555
+  master: f1
+  slave: '15'
+  sub: 05a500000300
+  resp: 070006001600c800
+  count: '571'
+  label: ctlv3 Z1Timer_Thursday0
+- msgid: b555
+  master: f1
+  slave: '15'
+  sub: 05a500000400
+  resp: 070006001600c800
+  count: '570'
+  label: ctlv3 Z1Timer_Friday0
+unknown_telegrams:
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081001ffff02052735
+  resp: 0b0100070205273500000000
+  count: '264'
+  label: null
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081001ffff02052635
+  resp: 0b0100070205263500000000
+  count: '265'
+  label: null
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081001ffff02052535
+  resp: 0b0100070205253500000000
+  count: '160'
+  label: null
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081001ffff02052235
+  resp: 0b0100070205223500000000
+  count: '1'
+  label: null
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081001ffff02052135
+  resp: 0b0100070205213500000000
+  count: '1'
+  label: null
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081001ffff02051f35
+  resp: 0b01000702051f3500000000
+  count: '1'
+  label: null
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081001ffff02051b35
+  resp: 0b01000702051b3500000000
+  count: '2'
+  label: null
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081001ffff02051935
+  resp: 0b0100070205193500000000
+  count: '1'
+  label: null
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081002ffff02052735
+  resp: 0b0200070205213500000000
+  count: '264'
+  label: null
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081002ffff02052635
+  resp: 0b0200070205213500000000
+  count: '265'
+  label: null
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081002ffff02052535
+  resp: 0b0200070205213500000000
+  count: '160'
+  label: null
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081002ffff02052235
+  resp: 0b0200070205213500000000
+  count: '1'
+  label: null
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081002ffff02052135
+  resp: 0b0200070205213500000000
+  count: '1'
+  label: null
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081002ffff02051f35
+  resp: 0b0200070205013500000000
+  count: '1'
+  label: null
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081002ffff02051b35
+  resp: 0b0200070205013500000000
+  count: '2'
+  label: null
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081002ffff02051935
+  resp: 0b0200070205013500000000
+  count: '1'
+  label: null
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081001ffff03032735
+  resp: 0b0100000303273509881043
+  count: '264'
+  label: null
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081001ffff03032635
+  resp: 0b010000030326356edf1543
+  count: '265'
+  label: null
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081001ffff03032535
+  resp: 0b010000030325357f501043
+  count: '159'
+  label: null
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081001ffff03032235
+  resp: 0b010000030322350819f542
+  count: '1'
+  label: null
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081001ffff03032135
+  resp: 0b0100000303213502ce0243
+  count: '1'
+  label: null
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081001ffff03031f35
+  resp: 0b01000003031f35da001d43
+  count: '1'
+  label: null
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081001ffff03031b35
+  resp: 0b01000003031b35bd5af142
+  count: '2'
+  label: null
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081001ffff03052735
+  resp: 0b0100060305273500000000
+  count: '264'
+  label: null
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081001ffff03052635
+  resp: 0b0100060305263500000000
+  count: '265'
+  label: null
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081001ffff03052535
+  resp: 0b0100060305253585ebd13d
+  count: '159'
+  label: null
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081001ffff03052235
+  resp: 0b0100060305223585ebd13d
+  count: '1'
+  label: null
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081001ffff03052135
+  resp: 0b0100060305213585ebd13d
+  count: '1'
+  label: null
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081001ffff03051f35
+  resp: 0b01000603051f3585ebd13d
+  count: '1'
+  label: null
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081001ffff03051b35
+  resp: 0b01000603051b3585ebd13d
+  count: '2'
+  label: null
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081001ffff03042735
+  resp: 0b0100030304273500000000
+  count: '264'
+  label: null
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081001ffff03042635
+  resp: 0b0100030304263500000000
+  count: '265'
+  label: null
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081001ffff03042535
+  resp: 0b0100030304253500000000
+  count: '159'
+  label: null
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081001ffff03042235
+  resp: 0b0100030304223500000000
+  count: '1'
+  label: null
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081001ffff03042135
+  resp: 0b0100030304213500000000
+  count: '1'
+  label: null
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081001ffff03041f35
+  resp: 0b01000303041f3500000000
+  count: '1'
+  label: null
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081001ffff03041b35
+  resp: 0b01000303041b3500000000
+  count: '2'
+  label: null
+- msgid: b504
+  master: '10'
+  slave: 08
+  sub: '0100'
+  resp: 0a0302132008090226f50f
+  count: '32978'
+  label: null
+- msgid: b507
+  master: '10'
+  slave: 08
+  sub: 010a
+  resp: 038f8f07
+  count: '552'
+  label: null
+- msgid: b511
+  master: '10'
+  slave: 08
+  sub: '0100'
+  resp: 091a0112000000000000
+  count: '32993'
+  label: null
+- msgid: b511
+  master: '10'
+  slave: 08
+  sub: '0101'
+  resp: 092322f50fffff0000ff
+  count: '197864'
+  label: null
+- msgid: b516
+  master: '10'
+  slave: 08
+  sub: '0111'
+  resp: 09020309100934090a09
+  count: '23'
+  label: null
+- msgid: b511
+  master: '10'
+  slave: '76'
+  sub: '0101'
+  resp: 092e22f50fffff0000ff
+  count: '197896'
+  label: null
+- msgid: b516
+  master: '10'
+  slave: '76'
+  sub: '0111'
+  resp: 09020304100434040a04
+  count: '23'
+  label: null
+- msgid: b505
+  master: '10'
+  slave: fe
+  sub: 025c00
+  resp: null
+  count: '33065'
+  label: null
+- msgid: b508
+  master: '10'
+  slave: fe
+  sub: 020900
+  resp: null
+  count: '3348'
+  label: null
+- msgid: b510
+  master: '10'
+  slave: fe
+  sub: '020600'
+  resp: null
+  count: '6612'
+  label: null
+- msgid: b509
+  master: f1
+  slave: 08
+  sub: '0124'
+  resp: 09003231323632333830
+  count: '24'
+  label: null
+- msgid: b509
+  master: f1
+  slave: 08
+  sub: '0125'
+  resp: 09303030323231373733
+  count: '25'
+  label: null
+- msgid: b509
+  master: f1
+  slave: 08
+  sub: '0126'
+  resp: 09313333353735343638
+  count: '25'
+  label: null
+- msgid: b509
+  master: f1
+  slave: 08
+  sub: '0127'
+  resp: 094e313c3c3c3c3c3c3c
+  count: '25'
+  label: null
+- msgid: b511
+  master: f1
+  slave: 08
+  sub: '0100'
+  resp: 091a0112000000000000
+  count: '6817'
+  label: null
+- msgid: b511
+  master: f1
+  slave: 08
+  sub: '0101'
+  resp: 092322f50fffff0000ff
+  count: '46323'
+  label: null
+- msgid: b516
+  master: f1
+  slave: 08
+  sub: '0114'
+  resp: 09000000c04000000000
+  count: '32391'
+  label: null
+- msgid: b531
+  master: f1
+  slave: 08
+  sub: '0102'
+  resp: '0416006601'
+  count: '24'
+  label: null
+- msgid: b516
+  master: f1
+  slave: '76'
+  sub: '0114'
+  resp: 09000000a04000000000
+  count: '32384'
+  label: null
+- msgid: b531
+  master: f1
+  slave: '76'
+  sub: '0102'
+  resp: 04c800c800
+  count: '24'
+  label: null
+- msgid: b507
+  master: '10'
+  slave: 08
+  sub: 020900
+  resp: 0220fe
+  count: '33038'
+  label: null
+- msgid: b507
+  master: '10'
+  slave: 08
+  sub: 02094d
+  resp: 02aaff
+  count: '2'
+  label: null
+- msgid: b507
+  master: '10'
+  slave: 08
+  sub: 02094e
+  resp: 02aeff
+  count: '2'
+  label: null
+- msgid: b512
+  master: '10'
+  slave: 08
+  sub: '020000'
+  resp: '00'
+  count: '6612'
+  label: null
+- msgid: b512
+  master: '10'
+  slave: 08
+  sub: '020464'
+  resp: '00'
+  count: '5'
+  label: null
+- msgid: b512
+  master: '10'
+  slave: 08
+  sub: 0204ff
+  resp: '00'
+  count: '6609'
+  label: null
+- msgid: b513
+  master: '10'
+  slave: 08
+  sub: 020528
+  resp: '0101'
+  count: '6607'
+  label: null
+- msgid: b503
+  master: f1
+  slave: 08
+  sub: '020001'
+  resp: 0affffffffffffffffffff
+  count: '32998'
+  label: null
+- msgid: b503
+  master: f1
+  slave: 08
+  sub: '020002'
+  resp: 0affffffffffffffffffff
+  count: '33006'
+  label: null
+- msgid: b503
+  master: f1
+  slave: 08
+  sub: '020003'
+  resp: 0a6400ffffffffffffffff
+  count: '13348'
+  label: null
+- msgid: b503
+  master: f1
+  slave: 08
+  sub: '020004'
+  resp: 0affffffffffffffffffff
+  count: '32998'
+  label: null
+- msgid: b503
+  master: f1
+  slave: 08
+  sub: '020005'
+  resp: 0affffffffffffffffffff
+  count: '33010'
+  label: null
+- msgid: b509
+  master: f1
+  slave: 08
+  sub: 022802
+  resp: 0c02000406950100484d555830
+  count: '25'
+  label: null
+- msgid: b511
+  master: f1
+  slave: 08
+  sub: 021801
+  resp: 09001200000002000000
+  count: '548'
+  label: null
+- msgid: b511
+  master: f1
+  slave: 08
+  sub: 021802
+  resp: 09000000000000000000
+  count: '549'
+  label: null
+- msgid: b511
+  master: f1
+  slave: 08
+  sub: 021803
+  resp: 0900e80b00006b000000
+  count: '548'
+  label: null
+- msgid: b503
+  master: f1
+  slave: '15'
+  sub: '020002'
+  resp: 0affffffffffffffffffff
+  count: '33010'
+  label: null
+- msgid: b531
+  master: f1
+  slave: '15'
+  sub: '020300'
+  resp: '0101'
+  count: '2'
+  label: null
+- msgid: b531
+  master: f1
+  slave: '15'
+  sub: '020301'
+  resp: '0101'
+  count: '6600'
+  label: null
+- msgid: b503
+  master: f1
+  slave: '76'
+  sub: '020001'
+  resp: 0affffffffffffffffffff
+  count: '32954'
+  label: null
+- msgid: b509
+  master: f1
+  slave: '76'
+  sub: 022802
+  resp: 0c0200040695010056575a494f
+  count: '25'
+  label: null
+- msgid: b511
+  master: f1
+  slave: '76'
+  sub: 021801
+  resp: 09000000000001000000
+  count: '548'
+  label: null
+- msgid: b511
+  master: f1
+  slave: '76'
+  sub: 021802
+  resp: 09000000000000000000
+  count: '550'
+  label: null
+- msgid: b511
+  master: f1
+  slave: '76'
+  sub: 021803
+  resp: '0101'
+  count: '549'
+  label: null
+- msgid: b512
+  master: '10'
+  slave: '76'
+  sub: 030f0001
+  resp: 07008000700112ff
+  count: '197874'
+  label: null
+- msgid: b512
+  master: '10'
+  slave: '76'
+  sub: 030f0101
+  resp: 07008000660112ff
+  count: '18'
+  label: null
+- msgid: b531
+  master: f1
+  slave: 08
+  sub: 0301ffff
+  resp: '0101'
+  count: '24'
+  label: null
+- msgid: b524
+  master: f1
+  slave: '15'
+  sub: '03000000'
+  resp: 040000803f
+  count: '24'
+  label: null
+- msgid: b524
+  master: f1
+  slave: '15'
+  sub: '03000100'
+  resp: 040000803f
+  count: '24'
+  label: null
+- msgid: b524
+  master: f1
+  slave: '15'
+  sub: '03000200'
+  resp: '0400000000'
+  count: '24'
+  label: null
+- msgid: b524
+  master: f1
+  slave: '15'
+  sub: '03000300'
+  resp: '0400000000'
+  count: '24'
+  label: null
+- msgid: b524
+  master: f1
+  slave: '15'
+  sub: '03000400'
+  resp: '0400004040'
+  count: '24'
+  label: null
+- msgid: b524
+  master: f1
+  slave: '15'
+  sub: 03000800
+  resp: '0400000000'
+  count: '24'
+  label: null
+- msgid: b524
+  master: f1
+  slave: '15'
+  sub: 03000900
+  resp: '0400000000'
+  count: '24'
+  label: null
+- msgid: b524
+  master: f1
+  slave: '15'
+  sub: 03000a00
+  resp: '0400000000'
+  count: '24'
+  label: null
+- msgid: b524
+  master: f1
+  slave: '15'
+  sub: 03000b00
+  resp: '0400000000'
+  count: '23'
+  label: null
+- msgid: b524
+  master: f1
+  slave: '15'
+  sub: 03000c00
+  resp: '0400000000'
+  count: '24'
+  label: null
+- msgid: b524
+  master: f1
+  slave: '15'
+  sub: 03000d00
+  resp: 040000803f
+  count: '23'
+  label: null
+- msgid: b524
+  master: f1
+  slave: '15'
+  sub: 03000e00
+  resp: '0400000000'
+  count: '23'
+  label: null
+- msgid: b524
+  master: f1
+  slave: '15'
+  sub: 03000f00
+  resp: '0400000000'
+  count: '24'
+  label: null
+- msgid: b524
+  master: f1
+  slave: '15'
+  sub: '03001000'
+  resp: '0400000000'
+  count: '24'
+  label: null
+- msgid: b524
+  master: f1
+  slave: '15'
+  sub: '03001100'
+  resp: 040000803f
+  count: '24'
+  label: null
+- msgid: b524
+  master: f1
+  slave: '15'
+  sub: '03001200'
+  resp: 04ffffff7f
+  count: '24'
+  label: null
+- msgid: b555
+  master: f1
+  slave: '15'
+  sub: 03a40001
+  resp: 09000101010101010100
+  count: '570'
+  label: null
+- msgid: b531
+  master: f1
+  slave: '76'
+  sub: 0301ffff
+  resp: '0101'
+  count: '24'
+  label: null
+- msgid: b516
+  master: '10'
+  slave: 08
+  sub: 081000ffff02002134
+  resp: 0b0000ff02002735ff3fce45
+  count: '114'
+  label: null
+- msgid: b516
+  master: '10'
+  slave: 08
+  sub: 081002ffff02000135
+  resp: 0b0201ff0200013500306645
+  count: '229'
+  label: null
+- msgid: b516
+  master: '10'
+  slave: 08
+  sub: 081003ffff02002132
+  resp: 0b13ffff0200213200000000
+  count: '230'
+  label: null
+- msgid: b509
+  master: '10'
+  slave: '76'
+  sub: 040e0f0000
+  resp: '00'
+  count: '23'
+  label: null
+- msgid: b509
+  master: '10'
+  slave: '76'
+  sub: 040e130001
+  resp: '00'
+  count: '23'
+  label: null
+- msgid: b510
+  master: '10'
+  slave: '76'
+  sub: 09000000ffffff050000
+  resp: '0101'
+  count: '197842'
+  label: null
+- msgid: b516
+  master: '10'
+  slave: '76'
+  sub: 081000ffff03052134
+  resp: 0b1000ff0305273500000000
+  count: '92'
+  label: null
+- msgid: b516
+  master: '10'
+  slave: '76'
+  sub: 081002ffff03050135
+  resp: 0b1201ff0305013500000000
+  count: '184'
+  label: null
+- msgid: b516
+  master: '10'
+  slave: '76'
+  sub: 081003ffff03052132
+  resp: 0b13ffff0305213200000000
+  count: '182'
+  label: null
+- msgid: b509
+  master: f1
+  slave: 08
+  sub: 05540200030b
+  resp: 060201030bf900
+  count: '3346'
+  label: null
+- msgid: b509
+  master: f1
+  slave: 08
+  sub: 055402000d0a
+  resp: 0802010d0a00000000
+  count: '3350'
+  label: null
+- msgid: b509
+  master: f1
+  slave: 08
+  sub: 055402005b0d
+  resp: 0802015b0d0000c040
+  count: '32902'
+  label: null
+- msgid: b509
+  master: f1
+  slave: 08
+  sub: 05540200650b
+  resp: 050201650b01
+  count: '23'
+  label: null
+- msgid: b509
+  master: f1
+  slave: 08
+  sub: 055402008813
+  resp: 0e020188136400ffffffffffffffff
+  count: '3338'
+  label: null
+- msgid: b509
+  master: f1
+  slave: 08
+  sub: 055402008b13
+  resp: 0e02018b13ffffffffffffffffffff
+  count: '3343'
+  label: null
+- msgid: b509
+  master: f1
+  slave: 08
+  sub: 05540200c20b
+  resp: 080201c20b32000000
+  count: '21'
+  label: null
+- msgid: b509
+  master: f1
+  slave: 08
+  sub: 05540200c509
+  resp: 080201c50900000000
+  count: '3353'
+  label: null
+- msgid: b509
+  master: f1
+  slave: 08
+  sub: 05540200cc10
+  resp: 060201cc101601
+  count: '3343'
+  label: null
+- msgid: b509
+  master: f1
+  slave: 08
+  sub: 05540200fd0a
+  resp: 060201fd0a1b01
+  count: '3344'
+  label: null
+- msgid: b516
+  master: f1
+  slave: 08
+  sub: 081000ffff49050000
+  resp: 0b00000849052835ffe73248
+  count: '6110'
+  label: null
+- msgid: b51a
+  master: f1
+  slave: 08
+  sub: 0405000c00
+  resp: '020001'
+  count: '553'
+  label: null
+- msgid: b51a
+  master: f1
+  slave: 08
+  sub: 0405000c4d
+  resp: '020001'
+  count: '552'
+  label: null
+- msgid: b51a
+  master: f1
+  slave: 08
+  sub: 0405000c50
+  resp: '020001'
+  count: '551'
+  label: null
+- msgid: b51a
+  master: f1
+  slave: 08
+  sub: 0405000c51
+  resp: '020001'
+  count: '552'
+  label: null
+- msgid: b51a
+  master: f1
+  slave: 08
+  sub: 0405000c52
+  resp: '020001'
+  count: '552'
+  label: null
+- msgid: b51a
+  master: f1
+  slave: 08
+  sub: 0405000c53
+  resp: '020001'
+  count: '549'
+  label: null
+- msgid: b51a
+  master: f1
+  slave: 08
+  sub: 0405000c54
+  resp: '020001'
+  count: '552'
+  label: null
+- msgid: b51a
+  master: f1
+  slave: 08
+  sub: 0405000ca1
+  resp: '020001'
+  count: '551'
+  label: null
+- msgid: b516
+  master: f1
+  slave: '15'
+  sub: 081000ffff01000000
+  resp: 0b0000ff0100283500000000
+  count: '556'
+  label: null
+- msgid: b524
+  master: f1
+  slave: '15'
+  sub: 050100ff2700
+  resp: 0f0027000000803f0000a0410000003f
+  count: '24'
+  label: null
+- msgid: b524
+  master: f1
+  slave: '15'
+  sub: 06020000006800
+  resp: 0800006800ffffff7f
+  count: '108608'
+  label: null
+- msgid: b524
+  master: f1
+  slave: '15'
+  sub: '06020001001500'
+  resp: 080201150000004442
+  count: '1737'
+  label: null
+- msgid: b524
+  master: f1
+  slave: '15'
+  sub: 06020002000a00
+  resp: 0803020a0000004040
+  count: '1212'
+  label: null
+- msgid: b524
+  master: f1
+  slave: '15'
+  sub: '06020002030200'
+  resp: '06020202000000'
+  count: '24'
+  label: null
+- msgid: b524
+  master: f1
+  slave: '15'
+  sub: '06020002040200'
+  resp: '06020202000000'
+  count: '24'
+  label: null
+- msgid: b524
+  master: f1
+  slave: '15'
+  sub: '06020002050200'
+  resp: '06020202000000'
+  count: '24'
+  label: null
+- msgid: b524
+  master: f1
+  slave: '15'
+  sub: '06020002060200'
+  resp: '06020202000000'
+  count: '24'
+  label: null
+- msgid: b524
+  master: f1
+  slave: '15'
+  sub: '06020002070200'
+  resp: '06020202000000'
+  count: '24'
+  label: null
+- msgid: b524
+  master: f1
+  slave: '15'
+  sub: 06020002080200
+  resp: '06020202000000'
+  count: '23'
+  label: null
+- msgid: b524
+  master: f1
+  slave: '15'
+  sub: 06020003002c00
+  resp: 0501032c0001
+  count: '178747'
+  label: null
+- msgid: b524
+  master: f1
+  slave: '15'
+  sub: 06020003011c00
+  resp: 0500031c00ff
+  count: '48'
+  label: null
+- msgid: b524
+  master: f1
+  slave: '15'
+  sub: 06020003021c00
+  resp: 0500031c00ff
+  count: '48'
+  label: null
+- msgid: b524
+  master: f1
+  slave: '15'
+  sub: 06020003031c00
+  resp: 0500031c00ff
+  count: '71'
+  label: null
+- msgid: b524
+  master: f1
+  slave: '15'
+  sub: 06020003041c00
+  resp: 0500031c00ff
+  count: '72'
+  label: null
+- msgid: b524
+  master: f1
+  slave: '15'
+  sub: 06020003051c00
+  resp: 0500031c00ff
+  count: '72'
+  label: null
+- msgid: b524
+  master: f1
+  slave: '15'
+  sub: 06020003061c00
+  resp: 0500031c00ff
+  count: '72'
+  label: null
+- msgid: b524
+  master: f1
+  slave: '15'
+  sub: 06020003071c00
+  resp: 0500031c00ff
+  count: '72'
+  label: null
+- msgid: b524
+  master: f1
+  slave: '15'
+  sub: 06020003081c00
+  resp: 0500031c00ff
+  count: '72'
+  label: null
+- msgid: b555
+  master: f1
+  slave: '15'
+  sub: 05a500010000
+  resp: 070006001400e600
+  count: '572'
+  label: null
+- msgid: b555
+  master: f1
+  slave: '15'
+  sub: 05a500010100
+  resp: 070006001400e600
+  count: '572'
+  label: null
+- msgid: b555
+  master: f1
+  slave: '15'
+  sub: 05a500010200
+  resp: 070006001400e600
+  count: '572'
+  label: null
+- msgid: b555
+  master: f1
+  slave: '15'
+  sub: 05a500010300
+  resp: 070006001400e600
+  count: '568'
+  label: null
+- msgid: b555
+  master: f1
+  slave: '15'
+  sub: 05a500010400
+  resp: 070006001400e600
+  count: '571'
+  label: null
+- msgid: b555
+  master: f1
+  slave: '15'
+  sub: 05a500010500
+  resp: 070006001400e600
+  count: '572'
+  label: null
+- msgid: b555
+  master: f1
+  slave: '15'
+  sub: 05a500010600
+  resp: 070006001400e600
+  count: '571'
+  label: null
+- msgid: b509
+  master: f1
+  slave: '76'
+  sub: 05540200cc10
+  resp: 060201cc101601
+  count: '3344'
+  label: null
+- msgid: b516
+  master: f1
+  slave: '76'
+  sub: 081000ffff49040000
+  resp: 0b0000034904283500000000
+  count: '2193'
+  label: null
+after_registers:
+- circuit: Broadcast
+  name: Datetime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Error
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: Broadcast
+  name: HwcStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Id
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: IdAnswer
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: IdQuery
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Load
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Outsidetemp
+  fields:
+  - value
+  values:
+  - '15.957'
+  writable: false
+  has_data: true
+- circuit: Broadcast
+  name: Queryexistence
+  fields:
+  - value
+  values:
+  - (empty for 31fe07fe00 / )
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Signoflife
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Vdatetime
+  fields:
+  - value
+  values:
+  - 20:13:01;08.09.2026
+  writable: false
+  has_data: true
+- circuit: Broadcast
+  name: Vdatetime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: WaterPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: General
+  name: Valuerange
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Eeprom
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Eeprom
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Ram
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Ram
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Scan
+  name: Id
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Scan.15
+  name: Id
+  fields:
+  - value
+  values:
+  - 21;25;45;0020260913;0953;026479;N3
+  writable: false
+  has_data: true
+- circuit: Scan.76
+  name: Id
+  fields:
+  - value
+  values:
+  - 21;26;03;8000035574;0001;005739;N8
+  writable: false
+  has_data: true
+- circuit: Scan.f6
+  name: Id
+  fields:
+  - value
+  values:
+  - 21;26;10;0020292012;0933;049007;N4
+  writable: false
+  has_data: true
+- circuit: bai
+  name: ActiveStages
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: bai
+  name: FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: bai
+  name: FlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: bai
+  name: HeatingStage1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: bai
+  name: HeatingStage3
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: bai
+  name: PrEnergySumHc1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: bai
+  name: PrEnergySumHwc1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: bai
+  name: SetModeOverride
+  fields:
+  - value
+  values:
+  - 0;0.0;-;-;-;1;1;1;0;0;0;0
+  writable: false
+  has_data: true
+- circuit: bai
+  name: StorageTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: bai
+  name: StorageTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: bai
+  name: WaterPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: AdaptHeatCurve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: CcTimer_Config
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: CcTimer_Timeframes
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: ContinuousHeating
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: CylinderChargeHyst
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: CylinderChargeOffset
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Date
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: DisplayedOutsideTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: FrostOverRideTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1AutoOffMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1CircuitType
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1CoolingEnabled
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1CoolingFlowTempMin
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1DewPointMonitoring
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1DewPointOffset
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1DewPointTemp
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002300 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1ExcessTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1FlowTempCalc
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002000 / 050102200001)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1HeatCurve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1Humidity
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002200 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MixerMovement
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MixerPosition
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002100 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1PumpHours
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002400 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1PumpStarts
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002500 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1PumpStatus
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1RoomTempModulation
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1Status
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1SummerTempLimit
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2AutoOffMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2CircuitType
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2DewPointTemp
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012300 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2ExcessTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2FlowTempCalc
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012000 / 050002200000)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2HeatCurve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2Humidity
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012200 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MixerMovement
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MixerPosition
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012100 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2PumpHours
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012400 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2PumpStarts
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012500 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2PumpStatus
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2Status
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2SummerTempLimit
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3AutoOffMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3CircuitType
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3ExcessTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3HeatCurve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MixerMovement
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3PumpStatus
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3Status
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3SummerTempLimit
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HcStorageTempBottom
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: ctlv2
+  name: HcStorageTempTop
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: ctlv2
+  name: HwcFlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcLockTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcMaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcOpMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcParallelLoading
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcSFMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcSfMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcStorageTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcStorageTempBottom
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcStorageTempTop
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HydraulicScheme
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: ManualCoolingEndDate
+  fields:
+  - value
+  values:
+  - 01.01.2015
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: ManualCoolingEndDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: ManualCoolingStartDate
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: ManualCoolingStartDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: MaxCylinderChargeTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: MaxRoomHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: MultiRelaySetting
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: OutsideTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: OutsideTempAvg
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySum
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHcLastMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHcThisMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHwcLastMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHwcThisMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: SystemFlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: WaterPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingManualTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingOpMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingSetbackTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1DayTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1HolidayTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1NightTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1OpMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoDuration
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoEndDate
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoEndTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1RoomTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1SFMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z2RoomTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: z1RoomHumidity
+  fields:
+  - value
+  values:
+  - '67'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: AdaptHeatCurve
+  fields:
+  - value
+  values:
+  - 'yes'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: AdaptHeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Config
+  fields:
+  - value
+  values:
+  - 03 01 01 00 00 00 ff ff 00
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CcTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Friday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Friday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Friday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Monday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Monday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Monday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Saturday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Saturday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Saturday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Sunday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Sunday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Sunday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Thursday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Timeframes
+  fields:
+  - value
+  values:
+  - 0;0;0;0;0;0;0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CcTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Tuesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Wednesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Clearerrorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: ContinuousHeating
+  fields:
+  - value
+  values:
+  - '-26'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: ContinuousHeating
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - -;-;-;-;-
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CylinderChargeHyst
+  fields:
+  - value
+  values:
+  - '7'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CylinderChargeHyst
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CylinderChargeOffset
+  fields:
+  - value
+  values:
+  - '10'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CylinderChargeOffset
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Date
+  fields:
+  - value
+  values:
+  - 08.09.2026
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Date
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: DisplayedOutsideTemp
+  fields:
+  - value
+  values:
+  - '15.957'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: FrostOverRideTime
+  fields:
+  - value
+  values:
+  - '4'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: FrostOverRideTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1AutoOffMode
+  fields:
+  - value
+  values:
+  - eco
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1AutoOffMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1CircuitType
+  fields:
+  - value
+  values:
+  - mixer
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1ExcessTemp
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1ExcessTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1FlowTemp
+  fields:
+  - value
+  values:
+  - '17.5'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1HeatCurve
+  fields:
+  - value
+  values:
+  - '0.8'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1HeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '40'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - '19'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - '19'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1MixerMovement
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1PumpStatus
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1PumpStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - thermostat
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1Status
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1SummerTempLimit
+  fields:
+  - value
+  values:
+  - '18'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1SummerTempLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2AutoOffMode
+  fields:
+  - value
+  values:
+  - eco
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2AutoOffMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2CircuitType
+  fields:
+  - value
+  values:
+  - inactive
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2ExcessTemp
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2ExcessTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2FlowTemp
+  fields:
+  - value
+  values:
+  - (empty for 3115b52406020002010800 / 0800020800ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2HeatCurve
+  fields:
+  - value
+  values:
+  - '0.6'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2HeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '55'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - '20'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - '15'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2MixerMovement
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2PumpStatus
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2PumpStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'off'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2Status
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2SummerTempLimit
+  fields:
+  - value
+  values:
+  - '16'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2SummerTempLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3AutoOffMode
+  fields:
+  - value
+  values:
+  - eco
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3AutoOffMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3CircuitType
+  fields:
+  - value
+  values:
+  - inactive
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3ExcessTemp
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3ExcessTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3FlowTemp
+  fields:
+  - value
+  values:
+  - (empty for 3115b52406020002020800 / 0800020800ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3HeatCurve
+  fields:
+  - value
+  values:
+  - '1.35'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3HeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '55'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - '20'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - '15'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3MixerMovement
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3PumpStatus
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3PumpStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'off'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3Status
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3SummerTempLimit
+  fields:
+  - value
+  values:
+  - '16'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3SummerTempLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HcStorageTempBottom
+  fields:
+  - value
+  values:
+  - (empty for f115b5240602000000a000 / 080000a000ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HcStorageTempTop
+  fields:
+  - value
+  values:
+  - (empty for f115b52406020000009f00 / 0800009f00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcBankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcBankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcBankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcBankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcFlowTemp
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcLockTime
+  fields:
+  - value
+  values:
+  - '60'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcLockTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcMaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '80'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcMaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcOpMode
+  fields:
+  - value
+  values:
+  - auto
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcOpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcParallelLoading
+  fields:
+  - value
+  values:
+  - 'off'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcParallelLoading
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcSFMode
+  fields:
+  - value
+  values:
+  - auto
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcSFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcStorageTemp
+  fields:
+  - value
+  values:
+  - (empty for 3115b52406020001000500 / 0800010500ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcStorageTempBottom
+  fields:
+  - value
+  values:
+  - (empty for f115b52406020000009e00 / 0800009e00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcStorageTempTop
+  fields:
+  - value
+  values:
+  - (empty for f115b52406020000009d00 / 0800009d00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTempDesired
+  fields:
+  - value
+  values:
+  - '55'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Config
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Friday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Friday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Friday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Monday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Monday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Monday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Saturday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Saturday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Saturday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Sunday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Sunday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Sunday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Thursday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Timeframes
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Tuesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Wednesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HydraulicScheme
+  fields:
+  - value
+  values:
+  - '8'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HydraulicScheme
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Installer1
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Installer1
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Installer2
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Installer2
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: KeyCodeforConfigMenu
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: KeyCodeforConfigMenu
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: MaintenanceDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: MaintenanceDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: MaintenanceDue
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: MaxCylinderChargeTime
+  fields:
+  - value
+  values:
+  - '90'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: MaxCylinderChargeTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: MaxRoomHumidity
+  fields:
+  - value
+  values:
+  - '50'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: MaxRoomHumidity
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: MultiRelaySetting
+  fields:
+  - value
+  values:
+  - '4'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: MultiRelaySetting
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: OutsideTempAvg
+  fields:
+  - value
+  values:
+  - '18.3398'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: OutsideTempAvg
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PhoneNumber1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PhoneNumber1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PhoneNumber2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PhoneNumber2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySum
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020000005c00 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHc
+  fields:
+  - value
+  values:
+  - '17'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: PrEnergySumHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHcLastMonth
+  fields:
+  - value
+  values:
+  - '11'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: PrEnergySumHcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHcThisMonth
+  fields:
+  - value
+  values:
+  - '2'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: PrEnergySumHcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHwc
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: PrEnergySumHwc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHwcLastMonth
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: PrEnergySumHwcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHwcThisMonth
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: PrEnergySumHwcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHwc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHwc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHwcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHwcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHwcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHwcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PumpAdditionalTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PumpAdditionalTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: SolarYieldTotal
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: SolarYieldTotal
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: SystemFlowTemp
+  fields:
+  - value
+  values:
+  - (empty for f115b52406020000004b00 / 0800004b00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Time
+  fields:
+  - value
+  values:
+  - '19:41:52'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Time
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: WaterPressure
+  fields:
+  - value
+  values:
+  - '1.8'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: YieldTotal
+  fields:
+  - value
+  values:
+  - '6'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: YieldTotal
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - '16'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1CoolingTemp
+  fields:
+  - value
+  values:
+  - '23'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1CoolingTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1DayTemp
+  fields:
+  - value
+  values:
+  - '16'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1HolidayTemp
+  fields:
+  - value
+  values:
+  - '15'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Name1
+  fields:
+  - value
+  values:
+  - Zone
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Name2
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for f115b52406020003001800 / 06030318003100)'
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1NightTemp
+  fields:
+  - value
+  values:
+  - '15'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1OpMode
+  fields:
+  - value
+  values:
+  - day
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1QuickVetoDuration
+  fields:
+  - value
+  values:
+  - '3'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1QuickVetoEndDate
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1QuickVetoEndTime
+  fields:
+  - value
+  values:
+  - 00:00:00
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1QuickVetoTemp
+  fields:
+  - value
+  values:
+  - '21'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1RoomTemp
+  fields:
+  - value
+  values:
+  - '22.475'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1SFMode
+  fields:
+  - value
+  values:
+  - auto
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Config
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Friday0
+  fields:
+  - value
+  values:
+  - 06:00;22:00;20.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Friday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Friday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Monday0
+  fields:
+  - value
+  values:
+  - 06:00;22:00;20.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Monday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Monday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Saturday0
+  fields:
+  - value
+  values:
+  - 07:30;23:30;20.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Saturday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Saturday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Sunday0
+  fields:
+  - value
+  values:
+  - 07:30;22:00;20.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Sunday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Sunday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Thursday0
+  fields:
+  - value
+  values:
+  - 06:00;22:00;20.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Timeframes
+  fields:
+  - value
+  values:
+  - 1;1;1;1;1;1;1
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Tuesday0
+  fields:
+  - value
+  values:
+  - 06:00;22:00;20.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Wednesday0
+  fields:
+  - value
+  values:
+  - 06:00;22:00;20.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2CoolingTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2CoolingTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2QuickVetoEndDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2QuickVetoEndTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2RoomTemp
+  fields:
+  - value
+  values:
+  - (empty for 3115b52406020003010f00 / 0802030f00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z2RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Config
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Friday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Friday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Friday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Monday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Monday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Monday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Saturday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Saturday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Saturday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Sunday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Sunday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Sunday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Thursday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Timeframes
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Tuesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Wednesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3QuickVetoEndDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3QuickVetoEndTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3RoomTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z3RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Config
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Friday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Friday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Friday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Monday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Monday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Monday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Saturday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Saturday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Saturday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Sunday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Sunday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Sunday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Thursday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Timeframes
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Tuesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Wednesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: BuildingCircuitFlow
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: BuildingCircuitPumpSpeed
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: CompressorHc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: CompressorHwc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHwc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: ConsumptionTotal
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CoolElecConsDay
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CoolElecConsTotal
+  fields:
+  - value
+  values:
+  - '32200'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CoolEnvYieldDay
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CoolEnvYieldMonth
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CoolEnvYieldTotal
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CopCooling
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CopCoolingMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CopHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CopHcMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CopHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CopHwcMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CurrentCompressorUtil
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CurrentConsumedPower
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CurrentYieldPower
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: DateTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: FlowTemperature
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: HcElecConsDay
+  fields:
+  - value
+  values:
+  - '122.594'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: HcElecConsTotal
+  fields:
+  - value
+  values:
+  - '10759.6'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: HoursCool
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: HwcElecConsDay
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: HwcElecConsTotal
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: LiveMonitorCurrentConsumedPower
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: PowerConsumptionHmu
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunDataAirInletTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataBuildingCPumpPower
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataCompressorInletTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataCompressorOutletTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataCompressorSpeed
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataEEVOutletTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataEEVPositionAbs
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataElectricPowerConsumption
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataFan1Speed
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataFan2Speed
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataHighPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataLowPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunDataReturnTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataStatuscode
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStats4PortValveHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStats4PortValveSwitches
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsBuildingCPumpStarts
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsBuildingPumpHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunStatsCompressorHc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunStatsCompressorHwc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHwc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorStarts
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsFan1Hours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsFan1Starts
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsFan2Hours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsFan2Starts
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsHMUHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsHcHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsHwcHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: SourceTempInput
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: SourceTempOutput
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatElectricEnergySum
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatElectricEnergySumCool
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatElectricEnergySumHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatElectricEnergySumHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatEnvironmentEnergySum
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatEnvironmentEnergySumCool
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatEnvironmentEnergySumHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatEnvironmentEnergySumHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatSolarEnergySum
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatSolarEnergySumHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatSolarEnergySumHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.pumpstate
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.temp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.temp_1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.temp_2
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: Status01.temp_3
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: Status01.temp_4
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: StatusCirPump
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: SupplyTempWeighted
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: TotalEnergyUsage
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldCoolDay
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldCooling
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldCoolingMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldHcDay
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldHcMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldHwcDay
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldHwcMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmux0
+  name: Status01
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmux0
+  name: Status01.pumpstate
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmux0
+  name: Status01.temp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmux0
+  name: Status01.temp_1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmux0
+  name: Status01.temp_2
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmux0
+  name: Status01.temp_3
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmux0
+  name: Status01.temp_4
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: v32
+  name: BypassPosition
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: ExhaustAirHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: ExhaustAirTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: FanHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: FlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: FlowTempMax
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: HcHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: HoursTillService
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: HwcHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: HwcTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: v32
+  name: Maintenancedata_HwcTempMax
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: v32
+  name: MaxAirHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: MinAirHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: OutdoorstempSensor
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: v32
+  name: OutsideAirTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: PumpHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: PumpPower
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: ReturnTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: ReturnTempMax
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: Status02.hwcmode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: Status02.temp0
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: Status02.temp0_1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: Status02.temp1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: Status02.temp1_1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: StorageLoadPumpHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: StorageTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: StorageTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: SupplyAirTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: VentilationLevelDay
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: VentilationLevelNight
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldToday
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldTotal
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldYear
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Clearerrorhistory
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Mc1Operation
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Mc2Operation
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Mc3Operation
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: SensorData1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: SensorData2
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: SetActorState
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vwz
+  name: TestHwcTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: vwz
+  name: TestOutdoorTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: vwz
+  name: TestThreeWayValve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: vwzio
+  name: EnableTestHwcTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: EnableTestOutdoorTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: EnableTestThreeWayValve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: TestHwcTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: TestOutdoorTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: TestThreeWayValve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+raw_find_lines_after:
+- bai SetModeOverride = 0;0.0;-;-;-;1;1;1;0;0;0;0
+- Broadcast Datetime = no data stored
+- Broadcast Error = no data stored
+- Broadcast HwcStatus = no data stored
+- Broadcast Id = no data stored
+- Broadcast IdAnswer = no data stored
+- Broadcast IdQuery = no data stored
+- Broadcast Load = no data stored
+- Broadcast Outsidetemp = 15.957
+- Broadcast Queryexistence =  (empty for 31fe07fe00 / )
+- Broadcast Signoflife = no data stored
+- Broadcast Vdatetime = 20:13:01;08.09.2026
+- Broadcast Vdatetime = no data stored
+- 'ctlv2 Hc1DewPointTemp =  (ERR: invalid position for 3115b52406020002002300 / 00)'
+- 'ctlv2 Hc1FlowTempCalc =  (ERR: invalid position for 3115b52406020002002000 / 050102200001)'
+- 'ctlv2 Hc1Humidity =  (ERR: invalid position for 3115b52406020002002200 / 00)'
+- 'ctlv2 Hc1MixerPosition =  (ERR: invalid position for 3115b52406020002002100 / 00)'
+- 'ctlv2 Hc1PumpHours =  (ERR: invalid position for 3115b52406020002002400 / 00)'
+- 'ctlv2 Hc1PumpStarts =  (ERR: invalid position for 3115b52406020002002500 / 00)'
+- 'ctlv2 Hc2DewPointTemp =  (ERR: invalid position for 3115b52406020002012300 / 00)'
+- 'ctlv2 Hc2FlowTempCalc =  (ERR: invalid position for 3115b52406020002012000 / 050002200000)'
+- 'ctlv2 Hc2Humidity =  (ERR: invalid position for 3115b52406020002012200 / 00)'
+- 'ctlv2 Hc2MixerPosition =  (ERR: invalid position for 3115b52406020002012100 / 00)'
+- 'ctlv2 Hc2PumpHours =  (ERR: invalid position for 3115b52406020002012400 / 00)'
+- 'ctlv2 Hc2PumpStarts =  (ERR: invalid position for 3115b52406020002012500 / 00)'
+- ctlv2 ManualCoolingEndDate = 01.01.2015
+- ctlv2 ManualCoolingEndDate = no data stored
+- ctlv2 ManualCoolingStartDate = 01.01.2019
+- ctlv2 ManualCoolingStartDate = no data stored
+- ctlv2 z1RoomHumidity = 67
+- ctlv3 AdaptHeatCurve = yes
+- ctlv3 AdaptHeatCurve = no data stored
+- ctlv3 CcTimer_Config = 03 01 01 00 00 00 ff ff 00
+- ctlv3 CcTimer_Friday0 = no data stored
+- ctlv3 CcTimer_Friday1 = no data stored
+- ctlv3 CcTimer_Friday2 = no data stored
+- ctlv3 CcTimer_Friday = no data stored
+- ctlv3 CcTimer_Monday0 = no data stored
+- ctlv3 CcTimer_Monday1 = no data stored
+- ctlv3 CcTimer_Monday2 = no data stored
+- ctlv3 CcTimer_Monday = no data stored
+- ctlv3 CcTimer_Saturday0 = no data stored
+- ctlv3 CcTimer_Saturday1 = no data stored
+- ctlv3 CcTimer_Saturday2 = no data stored
+- ctlv3 CcTimer_Saturday = no data stored
+- ctlv3 CcTimer_Sunday0 = no data stored
+- ctlv3 CcTimer_Sunday1 = no data stored
+- ctlv3 CcTimer_Sunday2 = no data stored
+- ctlv3 CcTimer_Sunday = no data stored
+- ctlv3 CcTimer_Thursday0 = no data stored
+- ctlv3 CcTimer_Thursday1 = no data stored
+- ctlv3 CcTimer_Thursday2 = no data stored
+- ctlv3 CcTimer_Thursday = no data stored
+- ctlv3 CcTimer_Timeframes = 0;0;0;0;0;0;0
+- ctlv3 CcTimer_Tuesday0 = no data stored
+- ctlv3 CcTimer_Tuesday1 = no data stored
+- ctlv3 CcTimer_Tuesday2 = no data stored
+- ctlv3 CcTimer_Tuesday = no data stored
+- ctlv3 CcTimer_Wednesday0 = no data stored
+- ctlv3 CcTimer_Wednesday1 = no data stored
+- ctlv3 CcTimer_Wednesday2 = no data stored
+- ctlv3 CcTimer_Wednesday = no data stored
+- ctlv3 Clearerrorhistory = no data stored
+- ctlv3 ContinuousHeating = -26
+- ctlv3 ContinuousHeating = no data stored
+- ctlv3 Currenterror = -;-;-;-;-
+- ctlv3 CylinderChargeHyst = 7
+- ctlv3 CylinderChargeHyst = no data stored
+- ctlv3 CylinderChargeOffset = 10
+- ctlv3 CylinderChargeOffset = no data stored
+- ctlv3 Date = 08.09.2026
+- ctlv3 Date = no data stored
+- ctlv3 DisplayedOutsideTemp = 15.957
+- ctlv3 Errorhistory = no data stored
+- ctlv3 FrostOverRideTime = 4
+- ctlv3 FrostOverRideTime = no data stored
+- ctlv3 Hc1ActualFlowTempDesired = 0.0
+- ctlv3 Hc1AutoOffMode = eco
+- ctlv3 Hc1AutoOffMode = no data stored
+- ctlv3 Hc1CircuitType = mixer
+- ctlv3 Hc1ExcessTemp = 0.0
+- ctlv3 Hc1ExcessTemp = no data stored
+- ctlv3 Hc1FlowTemp = 17.5
+- ctlv3 Hc1HeatCurve = 0.8
+- ctlv3 Hc1HeatCurve = no data stored
+- ctlv3 Hc1HeatCurveAdaption = 0.0
+- ctlv3 Hc1MaxFlowTempDesired = 40
+- ctlv3 Hc1MaxFlowTempDesired = no data stored
+- ctlv3 Hc1MinCoolingTempDesired = 19
+- ctlv3 Hc1MinCoolingTempDesired = no data stored
+- ctlv3 Hc1MinFlowTempDesired = 19
+- ctlv3 Hc1MinFlowTempDesired = no data stored
+- ctlv3 Hc1MixerMovement = 0.0
+- ctlv3 Hc1PumpStatus = 0
+- ctlv3 Hc1PumpStatus = no data stored
+- ctlv3 Hc1RoomTempSwitchOn = thermostat
+- ctlv3 Hc1RoomTempSwitchOn = no data stored
+- ctlv3 Hc1Status = 0
+- ctlv3 Hc1Status = no data stored
+- ctlv3 Hc1SummerTempLimit = 18
+- ctlv3 Hc1SummerTempLimit = no data stored
+- ctlv3 Hc2ActualFlowTempDesired = 0.0
+- ctlv3 Hc2AutoOffMode = eco
+- ctlv3 Hc2AutoOffMode = no data stored
+- ctlv3 Hc2CircuitType = inactive
+- ctlv3 Hc2ExcessTemp = 0.0
+- ctlv3 Hc2ExcessTemp = no data stored
+- ctlv3 Hc2FlowTemp =  (empty for 3115b52406020002010800 / 0800020800ffffff7f)
+- ctlv3 Hc2HeatCurve = 0.6
+- ctlv3 Hc2HeatCurve = no data stored
+- ctlv3 Hc2HeatCurveAdaption = 0.0
+- ctlv3 Hc2MaxFlowTempDesired = 55
+- ctlv3 Hc2MaxFlowTempDesired = no data stored
+- ctlv3 Hc2MinCoolingTempDesired = 20
+- ctlv3 Hc2MinCoolingTempDesired = no data stored
+- ctlv3 Hc2MinFlowTempDesired = 15
+- ctlv3 Hc2MinFlowTempDesired = no data stored
+- ctlv3 Hc2MixerMovement = 0.0
+- ctlv3 Hc2PumpStatus = 0
+- ctlv3 Hc2PumpStatus = no data stored
+- ctlv3 Hc2RoomTempSwitchOn = off
+- ctlv3 Hc2RoomTempSwitchOn = no data stored
+- ctlv3 Hc2Status = 0
+- ctlv3 Hc2Status = no data stored
+- ctlv3 Hc2SummerTempLimit = 16
+- ctlv3 Hc2SummerTempLimit = no data stored
+- ctlv3 Hc3ActualFlowTempDesired = 0.0
+- ctlv3 Hc3AutoOffMode = eco
+- ctlv3 Hc3AutoOffMode = no data stored
+- ctlv3 Hc3CircuitType = inactive
+- ctlv3 Hc3ExcessTemp = 0.0
+- ctlv3 Hc3ExcessTemp = no data stored
+- ctlv3 Hc3FlowTemp =  (empty for 3115b52406020002020800 / 0800020800ffffff7f)
+- ctlv3 Hc3HeatCurve = 1.35
+- ctlv3 Hc3HeatCurve = no data stored
+- ctlv3 Hc3HeatCurveAdaption = 0.0
+- ctlv3 Hc3MaxFlowTempDesired = 55
+- ctlv3 Hc3MaxFlowTempDesired = no data stored
+- ctlv3 Hc3MinCoolingTempDesired = 20
+- ctlv3 Hc3MinCoolingTempDesired = no data stored
+- ctlv3 Hc3MinFlowTempDesired = 15
+- ctlv3 Hc3MinFlowTempDesired = no data stored
+- ctlv3 Hc3MixerMovement = 0.0
+- ctlv3 Hc3PumpStatus = 0
+- ctlv3 Hc3PumpStatus = no data stored
+- ctlv3 Hc3RoomTempSwitchOn = off
+- ctlv3 Hc3RoomTempSwitchOn = no data stored
+- ctlv3 Hc3Status = 0
+- ctlv3 Hc3Status = no data stored
+- ctlv3 Hc3SummerTempLimit = 16
+- ctlv3 Hc3SummerTempLimit = no data stored
+- ctlv3 HcStorageTempBottom =  (empty for f115b5240602000000a000 / 080000a000ffffff7f)
+- ctlv3 HcStorageTempTop =  (empty for f115b52406020000009f00 / 0800009f00ffffff7f)
+- ctlv3 HwcBankHolidayEndPeriod = no data stored
+- ctlv3 HwcBankHolidayEndPeriod = no data stored
+- ctlv3 HwcBankHolidayStartPeriod = no data stored
+- ctlv3 HwcBankHolidayStartPeriod = no data stored
+- ctlv3 HwcFlowTemp = 0.0
+- ctlv3 HwcHolidayEndPeriod = 01.01.2019
+- ctlv3 HwcHolidayEndPeriod = no data stored
+- ctlv3 HwcHolidayStartPeriod = 01.01.2019
+- ctlv3 HwcHolidayStartPeriod = no data stored
+- ctlv3 HwcLockTime = 60
+- ctlv3 HwcLockTime = no data stored
+- ctlv3 HwcMaxFlowTempDesired = 80
+- ctlv3 HwcMaxFlowTempDesired = no data stored
+- ctlv3 HwcOpMode = auto
+- ctlv3 HwcOpMode = no data stored
+- ctlv3 HwcParallelLoading = off
+- ctlv3 HwcParallelLoading = no data stored
+- ctlv3 HwcSFMode = auto
+- ctlv3 HwcSFMode = no data stored
+- ctlv3 HwcStorageTemp =  (empty for 3115b52406020001000500 / 0800010500ffffff7f)
+- ctlv3 HwcStorageTempBottom =  (empty for f115b52406020000009e00 / 0800009e00ffffff7f)
+- ctlv3 HwcStorageTempTop =  (empty for f115b52406020000009d00 / 0800009d00ffffff7f)
+- ctlv3 HwcTempDesired = 55
+- ctlv3 HwcTempDesired = no data stored
+- ctlv3 HwcTimer_Config = no data stored
+- ctlv3 HwcTimer_Friday0 = no data stored
+- ctlv3 HwcTimer_Friday1 = no data stored
+- ctlv3 HwcTimer_Friday2 = no data stored
+- ctlv3 HwcTimer_Friday = no data stored
+- ctlv3 HwcTimer_Monday0 = no data stored
+- ctlv3 HwcTimer_Monday1 = no data stored
+- ctlv3 HwcTimer_Monday2 = no data stored
+- ctlv3 HwcTimer_Monday = no data stored
+- ctlv3 HwcTimer_Saturday0 = no data stored
+- ctlv3 HwcTimer_Saturday1 = no data stored
+- ctlv3 HwcTimer_Saturday2 = no data stored
+- ctlv3 HwcTimer_Saturday = no data stored
+- ctlv3 HwcTimer_Sunday0 = no data stored
+- ctlv3 HwcTimer_Sunday1 = no data stored
+- ctlv3 HwcTimer_Sunday2 = no data stored
+- ctlv3 HwcTimer_Sunday = no data stored
+- ctlv3 HwcTimer_Thursday0 = no data stored
+- ctlv3 HwcTimer_Thursday1 = no data stored
+- ctlv3 HwcTimer_Thursday2 = no data stored
+- ctlv3 HwcTimer_Thursday = no data stored
+- ctlv3 HwcTimer_Timeframes = no data stored
+- ctlv3 HwcTimer_Tuesday0 = no data stored
+- ctlv3 HwcTimer_Tuesday1 = no data stored
+- ctlv3 HwcTimer_Tuesday2 = no data stored
+- ctlv3 HwcTimer_Tuesday = no data stored
+- ctlv3 HwcTimer_Wednesday0 = no data stored
+- ctlv3 HwcTimer_Wednesday1 = no data stored
+- ctlv3 HwcTimer_Wednesday2 = no data stored
+- ctlv3 HwcTimer_Wednesday = no data stored
+- ctlv3 HydraulicScheme = 8
+- ctlv3 HydraulicScheme = no data stored
+- ctlv3 Installer1 = no data stored
+- ctlv3 Installer1 = no data stored
+- ctlv3 Installer2 = no data stored
+- ctlv3 Installer2 = no data stored
+- ctlv3 KeyCodeforConfigMenu = no data stored
+- ctlv3 KeyCodeforConfigMenu = no data stored
+- ctlv3 MaintenanceDate = no data stored
+- ctlv3 MaintenanceDate = no data stored
+- ctlv3 MaintenanceDue = no data stored
+- ctlv3 MaxCylinderChargeTime = 90
+- ctlv3 MaxCylinderChargeTime = no data stored
+- ctlv3 MaxRoomHumidity = 50
+- ctlv3 MaxRoomHumidity = no data stored
+- ctlv3 MultiRelaySetting = 4
+- ctlv3 MultiRelaySetting = no data stored
+- ctlv3 OutsideTempAvg = 18.3398
+- ctlv3 OutsideTempAvg = no data stored
+- ctlv3 PhoneNumber1 = no data stored
+- ctlv3 PhoneNumber1 = no data stored
+- ctlv3 PhoneNumber2 = no data stored
+- ctlv3 PhoneNumber2 = no data stored
+- 'ctlv3 PrEnergySum =  (ERR: invalid position for 3115b52406020000005c00 / 00)'
+- ctlv3 PrEnergySum = no data stored
+- ctlv3 PrEnergySumHc = 17
+- ctlv3 PrEnergySumHc = no data stored
+- ctlv3 PrEnergySumHcLastMonth = 11
+- ctlv3 PrEnergySumHcLastMonth = no data stored
+- ctlv3 PrEnergySumHcThisMonth = 2
+- ctlv3 PrEnergySumHcThisMonth = no data stored
+- ctlv3 PrEnergySumHwc = 0
+- ctlv3 PrEnergySumHwc = no data stored
+- ctlv3 PrEnergySumHwcLastMonth = 0
+- ctlv3 PrEnergySumHwcLastMonth = no data stored
+- ctlv3 PrEnergySumHwcThisMonth = 0
+- ctlv3 PrEnergySumHwcThisMonth = no data stored
+- ctlv3 PrFuelSum = no data stored
+- ctlv3 PrFuelSum = no data stored
+- ctlv3 PrFuelSumHc = no data stored
+- ctlv3 PrFuelSumHc = no data stored
+- ctlv3 PrFuelSumHcLastMonth = no data stored
+- ctlv3 PrFuelSumHcLastMonth = no data stored
+- ctlv3 PrFuelSumHcThisMonth = no data stored
+- ctlv3 PrFuelSumHcThisMonth = no data stored
+- ctlv3 PrFuelSumHwc = no data stored
+- ctlv3 PrFuelSumHwc = no data stored
+- ctlv3 PrFuelSumHwcLastMonth = no data stored
+- ctlv3 PrFuelSumHwcLastMonth = no data stored
+- ctlv3 PrFuelSumHwcThisMonth = no data stored
+- ctlv3 PrFuelSumHwcThisMonth = no data stored
+- ctlv3 PumpAdditionalTime = no data stored
+- ctlv3 PumpAdditionalTime = no data stored
+- ctlv3 SolarYieldTotal = no data stored
+- ctlv3 SolarYieldTotal = no data stored
+- ctlv3 SystemFlowTemp =  (empty for f115b52406020000004b00 / 0800004b00ffffff7f)
+- ctlv3 Time = 19:41:52
+- ctlv3 Time = no data stored
+- ctlv3 WaterPressure = 1.8
+- ctlv3 YieldTotal = 6
+- ctlv3 YieldTotal = no data stored
+- ctlv3 Z1ActualRoomTempDesired = 16
+- ctlv3 Z1ActualRoomTempDesired = no data stored
+- ctlv3 Z1BankHolidayEndPeriod = no data stored
+- ctlv3 Z1BankHolidayEndPeriod = no data stored
+- ctlv3 Z1BankHolidayStartPeriod = no data stored
+- ctlv3 Z1BankHolidayStartPeriod = no data stored
+- ctlv3 Z1CoolingTemp = 23
+- ctlv3 Z1CoolingTemp = no data stored
+- ctlv3 Z1DayTemp = 16
+- ctlv3 Z1DayTemp = no data stored
+- ctlv3 Z1HolidayEndPeriod = 01.01.2019
+- ctlv3 Z1HolidayEndPeriod = no data stored
+- ctlv3 Z1HolidayStartPeriod = 01.01.2019
+- ctlv3 Z1HolidayStartPeriod = no data stored
+- ctlv3 Z1HolidayTemp = 15
+- ctlv3 Z1HolidayTemp = no data stored
+- 'ctlv3 Z1Name1 = Zone '
+- ctlv3 Z1Name1 = no data stored
+- 'ctlv3 Z1Name2 =  (ERR: invalid position for f115b52406020003001800 / 06030318003100)'
+- ctlv3 Z1Name2 = no data stored
+- ctlv3 Z1NightTemp = 15
+- ctlv3 Z1NightTemp = no data stored
+- ctlv3 Z1OpMode = day
+- ctlv3 Z1OpMode = no data stored
+- ctlv3 Z1QuickVetoDuration = 3
+- ctlv3 Z1QuickVetoDuration = no data stored
+- ctlv3 Z1QuickVetoEndDate = 01.01.2019
+- ctlv3 Z1QuickVetoEndTime = 00:00:00
+- ctlv3 Z1QuickVetoTemp = 21
+- ctlv3 Z1QuickVetoTemp = no data stored
+- ctlv3 Z1RoomTemp = 22.475
+- ctlv3 Z1RoomZoneMapping = VRC700
+- ctlv3 Z1RoomZoneMapping = no data stored
+- ctlv3 Z1SFMode = auto
+- ctlv3 Z1SFMode = no data stored
+- ctlv3 Z1Shortname = no data stored
+- ctlv3 Z1Shortname = no data stored
+- ctlv3 Z1Timer_Config = no data stored
+- ctlv3 Z1Timer_Friday0 = 06:00;22:00;20.0
+- ctlv3 Z1Timer_Friday1 = no data stored
+- ctlv3 Z1Timer_Friday2 = no data stored
+- ctlv3 Z1Timer_Friday = no data stored
+- ctlv3 Z1Timer_Monday0 = 06:00;22:00;20.0
+- ctlv3 Z1Timer_Monday1 = no data stored
+- ctlv3 Z1Timer_Monday2 = no data stored
+- ctlv3 Z1Timer_Monday = no data stored
+- ctlv3 Z1Timer_Saturday0 = 07:30;23:30;20.0
+- ctlv3 Z1Timer_Saturday1 = no data stored
+- ctlv3 Z1Timer_Saturday2 = no data stored
+- ctlv3 Z1Timer_Saturday = no data stored
+- ctlv3 Z1Timer_Sunday0 = 07:30;22:00;20.0
+- ctlv3 Z1Timer_Sunday1 = no data stored
+- ctlv3 Z1Timer_Sunday2 = no data stored
+- ctlv3 Z1Timer_Sunday = no data stored
+- ctlv3 Z1Timer_Thursday0 = 06:00;22:00;20.0
+- ctlv3 Z1Timer_Thursday1 = no data stored
+- ctlv3 Z1Timer_Thursday2 = no data stored
+- ctlv3 Z1Timer_Thursday = no data stored
+- ctlv3 Z1Timer_Timeframes = 1;1;1;1;1;1;1
+- ctlv3 Z1Timer_Tuesday0 = 06:00;22:00;20.0
+- ctlv3 Z1Timer_Tuesday1 = no data stored
+- ctlv3 Z1Timer_Tuesday2 = no data stored
+- ctlv3 Z1Timer_Tuesday = no data stored
+- ctlv3 Z1Timer_Wednesday0 = 06:00;22:00;20.0
+- ctlv3 Z1Timer_Wednesday1 = no data stored
+- ctlv3 Z1Timer_Wednesday2 = no data stored
+- ctlv3 Z1Timer_Wednesday = no data stored
+- ctlv3 Z1ValveStatus = no data stored
+- ctlv3 Z1ValveStatus = no data stored
+- ctlv3 Z2ActualRoomTempDesired = no data stored
+- ctlv3 Z2ActualRoomTempDesired = no data stored
+- ctlv3 Z2BankHolidayEndPeriod = no data stored
+- ctlv3 Z2BankHolidayEndPeriod = no data stored
+- ctlv3 Z2BankHolidayStartPeriod = no data stored
+- ctlv3 Z2BankHolidayStartPeriod = no data stored
+- ctlv3 Z2CoolingTemp = no data stored
+- ctlv3 Z2CoolingTemp = no data stored
+- ctlv3 Z2DayTemp = no data stored
+- ctlv3 Z2DayTemp = no data stored
+- ctlv3 Z2HolidayEndPeriod = no data stored
+- ctlv3 Z2HolidayEndPeriod = no data stored
+- ctlv3 Z2HolidayStartPeriod = no data stored
+- ctlv3 Z2HolidayStartPeriod = no data stored
+- ctlv3 Z2HolidayTemp = no data stored
+- ctlv3 Z2HolidayTemp = no data stored
+- ctlv3 Z2Name1 = no data stored
+- ctlv3 Z2Name1 = no data stored
+- ctlv3 Z2Name2 = no data stored
+- ctlv3 Z2Name2 = no data stored
+- ctlv3 Z2NightTemp = no data stored
+- ctlv3 Z2NightTemp = no data stored
+- ctlv3 Z2OpMode = no data stored
+- ctlv3 Z2OpMode = no data stored
+- ctlv3 Z2QuickVetoDuration = no data stored
+- ctlv3 Z2QuickVetoDuration = no data stored
+- ctlv3 Z2QuickVetoEndDate = no data stored
+- ctlv3 Z2QuickVetoEndTime = no data stored
+- ctlv3 Z2QuickVetoTemp = no data stored
+- ctlv3 Z2QuickVetoTemp = no data stored
+- ctlv3 Z2RoomTemp =  (empty for 3115b52406020003010f00 / 0802030f00ffffff7f)
+- ctlv3 Z2RoomZoneMapping = none
+- ctlv3 Z2RoomZoneMapping = no data stored
+- ctlv3 Z2SFMode = no data stored
+- ctlv3 Z2SFMode = no data stored
+- ctlv3 Z2Shortname = no data stored
+- ctlv3 Z2Shortname = no data stored
+- ctlv3 Z2Timer_Config = no data stored
+- ctlv3 Z2Timer_Friday0 = no data stored
+- ctlv3 Z2Timer_Friday1 = no data stored
+- ctlv3 Z2Timer_Friday2 = no data stored
+- ctlv3 Z2Timer_Friday = no data stored
+- ctlv3 Z2Timer_Monday0 = no data stored
+- ctlv3 Z2Timer_Monday1 = no data stored
+- ctlv3 Z2Timer_Monday2 = no data stored
+- ctlv3 Z2Timer_Monday = no data stored
+- ctlv3 Z2Timer_Saturday0 = no data stored
+- ctlv3 Z2Timer_Saturday1 = no data stored
+- ctlv3 Z2Timer_Saturday2 = no data stored
+- ctlv3 Z2Timer_Saturday = no data stored
+- ctlv3 Z2Timer_Sunday0 = no data stored
+- ctlv3 Z2Timer_Sunday1 = no data stored
+- ctlv3 Z2Timer_Sunday2 = no data stored
+- ctlv3 Z2Timer_Sunday = no data stored
+- ctlv3 Z2Timer_Thursday0 = no data stored
+- ctlv3 Z2Timer_Thursday1 = no data stored
+- ctlv3 Z2Timer_Thursday2 = no data stored
+- ctlv3 Z2Timer_Thursday = no data stored
+- ctlv3 Z2Timer_Timeframes = no data stored
+- ctlv3 Z2Timer_Tuesday0 = no data stored
+- ctlv3 Z2Timer_Tuesday1 = no data stored
+- ctlv3 Z2Timer_Tuesday2 = no data stored
+- ctlv3 Z2Timer_Tuesday = no data stored
+- ctlv3 Z2Timer_Wednesday0 = no data stored
+- ctlv3 Z2Timer_Wednesday1 = no data stored
+- ctlv3 Z2Timer_Wednesday2 = no data stored
+- ctlv3 Z2Timer_Wednesday = no data stored
+- ctlv3 Z2ValveStatus = no data stored
+- ctlv3 Z2ValveStatus = no data stored
+- ctlv3 Z3ActualRoomTempDesired = no data stored
+- ctlv3 Z3ActualRoomTempDesired = no data stored
+- ctlv3 Z3BankHolidayEndPeriod = no data stored
+- ctlv3 Z3BankHolidayEndPeriod = no data stored
+- ctlv3 Z3BankHolidayStartPeriod = no data stored
+- ctlv3 Z3BankHolidayStartPeriod = no data stored
+- ctlv3 Z3DayTemp = no data stored
+- ctlv3 Z3DayTemp = no data stored
+- ctlv3 Z3HolidayEndPeriod = no data stored
+- ctlv3 Z3HolidayEndPeriod = no data stored
+- ctlv3 Z3HolidayStartPeriod = no data stored
+- ctlv3 Z3HolidayStartPeriod = no data stored
+- ctlv3 Z3HolidayTemp = no data stored
+- ctlv3 Z3HolidayTemp = no data stored
+- ctlv3 Z3Name1 = no data stored
+- ctlv3 Z3Name1 = no data stored
+- ctlv3 Z3Name2 = no data stored
+- ctlv3 Z3Name2 = no data stored
+- ctlv3 Z3NightTemp = no data stored
+- ctlv3 Z3NightTemp = no data stored
+- ctlv3 Z3OpMode = no data stored
+- ctlv3 Z3OpMode = no data stored
+- ctlv3 Z3QuickVetoDuration = no data stored
+- ctlv3 Z3QuickVetoDuration = no data stored
+- ctlv3 Z3QuickVetoEndDate = no data stored
+- ctlv3 Z3QuickVetoEndTime = no data stored
+- ctlv3 Z3QuickVetoTemp = no data stored
+- ctlv3 Z3QuickVetoTemp = no data stored
+- ctlv3 Z3RoomTemp = no data stored
+- ctlv3 Z3RoomZoneMapping = none
+- ctlv3 Z3RoomZoneMapping = no data stored
+- ctlv3 Z3SFMode = no data stored
+- ctlv3 Z3SFMode = no data stored
+- ctlv3 Z3Shortname = no data stored
+- ctlv3 Z3Shortname = no data stored
+- ctlv3 Z3Timer_Config = no data stored
+- ctlv3 Z3Timer_Friday0 = no data stored
+- ctlv3 Z3Timer_Friday1 = no data stored
+- ctlv3 Z3Timer_Friday2 = no data stored
+- ctlv3 Z3Timer_Friday = no data stored
+- ctlv3 Z3Timer_Monday0 = no data stored
+- ctlv3 Z3Timer_Monday1 = no data stored
+- ctlv3 Z3Timer_Monday2 = no data stored
+- ctlv3 Z3Timer_Monday = no data stored
+- ctlv3 Z3Timer_Saturday0 = no data stored
+- ctlv3 Z3Timer_Saturday1 = no data stored
+- ctlv3 Z3Timer_Saturday2 = no data stored
+- ctlv3 Z3Timer_Saturday = no data stored
+- ctlv3 Z3Timer_Sunday0 = no data stored
+- ctlv3 Z3Timer_Sunday1 = no data stored
+- ctlv3 Z3Timer_Sunday2 = no data stored
+- ctlv3 Z3Timer_Sunday = no data stored
+- ctlv3 Z3Timer_Thursday0 = no data stored
+- ctlv3 Z3Timer_Thursday1 = no data stored
+- ctlv3 Z3Timer_Thursday2 = no data stored
+- ctlv3 Z3Timer_Thursday = no data stored
+- ctlv3 Z3Timer_Timeframes = no data stored
+- ctlv3 Z3Timer_Tuesday0 = no data stored
+- ctlv3 Z3Timer_Tuesday1 = no data stored
+- ctlv3 Z3Timer_Tuesday2 = no data stored
+- ctlv3 Z3Timer_Tuesday = no data stored
+- ctlv3 Z3Timer_Wednesday0 = no data stored
+- ctlv3 Z3Timer_Wednesday1 = no data stored
+- ctlv3 Z3Timer_Wednesday2 = no data stored
+- ctlv3 Z3Timer_Wednesday = no data stored
+- ctlv3 Z3ValveStatus = no data stored
+- ctlv3 Z3ValveStatus = no data stored
+- General Valuerange = no data stored
+- hmu CoolElecConsDay = 0.0
+- hmu CoolElecConsTotal = 32200
+- hmu CoolEnvYieldDay = 0.0
+- hmu CoolEnvYieldMonth = 0.0
+- hmu CoolEnvYieldTotal = 0.0
+- hmu HcElecConsDay = 122.594
+- hmu HcElecConsTotal = 10759.6
+- hmu HwcElecConsDay = 0.0
+- hmu HwcElecConsTotal = 0.0
+- 'hmu SourceTempInput =  (ERR: invalid position for 3108b51a0405ff3222 / 02ff01)'
+- Memory Eeprom = no data stored
+- Memory Eeprom = no data stored
+- Memory Ram = no data stored
+- Memory Ram = no data stored
+- Scan Id = no data stored
+- scan.04  = Vaillant;NETX3;0129;0404
+- scan.08  = Vaillant;HMUX0;0406;0504
+- scan.15  = Vaillant;CTLV3;0808;8004
+- Scan.15 Id = 21;25;45;0020260913;0953;026479;N3
+- scan.76  = Vaillant;VWZIO;0406;0504
+- Scan.76 Id = 21;26;03;8000035574;0001;005739;N8
+- scan.f6  = Vaillant;NETX3;0129;0404
+- Scan.f6 Id = 21;26;10;0020292012;0933;049007;N4
+- vwzio EnableTestHwcTemp = no data stored
+- vwzio EnableTestOutdoorTemp = no data stored
+- vwzio EnableTestThreeWayValve = no data stored
+- vwzio TestHwcTemp = no data stored
+- vwzio TestOutdoorTemp = no data stored
+- vwzio TestThreeWayValve = no data stored
+- ''

--- a/tests/fixtures/community/arotherm_pro7_quiet_on_heating_discovery.yaml
+++ b/tests/fixtures/community/arotherm_pro7_quiet_on_heating_discovery.yaml
@@ -1,0 +1,13954 @@
+# Discovery dump for vaillant_ebus
+# Review this file for sensitive information before sharing
+metadata:
+  timestamp: '2026-09-08T20:36:41.330529'
+  ebusd_version: ebusd 26.1.26.1
+  register_count: 762
+  grab_duration: 10
+  dump_version: 3
+raw_find_lines:
+- bai SetModeOverride = 0;40.0;-;-;-;0;1;1;0;0;0;0
+- Broadcast Datetime = no data stored
+- Broadcast Error = no data stored
+- Broadcast HwcStatus = no data stored
+- Broadcast Id = no data stored
+- Broadcast IdAnswer = no data stored
+- Broadcast IdQuery = no data stored
+- Broadcast Load = no data stored
+- Broadcast Outsidetemp = 15.754
+- Broadcast Queryexistence =  (empty for 31fe07fe00 / )
+- Broadcast Signoflife = no data stored
+- Broadcast Vdatetime = 20:34:59;08.09.2026
+- Broadcast Vdatetime = no data stored
+- 'ctlv2 Hc1DewPointTemp =  (ERR: invalid position for 3115b52406020002002300 / 00)'
+- 'ctlv2 Hc1FlowTempCalc =  (ERR: invalid position for 3115b52406020002002000 / 050102200001)'
+- 'ctlv2 Hc1Humidity =  (ERR: invalid position for 3115b52406020002002200 / 00)'
+- 'ctlv2 Hc1MixerPosition =  (ERR: invalid position for 3115b52406020002002100 / 00)'
+- 'ctlv2 Hc1PumpHours =  (ERR: invalid position for 3115b52406020002002400 / 00)'
+- 'ctlv2 Hc1PumpStarts =  (ERR: invalid position for 3115b52406020002002500 / 00)'
+- 'ctlv2 Hc2DewPointTemp =  (ERR: invalid position for 3115b52406020002012300 / 00)'
+- 'ctlv2 Hc2FlowTempCalc =  (ERR: invalid position for 3115b52406020002012000 / 050002200000)'
+- 'ctlv2 Hc2Humidity =  (ERR: invalid position for 3115b52406020002012200 / 00)'
+- 'ctlv2 Hc2MixerPosition =  (ERR: invalid position for 3115b52406020002012100 / 00)'
+- 'ctlv2 Hc2PumpHours =  (ERR: invalid position for 3115b52406020002012400 / 00)'
+- 'ctlv2 Hc2PumpStarts =  (ERR: invalid position for 3115b52406020002012500 / 00)'
+- ctlv2 ManualCoolingEndDate = 01.01.2015
+- ctlv2 ManualCoolingEndDate = no data stored
+- ctlv2 ManualCoolingStartDate = 01.01.2019
+- ctlv2 ManualCoolingStartDate = no data stored
+- ctlv2 z1RoomHumidity = 67
+- ctlv3 AdaptHeatCurve = yes
+- ctlv3 AdaptHeatCurve = no data stored
+- ctlv3 CcTimer_Config = 03 01 01 00 00 00 ff ff 00
+- ctlv3 CcTimer_Friday0 = no data stored
+- ctlv3 CcTimer_Friday1 = no data stored
+- ctlv3 CcTimer_Friday2 = no data stored
+- ctlv3 CcTimer_Friday = no data stored
+- ctlv3 CcTimer_Monday0 = no data stored
+- ctlv3 CcTimer_Monday1 = no data stored
+- ctlv3 CcTimer_Monday2 = no data stored
+- ctlv3 CcTimer_Monday = no data stored
+- ctlv3 CcTimer_Saturday0 = no data stored
+- ctlv3 CcTimer_Saturday1 = no data stored
+- ctlv3 CcTimer_Saturday2 = no data stored
+- ctlv3 CcTimer_Saturday = no data stored
+- ctlv3 CcTimer_Sunday0 = no data stored
+- ctlv3 CcTimer_Sunday1 = no data stored
+- ctlv3 CcTimer_Sunday2 = no data stored
+- ctlv3 CcTimer_Sunday = no data stored
+- ctlv3 CcTimer_Thursday0 = no data stored
+- ctlv3 CcTimer_Thursday1 = no data stored
+- ctlv3 CcTimer_Thursday2 = no data stored
+- ctlv3 CcTimer_Thursday = no data stored
+- ctlv3 CcTimer_Timeframes = 0;0;0;0;0;0;0
+- ctlv3 CcTimer_Tuesday0 = no data stored
+- ctlv3 CcTimer_Tuesday1 = no data stored
+- ctlv3 CcTimer_Tuesday2 = no data stored
+- ctlv3 CcTimer_Tuesday = no data stored
+- ctlv3 CcTimer_Wednesday0 = no data stored
+- ctlv3 CcTimer_Wednesday1 = no data stored
+- ctlv3 CcTimer_Wednesday2 = no data stored
+- ctlv3 CcTimer_Wednesday = no data stored
+- ctlv3 Clearerrorhistory = no data stored
+- ctlv3 ContinuousHeating = -26
+- ctlv3 ContinuousHeating = no data stored
+- ctlv3 Currenterror = -;-;-;-;-
+- ctlv3 CylinderChargeHyst = 7
+- ctlv3 CylinderChargeHyst = no data stored
+- ctlv3 CylinderChargeOffset = 10
+- ctlv3 CylinderChargeOffset = no data stored
+- ctlv3 Date = 08.09.2026
+- ctlv3 Date = no data stored
+- ctlv3 DisplayedOutsideTemp = 15.7539
+- ctlv3 Errorhistory = no data stored
+- ctlv3 FrostOverRideTime = 4
+- ctlv3 FrostOverRideTime = no data stored
+- ctlv3 Hc1ActualFlowTempDesired = 40
+- ctlv3 Hc1AutoOffMode = eco
+- ctlv3 Hc1AutoOffMode = no data stored
+- ctlv3 Hc1CircuitType = mixer
+- ctlv3 Hc1ExcessTemp = 0.0
+- ctlv3 Hc1ExcessTemp = no data stored
+- ctlv3 Hc1FlowTemp = 30.5
+- ctlv3 Hc1HeatCurve = 0.8
+- ctlv3 Hc1HeatCurve = no data stored
+- ctlv3 Hc1HeatCurveAdaption = 0.0
+- ctlv3 Hc1MaxFlowTempDesired = 40
+- ctlv3 Hc1MaxFlowTempDesired = no data stored
+- ctlv3 Hc1MinCoolingTempDesired = 19
+- ctlv3 Hc1MinCoolingTempDesired = no data stored
+- ctlv3 Hc1MinFlowTempDesired = 35
+- ctlv3 Hc1MinFlowTempDesired = no data stored
+- ctlv3 Hc1MixerMovement = 0.0
+- ctlv3 Hc1PumpStatus = 1
+- ctlv3 Hc1PumpStatus = no data stored
+- ctlv3 Hc1RoomTempSwitchOn = thermostat
+- ctlv3 Hc1RoomTempSwitchOn = no data stored
+- ctlv3 Hc1Status = 1
+- ctlv3 Hc1Status = no data stored
+- ctlv3 Hc1SummerTempLimit = 18
+- ctlv3 Hc1SummerTempLimit = no data stored
+- ctlv3 Hc2ActualFlowTempDesired = 0.0
+- ctlv3 Hc2AutoOffMode = eco
+- ctlv3 Hc2AutoOffMode = no data stored
+- ctlv3 Hc2CircuitType = inactive
+- ctlv3 Hc2ExcessTemp = 0.0
+- ctlv3 Hc2ExcessTemp = no data stored
+- ctlv3 Hc2FlowTemp =  (empty for 3115b52406020002010800 / 0800020800ffffff7f)
+- ctlv3 Hc2HeatCurve = 0.6
+- ctlv3 Hc2HeatCurve = no data stored
+- ctlv3 Hc2HeatCurveAdaption = 0.0
+- ctlv3 Hc2MaxFlowTempDesired = 55
+- ctlv3 Hc2MaxFlowTempDesired = no data stored
+- ctlv3 Hc2MinCoolingTempDesired = 20
+- ctlv3 Hc2MinCoolingTempDesired = no data stored
+- ctlv3 Hc2MinFlowTempDesired = 15
+- ctlv3 Hc2MinFlowTempDesired = no data stored
+- ctlv3 Hc2MixerMovement = 0.0
+- ctlv3 Hc2PumpStatus = 0
+- ctlv3 Hc2PumpStatus = no data stored
+- ctlv3 Hc2RoomTempSwitchOn = off
+- ctlv3 Hc2RoomTempSwitchOn = no data stored
+- ctlv3 Hc2Status = 0
+- ctlv3 Hc2Status = no data stored
+- ctlv3 Hc2SummerTempLimit = 16
+- ctlv3 Hc2SummerTempLimit = no data stored
+- ctlv3 Hc3ActualFlowTempDesired = 0.0
+- ctlv3 Hc3AutoOffMode = eco
+- ctlv3 Hc3AutoOffMode = no data stored
+- ctlv3 Hc3CircuitType = inactive
+- ctlv3 Hc3ExcessTemp = 0.0
+- ctlv3 Hc3ExcessTemp = no data stored
+- ctlv3 Hc3FlowTemp =  (empty for 3115b52406020002020800 / 0800020800ffffff7f)
+- ctlv3 Hc3HeatCurve = 1.35
+- ctlv3 Hc3HeatCurve = no data stored
+- ctlv3 Hc3HeatCurveAdaption = 0.0
+- ctlv3 Hc3MaxFlowTempDesired = 55
+- ctlv3 Hc3MaxFlowTempDesired = no data stored
+- ctlv3 Hc3MinCoolingTempDesired = 20
+- ctlv3 Hc3MinCoolingTempDesired = no data stored
+- ctlv3 Hc3MinFlowTempDesired = 15
+- ctlv3 Hc3MinFlowTempDesired = no data stored
+- ctlv3 Hc3MixerMovement = 0.0
+- ctlv3 Hc3PumpStatus = 0
+- ctlv3 Hc3PumpStatus = no data stored
+- ctlv3 Hc3RoomTempSwitchOn = off
+- ctlv3 Hc3RoomTempSwitchOn = no data stored
+- ctlv3 Hc3Status = 0
+- ctlv3 Hc3Status = no data stored
+- ctlv3 Hc3SummerTempLimit = 16
+- ctlv3 Hc3SummerTempLimit = no data stored
+- ctlv3 HcStorageTempBottom =  (empty for f115b5240602000000a000 / 080000a000ffffff7f)
+- ctlv3 HcStorageTempTop =  (empty for f115b52406020000009f00 / 0800009f00ffffff7f)
+- ctlv3 HwcBankHolidayEndPeriod = no data stored
+- ctlv3 HwcBankHolidayEndPeriod = no data stored
+- ctlv3 HwcBankHolidayStartPeriod = no data stored
+- ctlv3 HwcBankHolidayStartPeriod = no data stored
+- ctlv3 HwcFlowTemp = 0.0
+- ctlv3 HwcHolidayEndPeriod = 01.01.2019
+- ctlv3 HwcHolidayEndPeriod = no data stored
+- ctlv3 HwcHolidayStartPeriod = 01.01.2019
+- ctlv3 HwcHolidayStartPeriod = no data stored
+- ctlv3 HwcLockTime = 60
+- ctlv3 HwcLockTime = no data stored
+- ctlv3 HwcMaxFlowTempDesired = 80
+- ctlv3 HwcMaxFlowTempDesired = no data stored
+- ctlv3 HwcOpMode = auto
+- ctlv3 HwcOpMode = no data stored
+- ctlv3 HwcParallelLoading = off
+- ctlv3 HwcParallelLoading = no data stored
+- ctlv3 HwcSFMode = auto
+- ctlv3 HwcSFMode = no data stored
+- ctlv3 HwcStorageTemp =  (empty for 3115b52406020001000500 / 0800010500ffffff7f)
+- ctlv3 HwcStorageTempBottom =  (empty for f115b52406020000009e00 / 0800009e00ffffff7f)
+- ctlv3 HwcStorageTempTop =  (empty for f115b52406020000009d00 / 0800009d00ffffff7f)
+- ctlv3 HwcTempDesired = 55
+- ctlv3 HwcTempDesired = no data stored
+- ctlv3 HwcTimer_Config = no data stored
+- ctlv3 HwcTimer_Friday0 = no data stored
+- ctlv3 HwcTimer_Friday1 = no data stored
+- ctlv3 HwcTimer_Friday2 = no data stored
+- ctlv3 HwcTimer_Friday = no data stored
+- ctlv3 HwcTimer_Monday0 = no data stored
+- ctlv3 HwcTimer_Monday1 = no data stored
+- ctlv3 HwcTimer_Monday2 = no data stored
+- ctlv3 HwcTimer_Monday = no data stored
+- ctlv3 HwcTimer_Saturday0 = no data stored
+- ctlv3 HwcTimer_Saturday1 = no data stored
+- ctlv3 HwcTimer_Saturday2 = no data stored
+- ctlv3 HwcTimer_Saturday = no data stored
+- ctlv3 HwcTimer_Sunday0 = no data stored
+- ctlv3 HwcTimer_Sunday1 = no data stored
+- ctlv3 HwcTimer_Sunday2 = no data stored
+- ctlv3 HwcTimer_Sunday = no data stored
+- ctlv3 HwcTimer_Thursday0 = no data stored
+- ctlv3 HwcTimer_Thursday1 = no data stored
+- ctlv3 HwcTimer_Thursday2 = no data stored
+- ctlv3 HwcTimer_Thursday = no data stored
+- ctlv3 HwcTimer_Timeframes = no data stored
+- ctlv3 HwcTimer_Tuesday0 = no data stored
+- ctlv3 HwcTimer_Tuesday1 = no data stored
+- ctlv3 HwcTimer_Tuesday2 = no data stored
+- ctlv3 HwcTimer_Tuesday = no data stored
+- ctlv3 HwcTimer_Wednesday0 = no data stored
+- ctlv3 HwcTimer_Wednesday1 = no data stored
+- ctlv3 HwcTimer_Wednesday2 = no data stored
+- ctlv3 HwcTimer_Wednesday = no data stored
+- ctlv3 HydraulicScheme = 8
+- ctlv3 HydraulicScheme = no data stored
+- ctlv3 Installer1 = no data stored
+- ctlv3 Installer1 = no data stored
+- ctlv3 Installer2 = no data stored
+- ctlv3 Installer2 = no data stored
+- ctlv3 KeyCodeforConfigMenu = no data stored
+- ctlv3 KeyCodeforConfigMenu = no data stored
+- ctlv3 MaintenanceDate = no data stored
+- ctlv3 MaintenanceDate = no data stored
+- ctlv3 MaintenanceDue = no data stored
+- ctlv3 MaxCylinderChargeTime = 90
+- ctlv3 MaxCylinderChargeTime = no data stored
+- ctlv3 MaxRoomHumidity = 50
+- ctlv3 MaxRoomHumidity = no data stored
+- ctlv3 MultiRelaySetting = 4
+- ctlv3 MultiRelaySetting = no data stored
+- ctlv3 OutsideTempAvg = 18.3398
+- ctlv3 OutsideTempAvg = no data stored
+- ctlv3 PhoneNumber1 = no data stored
+- ctlv3 PhoneNumber1 = no data stored
+- ctlv3 PhoneNumber2 = no data stored
+- ctlv3 PhoneNumber2 = no data stored
+- 'ctlv3 PrEnergySum =  (ERR: invalid position for 3115b52406020000005c00 / 00)'
+- ctlv3 PrEnergySum = no data stored
+- ctlv3 PrEnergySumHc = 17
+- ctlv3 PrEnergySumHc = no data stored
+- ctlv3 PrEnergySumHcLastMonth = 11
+- ctlv3 PrEnergySumHcLastMonth = no data stored
+- ctlv3 PrEnergySumHcThisMonth = 2
+- ctlv3 PrEnergySumHcThisMonth = no data stored
+- ctlv3 PrEnergySumHwc = 0
+- ctlv3 PrEnergySumHwc = no data stored
+- ctlv3 PrEnergySumHwcLastMonth = 0
+- ctlv3 PrEnergySumHwcLastMonth = no data stored
+- ctlv3 PrEnergySumHwcThisMonth = 0
+- ctlv3 PrEnergySumHwcThisMonth = no data stored
+- ctlv3 PrFuelSum = no data stored
+- ctlv3 PrFuelSum = no data stored
+- ctlv3 PrFuelSumHc = no data stored
+- ctlv3 PrFuelSumHc = no data stored
+- ctlv3 PrFuelSumHcLastMonth = no data stored
+- ctlv3 PrFuelSumHcLastMonth = no data stored
+- ctlv3 PrFuelSumHcThisMonth = no data stored
+- ctlv3 PrFuelSumHcThisMonth = no data stored
+- ctlv3 PrFuelSumHwc = no data stored
+- ctlv3 PrFuelSumHwc = no data stored
+- ctlv3 PrFuelSumHwcLastMonth = no data stored
+- ctlv3 PrFuelSumHwcLastMonth = no data stored
+- ctlv3 PrFuelSumHwcThisMonth = no data stored
+- ctlv3 PrFuelSumHwcThisMonth = no data stored
+- ctlv3 PumpAdditionalTime = no data stored
+- ctlv3 PumpAdditionalTime = no data stored
+- ctlv3 SolarYieldTotal = no data stored
+- ctlv3 SolarYieldTotal = no data stored
+- ctlv3 SystemFlowTemp =  (empty for f115b52406020000004b00 / 0800004b00ffffff7f)
+- ctlv3 Time = 19:41:52
+- ctlv3 Time = no data stored
+- ctlv3 WaterPressure = 2
+- ctlv3 YieldTotal = 6
+- ctlv3 YieldTotal = no data stored
+- ctlv3 Z1ActualRoomTempDesired = 26
+- ctlv3 Z1ActualRoomTempDesired = no data stored
+- ctlv3 Z1BankHolidayEndPeriod = no data stored
+- ctlv3 Z1BankHolidayEndPeriod = no data stored
+- ctlv3 Z1BankHolidayStartPeriod = no data stored
+- ctlv3 Z1BankHolidayStartPeriod = no data stored
+- ctlv3 Z1CoolingTemp = 23
+- ctlv3 Z1CoolingTemp = no data stored
+- ctlv3 Z1DayTemp = 26
+- ctlv3 Z1DayTemp = no data stored
+- ctlv3 Z1HolidayEndPeriod = 01.01.2019
+- ctlv3 Z1HolidayEndPeriod = no data stored
+- ctlv3 Z1HolidayStartPeriod = 01.01.2019
+- ctlv3 Z1HolidayStartPeriod = no data stored
+- ctlv3 Z1HolidayTemp = 15
+- ctlv3 Z1HolidayTemp = no data stored
+- 'ctlv3 Z1Name1 = Zone '
+- ctlv3 Z1Name1 = no data stored
+- 'ctlv3 Z1Name2 =  (ERR: invalid position for f115b52406020003001800 / 06030318003100)'
+- ctlv3 Z1Name2 = no data stored
+- ctlv3 Z1NightTemp = 15
+- ctlv3 Z1NightTemp = no data stored
+- ctlv3 Z1OpMode = day
+- ctlv3 Z1OpMode = no data stored
+- ctlv3 Z1QuickVetoDuration = 3
+- ctlv3 Z1QuickVetoDuration = no data stored
+- ctlv3 Z1QuickVetoEndDate = 01.01.2019
+- ctlv3 Z1QuickVetoEndTime = 00:00:00
+- ctlv3 Z1QuickVetoTemp = 21
+- ctlv3 Z1QuickVetoTemp = no data stored
+- ctlv3 Z1RoomTemp = 22.5375
+- ctlv3 Z1RoomZoneMapping = VRC700
+- ctlv3 Z1RoomZoneMapping = no data stored
+- ctlv3 Z1SFMode = auto
+- ctlv3 Z1SFMode = no data stored
+- ctlv3 Z1Shortname = no data stored
+- ctlv3 Z1Shortname = no data stored
+- ctlv3 Z1Timer_Config = no data stored
+- ctlv3 Z1Timer_Friday0 = 06:00;22:00;20.0
+- ctlv3 Z1Timer_Friday1 = no data stored
+- ctlv3 Z1Timer_Friday2 = no data stored
+- ctlv3 Z1Timer_Friday = no data stored
+- ctlv3 Z1Timer_Monday0 = 06:00;22:00;20.0
+- ctlv3 Z1Timer_Monday1 = no data stored
+- ctlv3 Z1Timer_Monday2 = no data stored
+- ctlv3 Z1Timer_Monday = no data stored
+- ctlv3 Z1Timer_Saturday0 = 07:30;23:30;20.0
+- ctlv3 Z1Timer_Saturday1 = no data stored
+- ctlv3 Z1Timer_Saturday2 = no data stored
+- ctlv3 Z1Timer_Saturday = no data stored
+- ctlv3 Z1Timer_Sunday0 = 07:30;22:00;20.0
+- ctlv3 Z1Timer_Sunday1 = no data stored
+- ctlv3 Z1Timer_Sunday2 = no data stored
+- ctlv3 Z1Timer_Sunday = no data stored
+- ctlv3 Z1Timer_Thursday0 = 06:00;22:00;20.0
+- ctlv3 Z1Timer_Thursday1 = no data stored
+- ctlv3 Z1Timer_Thursday2 = no data stored
+- ctlv3 Z1Timer_Thursday = no data stored
+- ctlv3 Z1Timer_Timeframes = 1;1;1;1;1;1;1
+- ctlv3 Z1Timer_Tuesday0 = 06:00;22:00;20.0
+- ctlv3 Z1Timer_Tuesday1 = no data stored
+- ctlv3 Z1Timer_Tuesday2 = no data stored
+- ctlv3 Z1Timer_Tuesday = no data stored
+- ctlv3 Z1Timer_Wednesday0 = 06:00;22:00;20.0
+- ctlv3 Z1Timer_Wednesday1 = no data stored
+- ctlv3 Z1Timer_Wednesday2 = no data stored
+- ctlv3 Z1Timer_Wednesday = no data stored
+- ctlv3 Z1ValveStatus = no data stored
+- ctlv3 Z1ValveStatus = no data stored
+- ctlv3 Z2ActualRoomTempDesired = no data stored
+- ctlv3 Z2ActualRoomTempDesired = no data stored
+- ctlv3 Z2BankHolidayEndPeriod = no data stored
+- ctlv3 Z2BankHolidayEndPeriod = no data stored
+- ctlv3 Z2BankHolidayStartPeriod = no data stored
+- ctlv3 Z2BankHolidayStartPeriod = no data stored
+- ctlv3 Z2CoolingTemp = no data stored
+- ctlv3 Z2CoolingTemp = no data stored
+- ctlv3 Z2DayTemp = no data stored
+- ctlv3 Z2DayTemp = no data stored
+- ctlv3 Z2HolidayEndPeriod = no data stored
+- ctlv3 Z2HolidayEndPeriod = no data stored
+- ctlv3 Z2HolidayStartPeriod = no data stored
+- ctlv3 Z2HolidayStartPeriod = no data stored
+- ctlv3 Z2HolidayTemp = no data stored
+- ctlv3 Z2HolidayTemp = no data stored
+- ctlv3 Z2Name1 = no data stored
+- ctlv3 Z2Name1 = no data stored
+- ctlv3 Z2Name2 = no data stored
+- ctlv3 Z2Name2 = no data stored
+- ctlv3 Z2NightTemp = no data stored
+- ctlv3 Z2NightTemp = no data stored
+- ctlv3 Z2OpMode = no data stored
+- ctlv3 Z2OpMode = no data stored
+- ctlv3 Z2QuickVetoDuration = no data stored
+- ctlv3 Z2QuickVetoDuration = no data stored
+- ctlv3 Z2QuickVetoEndDate = no data stored
+- ctlv3 Z2QuickVetoEndTime = no data stored
+- ctlv3 Z2QuickVetoTemp = no data stored
+- ctlv3 Z2QuickVetoTemp = no data stored
+- ctlv3 Z2RoomTemp =  (empty for 3115b52406020003010f00 / 0802030f00ffffff7f)
+- ctlv3 Z2RoomZoneMapping = none
+- ctlv3 Z2RoomZoneMapping = no data stored
+- ctlv3 Z2SFMode = no data stored
+- ctlv3 Z2SFMode = no data stored
+- ctlv3 Z2Shortname = no data stored
+- ctlv3 Z2Shortname = no data stored
+- ctlv3 Z2Timer_Config = no data stored
+- ctlv3 Z2Timer_Friday0 = no data stored
+- ctlv3 Z2Timer_Friday1 = no data stored
+- ctlv3 Z2Timer_Friday2 = no data stored
+- ctlv3 Z2Timer_Friday = no data stored
+- ctlv3 Z2Timer_Monday0 = no data stored
+- ctlv3 Z2Timer_Monday1 = no data stored
+- ctlv3 Z2Timer_Monday2 = no data stored
+- ctlv3 Z2Timer_Monday = no data stored
+- ctlv3 Z2Timer_Saturday0 = no data stored
+- ctlv3 Z2Timer_Saturday1 = no data stored
+- ctlv3 Z2Timer_Saturday2 = no data stored
+- ctlv3 Z2Timer_Saturday = no data stored
+- ctlv3 Z2Timer_Sunday0 = no data stored
+- ctlv3 Z2Timer_Sunday1 = no data stored
+- ctlv3 Z2Timer_Sunday2 = no data stored
+- ctlv3 Z2Timer_Sunday = no data stored
+- ctlv3 Z2Timer_Thursday0 = no data stored
+- ctlv3 Z2Timer_Thursday1 = no data stored
+- ctlv3 Z2Timer_Thursday2 = no data stored
+- ctlv3 Z2Timer_Thursday = no data stored
+- ctlv3 Z2Timer_Timeframes = no data stored
+- ctlv3 Z2Timer_Tuesday0 = no data stored
+- ctlv3 Z2Timer_Tuesday1 = no data stored
+- ctlv3 Z2Timer_Tuesday2 = no data stored
+- ctlv3 Z2Timer_Tuesday = no data stored
+- ctlv3 Z2Timer_Wednesday0 = no data stored
+- ctlv3 Z2Timer_Wednesday1 = no data stored
+- ctlv3 Z2Timer_Wednesday2 = no data stored
+- ctlv3 Z2Timer_Wednesday = no data stored
+- ctlv3 Z2ValveStatus = no data stored
+- ctlv3 Z2ValveStatus = no data stored
+- ctlv3 Z3ActualRoomTempDesired = no data stored
+- ctlv3 Z3ActualRoomTempDesired = no data stored
+- ctlv3 Z3BankHolidayEndPeriod = no data stored
+- ctlv3 Z3BankHolidayEndPeriod = no data stored
+- ctlv3 Z3BankHolidayStartPeriod = no data stored
+- ctlv3 Z3BankHolidayStartPeriod = no data stored
+- ctlv3 Z3DayTemp = no data stored
+- ctlv3 Z3DayTemp = no data stored
+- ctlv3 Z3HolidayEndPeriod = no data stored
+- ctlv3 Z3HolidayEndPeriod = no data stored
+- ctlv3 Z3HolidayStartPeriod = no data stored
+- ctlv3 Z3HolidayStartPeriod = no data stored
+- ctlv3 Z3HolidayTemp = no data stored
+- ctlv3 Z3HolidayTemp = no data stored
+- ctlv3 Z3Name1 = no data stored
+- ctlv3 Z3Name1 = no data stored
+- ctlv3 Z3Name2 = no data stored
+- ctlv3 Z3Name2 = no data stored
+- ctlv3 Z3NightTemp = no data stored
+- ctlv3 Z3NightTemp = no data stored
+- ctlv3 Z3OpMode = no data stored
+- ctlv3 Z3OpMode = no data stored
+- ctlv3 Z3QuickVetoDuration = no data stored
+- ctlv3 Z3QuickVetoDuration = no data stored
+- ctlv3 Z3QuickVetoEndDate = no data stored
+- ctlv3 Z3QuickVetoEndTime = no data stored
+- ctlv3 Z3QuickVetoTemp = no data stored
+- ctlv3 Z3QuickVetoTemp = no data stored
+- ctlv3 Z3RoomTemp = no data stored
+- ctlv3 Z3RoomZoneMapping = none
+- ctlv3 Z3RoomZoneMapping = no data stored
+- ctlv3 Z3SFMode = no data stored
+- ctlv3 Z3SFMode = no data stored
+- ctlv3 Z3Shortname = no data stored
+- ctlv3 Z3Shortname = no data stored
+- ctlv3 Z3Timer_Config = no data stored
+- ctlv3 Z3Timer_Friday0 = no data stored
+- ctlv3 Z3Timer_Friday1 = no data stored
+- ctlv3 Z3Timer_Friday2 = no data stored
+- ctlv3 Z3Timer_Friday = no data stored
+- ctlv3 Z3Timer_Monday0 = no data stored
+- ctlv3 Z3Timer_Monday1 = no data stored
+- ctlv3 Z3Timer_Monday2 = no data stored
+- ctlv3 Z3Timer_Monday = no data stored
+- ctlv3 Z3Timer_Saturday0 = no data stored
+- ctlv3 Z3Timer_Saturday1 = no data stored
+- ctlv3 Z3Timer_Saturday2 = no data stored
+- ctlv3 Z3Timer_Saturday = no data stored
+- ctlv3 Z3Timer_Sunday0 = no data stored
+- ctlv3 Z3Timer_Sunday1 = no data stored
+- ctlv3 Z3Timer_Sunday2 = no data stored
+- ctlv3 Z3Timer_Sunday = no data stored
+- ctlv3 Z3Timer_Thursday0 = no data stored
+- ctlv3 Z3Timer_Thursday1 = no data stored
+- ctlv3 Z3Timer_Thursday2 = no data stored
+- ctlv3 Z3Timer_Thursday = no data stored
+- ctlv3 Z3Timer_Timeframes = no data stored
+- ctlv3 Z3Timer_Tuesday0 = no data stored
+- ctlv3 Z3Timer_Tuesday1 = no data stored
+- ctlv3 Z3Timer_Tuesday2 = no data stored
+- ctlv3 Z3Timer_Tuesday = no data stored
+- ctlv3 Z3Timer_Wednesday0 = no data stored
+- ctlv3 Z3Timer_Wednesday1 = no data stored
+- ctlv3 Z3Timer_Wednesday2 = no data stored
+- ctlv3 Z3Timer_Wednesday = no data stored
+- ctlv3 Z3ValveStatus = no data stored
+- ctlv3 Z3ValveStatus = no data stored
+- General Valuerange = no data stored
+- hmu CoolElecConsDay = 0.0
+- hmu CoolElecConsTotal = 32200
+- hmu CoolEnvYieldDay = 0.0
+- hmu CoolEnvYieldMonth = 0.0
+- hmu CoolEnvYieldTotal = 0.0
+- hmu HcElecConsDay = 297.978
+- hmu HcElecConsTotal = 10935
+- hmu HwcElecConsDay = 0.0
+- hmu HwcElecConsTotal = 0.0
+- 'hmu SourceTempInput =  (ERR: invalid position for 3108b51a0405ff3222 / 02ff01)'
+- Memory Eeprom = no data stored
+- Memory Eeprom = no data stored
+- Memory Ram = no data stored
+- Memory Ram = no data stored
+- Scan Id = no data stored
+- scan.04  = Vaillant;NETX3;0129;0404
+- scan.08  = Vaillant;HMUX0;0406;0504
+- scan.15  = Vaillant;CTLV3;0808;8004
+- Scan.15 Id = 21;25;45;0020260913;0953;026479;N3
+- scan.76  = Vaillant;VWZIO;0406;0504
+- Scan.76 Id = 21;26;03;8000035574;0001;005739;N8
+- scan.f6  = Vaillant;NETX3;0129;0404
+- Scan.f6 Id = 21;26;10;0020292012;0933;049007;N4
+- vwzio EnableTestHwcTemp = no data stored
+- vwzio EnableTestOutdoorTemp = no data stored
+- vwzio EnableTestThreeWayValve = no data stored
+- vwzio TestHwcTemp = no data stored
+- vwzio TestOutdoorTemp = no data stored
+- vwzio TestThreeWayValve = no data stored
+- ''
+before_registers:
+- circuit: Broadcast
+  name: Datetime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Error
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: Broadcast
+  name: HwcStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Id
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: IdAnswer
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: IdQuery
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Load
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Outsidetemp
+  fields:
+  - value
+  values:
+  - '15.754'
+  writable: false
+  has_data: true
+- circuit: Broadcast
+  name: Queryexistence
+  fields:
+  - value
+  values:
+  - (empty for 31fe07fe00 / )
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Signoflife
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Vdatetime
+  fields:
+  - value
+  values:
+  - 20:34:59;08.09.2026
+  writable: false
+  has_data: true
+- circuit: Broadcast
+  name: Vdatetime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: WaterPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: General
+  name: Valuerange
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Eeprom
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Eeprom
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Ram
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Ram
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Scan
+  name: Id
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Scan.15
+  name: Id
+  fields:
+  - value
+  values:
+  - 21;25;45;0020260913;0953;026479;N3
+  writable: false
+  has_data: true
+- circuit: Scan.76
+  name: Id
+  fields:
+  - value
+  values:
+  - 21;26;03;8000035574;0001;005739;N8
+  writable: false
+  has_data: true
+- circuit: Scan.f6
+  name: Id
+  fields:
+  - value
+  values:
+  - 21;26;10;0020292012;0933;049007;N4
+  writable: false
+  has_data: true
+- circuit: bai
+  name: ActiveStages
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: bai
+  name: FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: bai
+  name: FlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: bai
+  name: HeatingStage1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: bai
+  name: HeatingStage3
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: bai
+  name: PrEnergySumHc1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: bai
+  name: PrEnergySumHwc1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: bai
+  name: SetModeOverride
+  fields:
+  - value
+  values:
+  - 0;40.0;-;-;-;0;1;1;0;0;0;0
+  writable: false
+  has_data: true
+- circuit: bai
+  name: StorageTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: bai
+  name: StorageTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: bai
+  name: WaterPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: AdaptHeatCurve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: CcTimer_Config
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: CcTimer_Timeframes
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: ContinuousHeating
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: CylinderChargeHyst
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: CylinderChargeOffset
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Date
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: DisplayedOutsideTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: FrostOverRideTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1AutoOffMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1CircuitType
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1CoolingEnabled
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1CoolingFlowTempMin
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1DewPointMonitoring
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1DewPointOffset
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1DewPointTemp
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002300 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1ExcessTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1FlowTempCalc
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002000 / 050102200001)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1HeatCurve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1Humidity
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002200 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MixerMovement
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MixerPosition
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002100 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1PumpHours
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002400 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1PumpStarts
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002500 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1PumpStatus
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1RoomTempModulation
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1Status
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1SummerTempLimit
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2AutoOffMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2CircuitType
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2DewPointTemp
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012300 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2ExcessTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2FlowTempCalc
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012000 / 050002200000)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2HeatCurve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2Humidity
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012200 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MixerMovement
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MixerPosition
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012100 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2PumpHours
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012400 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2PumpStarts
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012500 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2PumpStatus
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2Status
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2SummerTempLimit
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3AutoOffMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3CircuitType
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3ExcessTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3HeatCurve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MixerMovement
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3PumpStatus
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3Status
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3SummerTempLimit
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HcStorageTempBottom
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: ctlv2
+  name: HcStorageTempTop
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: ctlv2
+  name: HwcFlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcLockTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcMaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcOpMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcParallelLoading
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcSFMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcSfMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcStorageTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcStorageTempBottom
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcStorageTempTop
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HydraulicScheme
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: ManualCoolingEndDate
+  fields:
+  - value
+  values:
+  - 01.01.2015
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: ManualCoolingEndDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: ManualCoolingStartDate
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: ManualCoolingStartDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: MaxCylinderChargeTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: MaxRoomHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: MultiRelaySetting
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: OutsideTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: OutsideTempAvg
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySum
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHcLastMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHcThisMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHwcLastMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHwcThisMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: SystemFlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: WaterPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingManualTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingOpMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingSetbackTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1DayTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1HolidayTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1NightTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1OpMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoDuration
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoEndDate
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoEndTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1RoomTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1SFMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z2RoomTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: z1RoomHumidity
+  fields:
+  - value
+  values:
+  - '67'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: AdaptHeatCurve
+  fields:
+  - value
+  values:
+  - 'yes'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: AdaptHeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Config
+  fields:
+  - value
+  values:
+  - 03 01 01 00 00 00 ff ff 00
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CcTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Friday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Friday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Friday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Monday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Monday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Monday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Saturday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Saturday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Saturday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Sunday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Sunday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Sunday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Thursday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Timeframes
+  fields:
+  - value
+  values:
+  - 0;0;0;0;0;0;0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CcTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Tuesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Wednesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Clearerrorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: ContinuousHeating
+  fields:
+  - value
+  values:
+  - '-26'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: ContinuousHeating
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - -;-;-;-;-
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CylinderChargeHyst
+  fields:
+  - value
+  values:
+  - '7'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CylinderChargeHyst
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CylinderChargeOffset
+  fields:
+  - value
+  values:
+  - '10'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CylinderChargeOffset
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Date
+  fields:
+  - value
+  values:
+  - 08.09.2026
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Date
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: DisplayedOutsideTemp
+  fields:
+  - value
+  values:
+  - '15.7539'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: FrostOverRideTime
+  fields:
+  - value
+  values:
+  - '4'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: FrostOverRideTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - '40'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1AutoOffMode
+  fields:
+  - value
+  values:
+  - eco
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1AutoOffMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1CircuitType
+  fields:
+  - value
+  values:
+  - mixer
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1ExcessTemp
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1ExcessTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1FlowTemp
+  fields:
+  - value
+  values:
+  - '30.5'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1HeatCurve
+  fields:
+  - value
+  values:
+  - '0.8'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1HeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '40'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - '19'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - '35'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1MixerMovement
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1PumpStatus
+  fields:
+  - value
+  values:
+  - '1'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1PumpStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - thermostat
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1Status
+  fields:
+  - value
+  values:
+  - '1'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1SummerTempLimit
+  fields:
+  - value
+  values:
+  - '18'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1SummerTempLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2AutoOffMode
+  fields:
+  - value
+  values:
+  - eco
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2AutoOffMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2CircuitType
+  fields:
+  - value
+  values:
+  - inactive
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2ExcessTemp
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2ExcessTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2FlowTemp
+  fields:
+  - value
+  values:
+  - (empty for 3115b52406020002010800 / 0800020800ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2HeatCurve
+  fields:
+  - value
+  values:
+  - '0.6'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2HeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '55'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - '20'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - '15'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2MixerMovement
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2PumpStatus
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2PumpStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'off'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2Status
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2SummerTempLimit
+  fields:
+  - value
+  values:
+  - '16'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2SummerTempLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3AutoOffMode
+  fields:
+  - value
+  values:
+  - eco
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3AutoOffMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3CircuitType
+  fields:
+  - value
+  values:
+  - inactive
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3ExcessTemp
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3ExcessTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3FlowTemp
+  fields:
+  - value
+  values:
+  - (empty for 3115b52406020002020800 / 0800020800ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3HeatCurve
+  fields:
+  - value
+  values:
+  - '1.35'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3HeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '55'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - '20'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - '15'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3MixerMovement
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3PumpStatus
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3PumpStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'off'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3Status
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3SummerTempLimit
+  fields:
+  - value
+  values:
+  - '16'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3SummerTempLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HcStorageTempBottom
+  fields:
+  - value
+  values:
+  - (empty for f115b5240602000000a000 / 080000a000ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HcStorageTempTop
+  fields:
+  - value
+  values:
+  - (empty for f115b52406020000009f00 / 0800009f00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcBankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcBankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcBankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcBankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcFlowTemp
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcLockTime
+  fields:
+  - value
+  values:
+  - '60'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcLockTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcMaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '80'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcMaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcOpMode
+  fields:
+  - value
+  values:
+  - auto
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcOpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcParallelLoading
+  fields:
+  - value
+  values:
+  - 'off'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcParallelLoading
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcSFMode
+  fields:
+  - value
+  values:
+  - auto
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcSFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcStorageTemp
+  fields:
+  - value
+  values:
+  - (empty for 3115b52406020001000500 / 0800010500ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcStorageTempBottom
+  fields:
+  - value
+  values:
+  - (empty for f115b52406020000009e00 / 0800009e00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcStorageTempTop
+  fields:
+  - value
+  values:
+  - (empty for f115b52406020000009d00 / 0800009d00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTempDesired
+  fields:
+  - value
+  values:
+  - '55'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Config
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Friday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Friday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Friday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Monday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Monday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Monday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Saturday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Saturday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Saturday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Sunday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Sunday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Sunday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Thursday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Timeframes
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Tuesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Wednesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HydraulicScheme
+  fields:
+  - value
+  values:
+  - '8'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HydraulicScheme
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Installer1
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Installer1
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Installer2
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Installer2
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: KeyCodeforConfigMenu
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: KeyCodeforConfigMenu
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: MaintenanceDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: MaintenanceDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: MaintenanceDue
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: MaxCylinderChargeTime
+  fields:
+  - value
+  values:
+  - '90'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: MaxCylinderChargeTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: MaxRoomHumidity
+  fields:
+  - value
+  values:
+  - '50'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: MaxRoomHumidity
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: MultiRelaySetting
+  fields:
+  - value
+  values:
+  - '4'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: MultiRelaySetting
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: OutsideTempAvg
+  fields:
+  - value
+  values:
+  - '18.3398'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: OutsideTempAvg
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PhoneNumber1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PhoneNumber1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PhoneNumber2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PhoneNumber2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySum
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020000005c00 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHc
+  fields:
+  - value
+  values:
+  - '17'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: PrEnergySumHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHcLastMonth
+  fields:
+  - value
+  values:
+  - '11'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: PrEnergySumHcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHcThisMonth
+  fields:
+  - value
+  values:
+  - '2'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: PrEnergySumHcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHwc
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: PrEnergySumHwc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHwcLastMonth
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: PrEnergySumHwcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHwcThisMonth
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: PrEnergySumHwcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHwc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHwc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHwcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHwcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHwcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHwcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PumpAdditionalTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PumpAdditionalTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: SolarYieldTotal
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: SolarYieldTotal
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: SystemFlowTemp
+  fields:
+  - value
+  values:
+  - (empty for f115b52406020000004b00 / 0800004b00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Time
+  fields:
+  - value
+  values:
+  - '19:41:52'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Time
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: WaterPressure
+  fields:
+  - value
+  values:
+  - '2'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: YieldTotal
+  fields:
+  - value
+  values:
+  - '6'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: YieldTotal
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - '26'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1CoolingTemp
+  fields:
+  - value
+  values:
+  - '23'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1CoolingTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1DayTemp
+  fields:
+  - value
+  values:
+  - '26'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1HolidayTemp
+  fields:
+  - value
+  values:
+  - '15'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Name1
+  fields:
+  - value
+  values:
+  - Zone
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Name2
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for f115b52406020003001800 / 06030318003100)'
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1NightTemp
+  fields:
+  - value
+  values:
+  - '15'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1OpMode
+  fields:
+  - value
+  values:
+  - day
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1QuickVetoDuration
+  fields:
+  - value
+  values:
+  - '3'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1QuickVetoEndDate
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1QuickVetoEndTime
+  fields:
+  - value
+  values:
+  - 00:00:00
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1QuickVetoTemp
+  fields:
+  - value
+  values:
+  - '21'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1RoomTemp
+  fields:
+  - value
+  values:
+  - '22.5375'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1SFMode
+  fields:
+  - value
+  values:
+  - auto
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Config
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Friday0
+  fields:
+  - value
+  values:
+  - 06:00;22:00;20.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Friday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Friday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Monday0
+  fields:
+  - value
+  values:
+  - 06:00;22:00;20.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Monday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Monday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Saturday0
+  fields:
+  - value
+  values:
+  - 07:30;23:30;20.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Saturday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Saturday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Sunday0
+  fields:
+  - value
+  values:
+  - 07:30;22:00;20.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Sunday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Sunday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Thursday0
+  fields:
+  - value
+  values:
+  - 06:00;22:00;20.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Timeframes
+  fields:
+  - value
+  values:
+  - 1;1;1;1;1;1;1
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Tuesday0
+  fields:
+  - value
+  values:
+  - 06:00;22:00;20.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Wednesday0
+  fields:
+  - value
+  values:
+  - 06:00;22:00;20.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2CoolingTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2CoolingTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2QuickVetoEndDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2QuickVetoEndTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2RoomTemp
+  fields:
+  - value
+  values:
+  - (empty for 3115b52406020003010f00 / 0802030f00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z2RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Config
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Friday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Friday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Friday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Monday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Monday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Monday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Saturday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Saturday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Saturday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Sunday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Sunday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Sunday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Thursday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Timeframes
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Tuesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Wednesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3QuickVetoEndDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3QuickVetoEndTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3RoomTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z3RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Config
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Friday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Friday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Friday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Monday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Monday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Monday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Saturday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Saturday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Saturday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Sunday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Sunday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Sunday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Thursday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Timeframes
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Tuesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Wednesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: BuildingCircuitFlow
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: BuildingCircuitPumpSpeed
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: CompressorHc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: CompressorHwc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHwc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: ConsumptionTotal
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CoolElecConsDay
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CoolElecConsTotal
+  fields:
+  - value
+  values:
+  - '32200'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CoolEnvYieldDay
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CoolEnvYieldMonth
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CoolEnvYieldTotal
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CopCooling
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CopCoolingMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CopHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CopHcMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CopHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CopHwcMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CurrentCompressorUtil
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CurrentConsumedPower
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CurrentYieldPower
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: DateTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: FlowTemperature
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: HcElecConsDay
+  fields:
+  - value
+  values:
+  - '297.978'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: HcElecConsTotal
+  fields:
+  - value
+  values:
+  - '10935'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: HoursCool
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: HwcElecConsDay
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: HwcElecConsTotal
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: LiveMonitorCurrentConsumedPower
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: PowerConsumptionHmu
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunDataAirInletTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataBuildingCPumpPower
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataCompressorInletTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataCompressorOutletTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataCompressorSpeed
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataEEVOutletTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataEEVPositionAbs
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataElectricPowerConsumption
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataFan1Speed
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataFan2Speed
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataHighPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataLowPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunDataReturnTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataStatuscode
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStats4PortValveHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStats4PortValveSwitches
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsBuildingCPumpStarts
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsBuildingPumpHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunStatsCompressorHc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunStatsCompressorHwc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHwc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorStarts
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsFan1Hours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsFan1Starts
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsFan2Hours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsFan2Starts
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsHMUHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsHcHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsHwcHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: SourceTempInput
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: SourceTempOutput
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatElectricEnergySum
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatElectricEnergySumCool
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatElectricEnergySumHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatElectricEnergySumHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatEnvironmentEnergySum
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatEnvironmentEnergySumCool
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatEnvironmentEnergySumHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatEnvironmentEnergySumHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatSolarEnergySum
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatSolarEnergySumHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatSolarEnergySumHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.pumpstate
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.temp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.temp_1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.temp_2
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: Status01.temp_3
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: Status01.temp_4
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: StatusCirPump
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: SupplyTempWeighted
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: TotalEnergyUsage
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldCoolDay
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldCooling
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldCoolingMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldHcDay
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldHcMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldHwcDay
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldHwcMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmux0
+  name: Status01
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmux0
+  name: Status01.pumpstate
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmux0
+  name: Status01.temp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmux0
+  name: Status01.temp_1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmux0
+  name: Status01.temp_2
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmux0
+  name: Status01.temp_3
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmux0
+  name: Status01.temp_4
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: v32
+  name: BypassPosition
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: ExhaustAirHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: ExhaustAirTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: FanHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: FlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: FlowTempMax
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: HcHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: HoursTillService
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: HwcHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: HwcTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: v32
+  name: Maintenancedata_HwcTempMax
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: v32
+  name: MaxAirHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: MinAirHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: OutdoorstempSensor
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: v32
+  name: OutsideAirTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: PumpHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: PumpPower
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: ReturnTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: ReturnTempMax
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: Status02.hwcmode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: Status02.temp0
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: Status02.temp0_1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: Status02.temp1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: Status02.temp1_1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: StorageLoadPumpHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: StorageTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: StorageTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: SupplyAirTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: VentilationLevelDay
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: VentilationLevelNight
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldToday
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldTotal
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldYear
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Clearerrorhistory
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Mc1Operation
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Mc2Operation
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Mc3Operation
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: SensorData1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: SensorData2
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: SetActorState
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vwz
+  name: TestHwcTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: vwz
+  name: TestOutdoorTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: vwz
+  name: TestThreeWayValve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: vwzio
+  name: EnableTestHwcTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: EnableTestOutdoorTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: EnableTestThreeWayValve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: TestHwcTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: TestOutdoorTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: TestThreeWayValve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+grab:
+- '[grab] grab started'
+- '3108b516081001ffff02052835 / 0b0100070205283500000000 = 1: hmu CoolEnvYieldDay'
+- '3108b516081000ffff02050000 / 0b0000070205283500000000 = 1: hmu CoolEnvYieldTotal'
+- '3108b516081002ffff02052835 / 0b0200070205213500000000 = 1: hmu CoolEnvYieldMonth'
+- '3108b516081001ffff03032835 / 0b010000030328352a63aa43 = 1: hmu HcElecConsDay'
+- '3108b516081000ffff03030000 / 0b00000003032835e5852b46 = 1: hmu HcElecConsTotal'
+- '3108b516081001ffff03052835 / 0b0100060305283500000000 = 1: hmu CoolElecConsDay'
+- '3108b516081000ffff03040000 / 0b0000030304283500000000 = 1: hmu HwcElecConsTotal'
+- '3108b516081001ffff03042835 / 0b0100030304283500000000 = 1: hmu HwcElecConsDay'
+- '3108b516081000ffff03050000 / 0b00000603052835ff8ffb46 = 1: hmu CoolElecConsTotal'
+- '10feb5160301c10f = 1: Broadcast Outsidetemp'
+- 1008b5110100 / 090b02145b040900005b = 1
+- 1008b5110101 / 094138c10fffff0100ff = 1
+- 1076b5110101 / 093838c10fffff0000ff = 1
+- f108b5160114 / 090153d1864400000000 = 1
+- f176b5160114 / 09000000a04000000000 = 1
+- 0304b511010e / 0116 = 1
+- '1008b51009000050ffffff060000 / 0101 = 1: bai SetModeOverride'
+- 1076b512030f0001 / 07008000c10114ff = 1
+- 1076b51009000000ffffff050000 / 0101 = 1
+- f115b52406020003001b00 / 0601031b000000 = 1
+- '3115b52406020002012200 / 00 = 1: ctlv2 Hc2Humidity'
+- '3115b52406020002012100 / 00 = 1: ctlv2 Hc2MixerPosition'
+- '[grab stop] grab stopped'
+labeled_telegrams:
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081001ffff02052835
+  resp: 0b0100070205283500000000
+  count: '1'
+  label: hmu CoolEnvYieldDay
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081000ffff02050000
+  resp: 0b0000070205283500000000
+  count: '1'
+  label: hmu CoolEnvYieldTotal
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081002ffff02052835
+  resp: 0b0200070205213500000000
+  count: '1'
+  label: hmu CoolEnvYieldMonth
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081001ffff03032835
+  resp: 0b010000030328352a63aa43
+  count: '1'
+  label: hmu HcElecConsDay
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081000ffff03030000
+  resp: 0b00000003032835e5852b46
+  count: '1'
+  label: hmu HcElecConsTotal
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081001ffff03052835
+  resp: 0b0100060305283500000000
+  count: '1'
+  label: hmu CoolElecConsDay
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081000ffff03040000
+  resp: 0b0000030304283500000000
+  count: '1'
+  label: hmu HwcElecConsTotal
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081001ffff03042835
+  resp: 0b0100030304283500000000
+  count: '1'
+  label: hmu HwcElecConsDay
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081000ffff03050000
+  resp: 0b00000603052835ff8ffb46
+  count: '1'
+  label: hmu CoolElecConsTotal
+- msgid: b516
+  master: '10'
+  slave: fe
+  sub: 0301c10f
+  resp: null
+  count: '1'
+  label: Broadcast Outsidetemp
+- msgid: b510
+  master: '10'
+  slave: 08
+  sub: 09000050ffffff060000
+  resp: '0101'
+  count: '1'
+  label: bai SetModeOverride
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020002012200'
+  resp: '00'
+  count: '1'
+  label: ctlv2 Hc2Humidity
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020002012100'
+  resp: '00'
+  count: '1'
+  label: ctlv2 Hc2MixerPosition
+unknown_telegrams:
+- msgid: b511
+  master: '10'
+  slave: 08
+  sub: '0100'
+  resp: 090b02145b040900005b
+  count: '1'
+  label: null
+- msgid: b511
+  master: '10'
+  slave: 08
+  sub: '0101'
+  resp: 094138c10fffff0100ff
+  count: '1'
+  label: null
+- msgid: b511
+  master: '10'
+  slave: '76'
+  sub: '0101'
+  resp: 093838c10fffff0000ff
+  count: '1'
+  label: null
+- msgid: b516
+  master: f1
+  slave: 08
+  sub: '0114'
+  resp: 090153d1864400000000
+  count: '1'
+  label: null
+- msgid: b516
+  master: f1
+  slave: '76'
+  sub: '0114'
+  resp: 09000000a04000000000
+  count: '1'
+  label: null
+- msgid: b512
+  master: '10'
+  slave: '76'
+  sub: 030f0001
+  resp: 07008000c10114ff
+  count: '1'
+  label: null
+- msgid: b510
+  master: '10'
+  slave: '76'
+  sub: 09000000ffffff050000
+  resp: '0101'
+  count: '1'
+  label: null
+- msgid: b524
+  master: f1
+  slave: '15'
+  sub: 06020003001b00
+  resp: 0601031b000000
+  count: '1'
+  label: null
+after_registers:
+- circuit: Broadcast
+  name: Datetime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Error
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: Broadcast
+  name: HwcStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Id
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: IdAnswer
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: IdQuery
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Load
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Outsidetemp
+  fields:
+  - value
+  values:
+  - '15.754'
+  writable: false
+  has_data: true
+- circuit: Broadcast
+  name: Queryexistence
+  fields:
+  - value
+  values:
+  - (empty for 31fe07fe00 / )
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Signoflife
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Vdatetime
+  fields:
+  - value
+  values:
+  - 20:35:59;08.09.2026
+  writable: false
+  has_data: true
+- circuit: Broadcast
+  name: Vdatetime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: WaterPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: General
+  name: Valuerange
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Eeprom
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Eeprom
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Ram
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Ram
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Scan
+  name: Id
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Scan.15
+  name: Id
+  fields:
+  - value
+  values:
+  - 21;25;45;0020260913;0953;026479;N3
+  writable: false
+  has_data: true
+- circuit: Scan.76
+  name: Id
+  fields:
+  - value
+  values:
+  - 21;26;03;8000035574;0001;005739;N8
+  writable: false
+  has_data: true
+- circuit: Scan.f6
+  name: Id
+  fields:
+  - value
+  values:
+  - 21;26;10;0020292012;0933;049007;N4
+  writable: false
+  has_data: true
+- circuit: bai
+  name: ActiveStages
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: bai
+  name: FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: bai
+  name: FlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: bai
+  name: HeatingStage1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: bai
+  name: HeatingStage3
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: bai
+  name: PrEnergySumHc1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: bai
+  name: PrEnergySumHwc1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: bai
+  name: SetModeOverride
+  fields:
+  - value
+  values:
+  - 0;40.0;-;-;-;0;1;1;0;0;0;0
+  writable: false
+  has_data: true
+- circuit: bai
+  name: StorageTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: bai
+  name: StorageTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: bai
+  name: WaterPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: AdaptHeatCurve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: CcTimer_Config
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: CcTimer_Timeframes
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: ContinuousHeating
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: CylinderChargeHyst
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: CylinderChargeOffset
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Date
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: DisplayedOutsideTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: FrostOverRideTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1AutoOffMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1CircuitType
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1CoolingEnabled
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1CoolingFlowTempMin
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1DewPointMonitoring
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1DewPointOffset
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1DewPointTemp
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002300 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1ExcessTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1FlowTempCalc
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002000 / 050102200001)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1HeatCurve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1Humidity
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002200 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MixerMovement
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MixerPosition
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002100 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1PumpHours
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002400 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1PumpStarts
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002500 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1PumpStatus
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1RoomTempModulation
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1Status
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1SummerTempLimit
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2AutoOffMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2CircuitType
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2DewPointTemp
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012300 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2ExcessTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2FlowTempCalc
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012000 / 050002200000)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2HeatCurve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2Humidity
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012200 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MixerMovement
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MixerPosition
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012100 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2PumpHours
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012400 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2PumpStarts
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012500 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2PumpStatus
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2Status
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2SummerTempLimit
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3AutoOffMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3CircuitType
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3ExcessTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3HeatCurve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MixerMovement
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3PumpStatus
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3Status
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3SummerTempLimit
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HcStorageTempBottom
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: ctlv2
+  name: HcStorageTempTop
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: ctlv2
+  name: HwcFlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcLockTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcMaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcOpMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcParallelLoading
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcSFMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcSfMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcStorageTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcStorageTempBottom
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcStorageTempTop
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HydraulicScheme
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: ManualCoolingEndDate
+  fields:
+  - value
+  values:
+  - 01.01.2015
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: ManualCoolingEndDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: ManualCoolingStartDate
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv2
+  name: ManualCoolingStartDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: MaxCylinderChargeTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: MaxRoomHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: MultiRelaySetting
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: OutsideTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: OutsideTempAvg
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySum
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHcLastMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHcThisMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHwcLastMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHwcThisMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: SystemFlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: WaterPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingManualTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingOpMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingSetbackTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1DayTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1HolidayTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1NightTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1OpMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoDuration
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoEndDate
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoEndTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1RoomTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1SFMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z2RoomTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: z1RoomHumidity
+  fields:
+  - value
+  values:
+  - '67'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: AdaptHeatCurve
+  fields:
+  - value
+  values:
+  - 'yes'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: AdaptHeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Config
+  fields:
+  - value
+  values:
+  - 03 01 01 00 00 00 ff ff 00
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CcTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Friday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Friday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Friday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Monday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Monday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Monday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Saturday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Saturday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Saturday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Sunday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Sunday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Sunday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Thursday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Timeframes
+  fields:
+  - value
+  values:
+  - 0;0;0;0;0;0;0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CcTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Tuesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Wednesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CcTimer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Clearerrorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: ContinuousHeating
+  fields:
+  - value
+  values:
+  - '-26'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: ContinuousHeating
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - -;-;-;-;-
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CylinderChargeHyst
+  fields:
+  - value
+  values:
+  - '7'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CylinderChargeHyst
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: CylinderChargeOffset
+  fields:
+  - value
+  values:
+  - '10'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: CylinderChargeOffset
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Date
+  fields:
+  - value
+  values:
+  - 08.09.2026
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Date
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: DisplayedOutsideTemp
+  fields:
+  - value
+  values:
+  - '15.7539'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: FrostOverRideTime
+  fields:
+  - value
+  values:
+  - '4'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: FrostOverRideTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - '40'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1AutoOffMode
+  fields:
+  - value
+  values:
+  - eco
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1AutoOffMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1CircuitType
+  fields:
+  - value
+  values:
+  - mixer
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1ExcessTemp
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1ExcessTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1FlowTemp
+  fields:
+  - value
+  values:
+  - '30.5'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1HeatCurve
+  fields:
+  - value
+  values:
+  - '0.8'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1HeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '40'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - '19'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - '35'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1MixerMovement
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1PumpStatus
+  fields:
+  - value
+  values:
+  - '1'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1PumpStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - thermostat
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1Status
+  fields:
+  - value
+  values:
+  - '1'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc1SummerTempLimit
+  fields:
+  - value
+  values:
+  - '18'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc1SummerTempLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2AutoOffMode
+  fields:
+  - value
+  values:
+  - eco
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2AutoOffMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2CircuitType
+  fields:
+  - value
+  values:
+  - inactive
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2ExcessTemp
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2ExcessTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2FlowTemp
+  fields:
+  - value
+  values:
+  - (empty for 3115b52406020002010800 / 0800020800ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2HeatCurve
+  fields:
+  - value
+  values:
+  - '0.6'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2HeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '55'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - '20'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - '15'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2MixerMovement
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2PumpStatus
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2PumpStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'off'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2Status
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc2SummerTempLimit
+  fields:
+  - value
+  values:
+  - '16'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc2SummerTempLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3AutoOffMode
+  fields:
+  - value
+  values:
+  - eco
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3AutoOffMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3CircuitType
+  fields:
+  - value
+  values:
+  - inactive
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3ExcessTemp
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3ExcessTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3FlowTemp
+  fields:
+  - value
+  values:
+  - (empty for 3115b52406020002020800 / 0800020800ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3HeatCurve
+  fields:
+  - value
+  values:
+  - '1.35'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3HeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '55'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - '20'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - '15'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3MixerMovement
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3PumpStatus
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3PumpStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'off'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3Status
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Hc3SummerTempLimit
+  fields:
+  - value
+  values:
+  - '16'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Hc3SummerTempLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HcStorageTempBottom
+  fields:
+  - value
+  values:
+  - (empty for f115b5240602000000a000 / 080000a000ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HcStorageTempTop
+  fields:
+  - value
+  values:
+  - (empty for f115b52406020000009f00 / 0800009f00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcBankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcBankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcBankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcBankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcFlowTemp
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcLockTime
+  fields:
+  - value
+  values:
+  - '60'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcLockTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcMaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '80'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcMaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcOpMode
+  fields:
+  - value
+  values:
+  - auto
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcOpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcParallelLoading
+  fields:
+  - value
+  values:
+  - 'off'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcParallelLoading
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcSFMode
+  fields:
+  - value
+  values:
+  - auto
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcSFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcStorageTemp
+  fields:
+  - value
+  values:
+  - (empty for 3115b52406020001000500 / 0800010500ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcStorageTempBottom
+  fields:
+  - value
+  values:
+  - (empty for f115b52406020000009e00 / 0800009e00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcStorageTempTop
+  fields:
+  - value
+  values:
+  - (empty for f115b52406020000009d00 / 0800009d00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTempDesired
+  fields:
+  - value
+  values:
+  - '55'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HwcTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Config
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Friday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Friday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Friday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Monday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Monday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Monday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Saturday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Saturday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Saturday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Sunday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Sunday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Sunday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Thursday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Timeframes
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Tuesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Wednesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HwcTimer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: HydraulicScheme
+  fields:
+  - value
+  values:
+  - '8'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: HydraulicScheme
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Installer1
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Installer1
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Installer2
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Installer2
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: KeyCodeforConfigMenu
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: KeyCodeforConfigMenu
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: MaintenanceDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: MaintenanceDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: MaintenanceDue
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: MaxCylinderChargeTime
+  fields:
+  - value
+  values:
+  - '90'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: MaxCylinderChargeTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: MaxRoomHumidity
+  fields:
+  - value
+  values:
+  - '50'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: MaxRoomHumidity
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: MultiRelaySetting
+  fields:
+  - value
+  values:
+  - '4'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: MultiRelaySetting
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: OutsideTempAvg
+  fields:
+  - value
+  values:
+  - '18.3398'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: OutsideTempAvg
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PhoneNumber1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PhoneNumber1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PhoneNumber2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PhoneNumber2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySum
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020000005c00 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHc
+  fields:
+  - value
+  values:
+  - '17'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: PrEnergySumHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHcLastMonth
+  fields:
+  - value
+  values:
+  - '11'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: PrEnergySumHcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHcThisMonth
+  fields:
+  - value
+  values:
+  - '2'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: PrEnergySumHcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHwc
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: PrEnergySumHwc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHwcLastMonth
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: PrEnergySumHwcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrEnergySumHwcThisMonth
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: PrEnergySumHwcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHwc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHwc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHwcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHwcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHwcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PrFuelSumHwcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PumpAdditionalTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: PumpAdditionalTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: SolarYieldTotal
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: SolarYieldTotal
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: SystemFlowTemp
+  fields:
+  - value
+  values:
+  - (empty for f115b52406020000004b00 / 0800004b00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Time
+  fields:
+  - value
+  values:
+  - '19:41:52'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Time
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: WaterPressure
+  fields:
+  - value
+  values:
+  - '2'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: YieldTotal
+  fields:
+  - value
+  values:
+  - '6'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: YieldTotal
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - '26'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1CoolingTemp
+  fields:
+  - value
+  values:
+  - '23'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1CoolingTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1DayTemp
+  fields:
+  - value
+  values:
+  - '26'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1HolidayTemp
+  fields:
+  - value
+  values:
+  - '15'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Name1
+  fields:
+  - value
+  values:
+  - Zone
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Name2
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for f115b52406020003001800 / 06030318003100)'
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1NightTemp
+  fields:
+  - value
+  values:
+  - '15'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1OpMode
+  fields:
+  - value
+  values:
+  - day
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1QuickVetoDuration
+  fields:
+  - value
+  values:
+  - '3'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1QuickVetoEndDate
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1QuickVetoEndTime
+  fields:
+  - value
+  values:
+  - 00:00:00
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1QuickVetoTemp
+  fields:
+  - value
+  values:
+  - '21'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1RoomTemp
+  fields:
+  - value
+  values:
+  - '22.5375'
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1SFMode
+  fields:
+  - value
+  values:
+  - auto
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Config
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Friday0
+  fields:
+  - value
+  values:
+  - 06:00;22:00;20.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Friday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Friday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Monday0
+  fields:
+  - value
+  values:
+  - 06:00;22:00;20.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Monday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Monday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Saturday0
+  fields:
+  - value
+  values:
+  - 07:30;23:30;20.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Saturday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Saturday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Sunday0
+  fields:
+  - value
+  values:
+  - 07:30;22:00;20.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Sunday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Sunday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Thursday0
+  fields:
+  - value
+  values:
+  - 06:00;22:00;20.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Timeframes
+  fields:
+  - value
+  values:
+  - 1;1;1;1;1;1;1
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Tuesday0
+  fields:
+  - value
+  values:
+  - 06:00;22:00;20.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Wednesday0
+  fields:
+  - value
+  values:
+  - 06:00;22:00;20.0
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z1Timer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1Timer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z1ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2CoolingTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2CoolingTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2QuickVetoEndDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2QuickVetoEndTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2RoomTemp
+  fields:
+  - value
+  values:
+  - (empty for 3115b52406020003010f00 / 0802030f00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z2RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Config
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Friday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Friday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Friday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Monday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Monday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Monday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Saturday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Saturday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Saturday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Sunday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Sunday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Sunday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Thursday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Timeframes
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Tuesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Wednesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2Timer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z2ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3QuickVetoEndDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3QuickVetoEndTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3RoomTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: true
+- circuit: ctlv3
+  name: Z3RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Config
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Friday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Friday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Friday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Monday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Monday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Monday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Saturday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Saturday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Saturday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Sunday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Sunday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Sunday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Thursday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Timeframes
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Tuesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Wednesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3Timer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv3
+  name: Z3ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: BuildingCircuitFlow
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: BuildingCircuitPumpSpeed
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: CompressorHc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: CompressorHwc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHwc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: ConsumptionTotal
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CoolElecConsDay
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CoolElecConsTotal
+  fields:
+  - value
+  values:
+  - '32200'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CoolEnvYieldDay
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CoolEnvYieldMonth
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CoolEnvYieldTotal
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CopCooling
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CopCoolingMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CopHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CopHcMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CopHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CopHwcMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CurrentCompressorUtil
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CurrentConsumedPower
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CurrentYieldPower
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: DateTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: FlowTemperature
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: HcElecConsDay
+  fields:
+  - value
+  values:
+  - '340.775'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: HcElecConsTotal
+  fields:
+  - value
+  values:
+  - '10977.5'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: HoursCool
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: HwcElecConsDay
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: HwcElecConsTotal
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: LiveMonitorCurrentConsumedPower
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: PowerConsumptionHmu
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunDataAirInletTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataBuildingCPumpPower
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataCompressorInletTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataCompressorOutletTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataCompressorSpeed
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataEEVOutletTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataEEVPositionAbs
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataElectricPowerConsumption
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataFan1Speed
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataFan2Speed
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataHighPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataLowPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunDataReturnTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataStatuscode
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStats4PortValveHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStats4PortValveSwitches
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsBuildingCPumpStarts
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsBuildingPumpHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunStatsCompressorHc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunStatsCompressorHwc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHwc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorStarts
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsFan1Hours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsFan1Starts
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsFan2Hours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsFan2Starts
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsHMUHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsHcHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsHwcHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: SourceTempInput
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: SourceTempOutput
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatElectricEnergySum
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatElectricEnergySumCool
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatElectricEnergySumHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatElectricEnergySumHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatEnvironmentEnergySum
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatEnvironmentEnergySumCool
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatEnvironmentEnergySumHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatEnvironmentEnergySumHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatSolarEnergySum
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatSolarEnergySumHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatSolarEnergySumHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.pumpstate
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.temp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.temp_1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.temp_2
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: Status01.temp_3
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: Status01.temp_4
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: StatusCirPump
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: SupplyTempWeighted
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: TotalEnergyUsage
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldCoolDay
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldCooling
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldCoolingMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldHcDay
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldHcMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldHwcDay
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldHwcMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmux0
+  name: Status01
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmux0
+  name: Status01.pumpstate
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmux0
+  name: Status01.temp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmux0
+  name: Status01.temp_1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmux0
+  name: Status01.temp_2
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmux0
+  name: Status01.temp_3
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmux0
+  name: Status01.temp_4
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: v32
+  name: BypassPosition
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: ExhaustAirHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: ExhaustAirTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: FanHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: FlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: FlowTempMax
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: HcHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: HoursTillService
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: HwcHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: HwcTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: v32
+  name: Maintenancedata_HwcTempMax
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: v32
+  name: MaxAirHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: MinAirHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: OutdoorstempSensor
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: v32
+  name: OutsideAirTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: PumpHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: PumpPower
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: ReturnTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: ReturnTempMax
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: Status02.hwcmode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: Status02.temp0
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: Status02.temp0_1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: Status02.temp1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: Status02.temp1_1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: StorageLoadPumpHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: StorageTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: StorageTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: SupplyAirTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: VentilationLevelDay
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: VentilationLevelNight
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldToday
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldTotal
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldYear
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Clearerrorhistory
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Mc1Operation
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Mc2Operation
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Mc3Operation
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: SensorData1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: SensorData2
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: SetActorState
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vwz
+  name: TestHwcTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: vwz
+  name: TestOutdoorTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: vwz
+  name: TestThreeWayValve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: vwzio
+  name: EnableTestHwcTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: EnableTestOutdoorTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: EnableTestThreeWayValve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: TestHwcTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: TestOutdoorTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: vwzio
+  name: TestThreeWayValve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+raw_find_lines_after:
+- bai SetModeOverride = 0;40.0;-;-;-;0;1;1;0;0;0;0
+- Broadcast Datetime = no data stored
+- Broadcast Error = no data stored
+- Broadcast HwcStatus = no data stored
+- Broadcast Id = no data stored
+- Broadcast IdAnswer = no data stored
+- Broadcast IdQuery = no data stored
+- Broadcast Load = no data stored
+- Broadcast Outsidetemp = 15.754
+- Broadcast Queryexistence =  (empty for 31fe07fe00 / )
+- Broadcast Signoflife = no data stored
+- Broadcast Vdatetime = 20:35:59;08.09.2026
+- Broadcast Vdatetime = no data stored
+- 'ctlv2 Hc1DewPointTemp =  (ERR: invalid position for 3115b52406020002002300 / 00)'
+- 'ctlv2 Hc1FlowTempCalc =  (ERR: invalid position for 3115b52406020002002000 / 050102200001)'
+- 'ctlv2 Hc1Humidity =  (ERR: invalid position for 3115b52406020002002200 / 00)'
+- 'ctlv2 Hc1MixerPosition =  (ERR: invalid position for 3115b52406020002002100 / 00)'
+- 'ctlv2 Hc1PumpHours =  (ERR: invalid position for 3115b52406020002002400 / 00)'
+- 'ctlv2 Hc1PumpStarts =  (ERR: invalid position for 3115b52406020002002500 / 00)'
+- 'ctlv2 Hc2DewPointTemp =  (ERR: invalid position for 3115b52406020002012300 / 00)'
+- 'ctlv2 Hc2FlowTempCalc =  (ERR: invalid position for 3115b52406020002012000 / 050002200000)'
+- 'ctlv2 Hc2Humidity =  (ERR: invalid position for 3115b52406020002012200 / 00)'
+- 'ctlv2 Hc2MixerPosition =  (ERR: invalid position for 3115b52406020002012100 / 00)'
+- 'ctlv2 Hc2PumpHours =  (ERR: invalid position for 3115b52406020002012400 / 00)'
+- 'ctlv2 Hc2PumpStarts =  (ERR: invalid position for 3115b52406020002012500 / 00)'
+- ctlv2 ManualCoolingEndDate = 01.01.2015
+- ctlv2 ManualCoolingEndDate = no data stored
+- ctlv2 ManualCoolingStartDate = 01.01.2019
+- ctlv2 ManualCoolingStartDate = no data stored
+- ctlv2 z1RoomHumidity = 67
+- ctlv3 AdaptHeatCurve = yes
+- ctlv3 AdaptHeatCurve = no data stored
+- ctlv3 CcTimer_Config = 03 01 01 00 00 00 ff ff 00
+- ctlv3 CcTimer_Friday0 = no data stored
+- ctlv3 CcTimer_Friday1 = no data stored
+- ctlv3 CcTimer_Friday2 = no data stored
+- ctlv3 CcTimer_Friday = no data stored
+- ctlv3 CcTimer_Monday0 = no data stored
+- ctlv3 CcTimer_Monday1 = no data stored
+- ctlv3 CcTimer_Monday2 = no data stored
+- ctlv3 CcTimer_Monday = no data stored
+- ctlv3 CcTimer_Saturday0 = no data stored
+- ctlv3 CcTimer_Saturday1 = no data stored
+- ctlv3 CcTimer_Saturday2 = no data stored
+- ctlv3 CcTimer_Saturday = no data stored
+- ctlv3 CcTimer_Sunday0 = no data stored
+- ctlv3 CcTimer_Sunday1 = no data stored
+- ctlv3 CcTimer_Sunday2 = no data stored
+- ctlv3 CcTimer_Sunday = no data stored
+- ctlv3 CcTimer_Thursday0 = no data stored
+- ctlv3 CcTimer_Thursday1 = no data stored
+- ctlv3 CcTimer_Thursday2 = no data stored
+- ctlv3 CcTimer_Thursday = no data stored
+- ctlv3 CcTimer_Timeframes = 0;0;0;0;0;0;0
+- ctlv3 CcTimer_Tuesday0 = no data stored
+- ctlv3 CcTimer_Tuesday1 = no data stored
+- ctlv3 CcTimer_Tuesday2 = no data stored
+- ctlv3 CcTimer_Tuesday = no data stored
+- ctlv3 CcTimer_Wednesday0 = no data stored
+- ctlv3 CcTimer_Wednesday1 = no data stored
+- ctlv3 CcTimer_Wednesday2 = no data stored
+- ctlv3 CcTimer_Wednesday = no data stored
+- ctlv3 Clearerrorhistory = no data stored
+- ctlv3 ContinuousHeating = -26
+- ctlv3 ContinuousHeating = no data stored
+- ctlv3 Currenterror = -;-;-;-;-
+- ctlv3 CylinderChargeHyst = 7
+- ctlv3 CylinderChargeHyst = no data stored
+- ctlv3 CylinderChargeOffset = 10
+- ctlv3 CylinderChargeOffset = no data stored
+- ctlv3 Date = 08.09.2026
+- ctlv3 Date = no data stored
+- ctlv3 DisplayedOutsideTemp = 15.7539
+- ctlv3 Errorhistory = no data stored
+- ctlv3 FrostOverRideTime = 4
+- ctlv3 FrostOverRideTime = no data stored
+- ctlv3 Hc1ActualFlowTempDesired = 40
+- ctlv3 Hc1AutoOffMode = eco
+- ctlv3 Hc1AutoOffMode = no data stored
+- ctlv3 Hc1CircuitType = mixer
+- ctlv3 Hc1ExcessTemp = 0.0
+- ctlv3 Hc1ExcessTemp = no data stored
+- ctlv3 Hc1FlowTemp = 30.5
+- ctlv3 Hc1HeatCurve = 0.8
+- ctlv3 Hc1HeatCurve = no data stored
+- ctlv3 Hc1HeatCurveAdaption = 0.0
+- ctlv3 Hc1MaxFlowTempDesired = 40
+- ctlv3 Hc1MaxFlowTempDesired = no data stored
+- ctlv3 Hc1MinCoolingTempDesired = 19
+- ctlv3 Hc1MinCoolingTempDesired = no data stored
+- ctlv3 Hc1MinFlowTempDesired = 35
+- ctlv3 Hc1MinFlowTempDesired = no data stored
+- ctlv3 Hc1MixerMovement = 0.0
+- ctlv3 Hc1PumpStatus = 1
+- ctlv3 Hc1PumpStatus = no data stored
+- ctlv3 Hc1RoomTempSwitchOn = thermostat
+- ctlv3 Hc1RoomTempSwitchOn = no data stored
+- ctlv3 Hc1Status = 1
+- ctlv3 Hc1Status = no data stored
+- ctlv3 Hc1SummerTempLimit = 18
+- ctlv3 Hc1SummerTempLimit = no data stored
+- ctlv3 Hc2ActualFlowTempDesired = 0.0
+- ctlv3 Hc2AutoOffMode = eco
+- ctlv3 Hc2AutoOffMode = no data stored
+- ctlv3 Hc2CircuitType = inactive
+- ctlv3 Hc2ExcessTemp = 0.0
+- ctlv3 Hc2ExcessTemp = no data stored
+- ctlv3 Hc2FlowTemp =  (empty for 3115b52406020002010800 / 0800020800ffffff7f)
+- ctlv3 Hc2HeatCurve = 0.6
+- ctlv3 Hc2HeatCurve = no data stored
+- ctlv3 Hc2HeatCurveAdaption = 0.0
+- ctlv3 Hc2MaxFlowTempDesired = 55
+- ctlv3 Hc2MaxFlowTempDesired = no data stored
+- ctlv3 Hc2MinCoolingTempDesired = 20
+- ctlv3 Hc2MinCoolingTempDesired = no data stored
+- ctlv3 Hc2MinFlowTempDesired = 15
+- ctlv3 Hc2MinFlowTempDesired = no data stored
+- ctlv3 Hc2MixerMovement = 0.0
+- ctlv3 Hc2PumpStatus = 0
+- ctlv3 Hc2PumpStatus = no data stored
+- ctlv3 Hc2RoomTempSwitchOn = off
+- ctlv3 Hc2RoomTempSwitchOn = no data stored
+- ctlv3 Hc2Status = 0
+- ctlv3 Hc2Status = no data stored
+- ctlv3 Hc2SummerTempLimit = 16
+- ctlv3 Hc2SummerTempLimit = no data stored
+- ctlv3 Hc3ActualFlowTempDesired = 0.0
+- ctlv3 Hc3AutoOffMode = eco
+- ctlv3 Hc3AutoOffMode = no data stored
+- ctlv3 Hc3CircuitType = inactive
+- ctlv3 Hc3ExcessTemp = 0.0
+- ctlv3 Hc3ExcessTemp = no data stored
+- ctlv3 Hc3FlowTemp =  (empty for 3115b52406020002020800 / 0800020800ffffff7f)
+- ctlv3 Hc3HeatCurve = 1.35
+- ctlv3 Hc3HeatCurve = no data stored
+- ctlv3 Hc3HeatCurveAdaption = 0.0
+- ctlv3 Hc3MaxFlowTempDesired = 55
+- ctlv3 Hc3MaxFlowTempDesired = no data stored
+- ctlv3 Hc3MinCoolingTempDesired = 20
+- ctlv3 Hc3MinCoolingTempDesired = no data stored
+- ctlv3 Hc3MinFlowTempDesired = 15
+- ctlv3 Hc3MinFlowTempDesired = no data stored
+- ctlv3 Hc3MixerMovement = 0.0
+- ctlv3 Hc3PumpStatus = 0
+- ctlv3 Hc3PumpStatus = no data stored
+- ctlv3 Hc3RoomTempSwitchOn = off
+- ctlv3 Hc3RoomTempSwitchOn = no data stored
+- ctlv3 Hc3Status = 0
+- ctlv3 Hc3Status = no data stored
+- ctlv3 Hc3SummerTempLimit = 16
+- ctlv3 Hc3SummerTempLimit = no data stored
+- ctlv3 HcStorageTempBottom =  (empty for f115b5240602000000a000 / 080000a000ffffff7f)
+- ctlv3 HcStorageTempTop =  (empty for f115b52406020000009f00 / 0800009f00ffffff7f)
+- ctlv3 HwcBankHolidayEndPeriod = no data stored
+- ctlv3 HwcBankHolidayEndPeriod = no data stored
+- ctlv3 HwcBankHolidayStartPeriod = no data stored
+- ctlv3 HwcBankHolidayStartPeriod = no data stored
+- ctlv3 HwcFlowTemp = 0.0
+- ctlv3 HwcHolidayEndPeriod = 01.01.2019
+- ctlv3 HwcHolidayEndPeriod = no data stored
+- ctlv3 HwcHolidayStartPeriod = 01.01.2019
+- ctlv3 HwcHolidayStartPeriod = no data stored
+- ctlv3 HwcLockTime = 60
+- ctlv3 HwcLockTime = no data stored
+- ctlv3 HwcMaxFlowTempDesired = 80
+- ctlv3 HwcMaxFlowTempDesired = no data stored
+- ctlv3 HwcOpMode = auto
+- ctlv3 HwcOpMode = no data stored
+- ctlv3 HwcParallelLoading = off
+- ctlv3 HwcParallelLoading = no data stored
+- ctlv3 HwcSFMode = auto
+- ctlv3 HwcSFMode = no data stored
+- ctlv3 HwcStorageTemp =  (empty for 3115b52406020001000500 / 0800010500ffffff7f)
+- ctlv3 HwcStorageTempBottom =  (empty for f115b52406020000009e00 / 0800009e00ffffff7f)
+- ctlv3 HwcStorageTempTop =  (empty for f115b52406020000009d00 / 0800009d00ffffff7f)
+- ctlv3 HwcTempDesired = 55
+- ctlv3 HwcTempDesired = no data stored
+- ctlv3 HwcTimer_Config = no data stored
+- ctlv3 HwcTimer_Friday0 = no data stored
+- ctlv3 HwcTimer_Friday1 = no data stored
+- ctlv3 HwcTimer_Friday2 = no data stored
+- ctlv3 HwcTimer_Friday = no data stored
+- ctlv3 HwcTimer_Monday0 = no data stored
+- ctlv3 HwcTimer_Monday1 = no data stored
+- ctlv3 HwcTimer_Monday2 = no data stored
+- ctlv3 HwcTimer_Monday = no data stored
+- ctlv3 HwcTimer_Saturday0 = no data stored
+- ctlv3 HwcTimer_Saturday1 = no data stored
+- ctlv3 HwcTimer_Saturday2 = no data stored
+- ctlv3 HwcTimer_Saturday = no data stored
+- ctlv3 HwcTimer_Sunday0 = no data stored
+- ctlv3 HwcTimer_Sunday1 = no data stored
+- ctlv3 HwcTimer_Sunday2 = no data stored
+- ctlv3 HwcTimer_Sunday = no data stored
+- ctlv3 HwcTimer_Thursday0 = no data stored
+- ctlv3 HwcTimer_Thursday1 = no data stored
+- ctlv3 HwcTimer_Thursday2 = no data stored
+- ctlv3 HwcTimer_Thursday = no data stored
+- ctlv3 HwcTimer_Timeframes = no data stored
+- ctlv3 HwcTimer_Tuesday0 = no data stored
+- ctlv3 HwcTimer_Tuesday1 = no data stored
+- ctlv3 HwcTimer_Tuesday2 = no data stored
+- ctlv3 HwcTimer_Tuesday = no data stored
+- ctlv3 HwcTimer_Wednesday0 = no data stored
+- ctlv3 HwcTimer_Wednesday1 = no data stored
+- ctlv3 HwcTimer_Wednesday2 = no data stored
+- ctlv3 HwcTimer_Wednesday = no data stored
+- ctlv3 HydraulicScheme = 8
+- ctlv3 HydraulicScheme = no data stored
+- ctlv3 Installer1 = no data stored
+- ctlv3 Installer1 = no data stored
+- ctlv3 Installer2 = no data stored
+- ctlv3 Installer2 = no data stored
+- ctlv3 KeyCodeforConfigMenu = no data stored
+- ctlv3 KeyCodeforConfigMenu = no data stored
+- ctlv3 MaintenanceDate = no data stored
+- ctlv3 MaintenanceDate = no data stored
+- ctlv3 MaintenanceDue = no data stored
+- ctlv3 MaxCylinderChargeTime = 90
+- ctlv3 MaxCylinderChargeTime = no data stored
+- ctlv3 MaxRoomHumidity = 50
+- ctlv3 MaxRoomHumidity = no data stored
+- ctlv3 MultiRelaySetting = 4
+- ctlv3 MultiRelaySetting = no data stored
+- ctlv3 OutsideTempAvg = 18.3398
+- ctlv3 OutsideTempAvg = no data stored
+- ctlv3 PhoneNumber1 = no data stored
+- ctlv3 PhoneNumber1 = no data stored
+- ctlv3 PhoneNumber2 = no data stored
+- ctlv3 PhoneNumber2 = no data stored
+- 'ctlv3 PrEnergySum =  (ERR: invalid position for 3115b52406020000005c00 / 00)'
+- ctlv3 PrEnergySum = no data stored
+- ctlv3 PrEnergySumHc = 17
+- ctlv3 PrEnergySumHc = no data stored
+- ctlv3 PrEnergySumHcLastMonth = 11
+- ctlv3 PrEnergySumHcLastMonth = no data stored
+- ctlv3 PrEnergySumHcThisMonth = 2
+- ctlv3 PrEnergySumHcThisMonth = no data stored
+- ctlv3 PrEnergySumHwc = 0
+- ctlv3 PrEnergySumHwc = no data stored
+- ctlv3 PrEnergySumHwcLastMonth = 0
+- ctlv3 PrEnergySumHwcLastMonth = no data stored
+- ctlv3 PrEnergySumHwcThisMonth = 0
+- ctlv3 PrEnergySumHwcThisMonth = no data stored
+- ctlv3 PrFuelSum = no data stored
+- ctlv3 PrFuelSum = no data stored
+- ctlv3 PrFuelSumHc = no data stored
+- ctlv3 PrFuelSumHc = no data stored
+- ctlv3 PrFuelSumHcLastMonth = no data stored
+- ctlv3 PrFuelSumHcLastMonth = no data stored
+- ctlv3 PrFuelSumHcThisMonth = no data stored
+- ctlv3 PrFuelSumHcThisMonth = no data stored
+- ctlv3 PrFuelSumHwc = no data stored
+- ctlv3 PrFuelSumHwc = no data stored
+- ctlv3 PrFuelSumHwcLastMonth = no data stored
+- ctlv3 PrFuelSumHwcLastMonth = no data stored
+- ctlv3 PrFuelSumHwcThisMonth = no data stored
+- ctlv3 PrFuelSumHwcThisMonth = no data stored
+- ctlv3 PumpAdditionalTime = no data stored
+- ctlv3 PumpAdditionalTime = no data stored
+- ctlv3 SolarYieldTotal = no data stored
+- ctlv3 SolarYieldTotal = no data stored
+- ctlv3 SystemFlowTemp =  (empty for f115b52406020000004b00 / 0800004b00ffffff7f)
+- ctlv3 Time = 19:41:52
+- ctlv3 Time = no data stored
+- ctlv3 WaterPressure = 2
+- ctlv3 YieldTotal = 6
+- ctlv3 YieldTotal = no data stored
+- ctlv3 Z1ActualRoomTempDesired = 26
+- ctlv3 Z1ActualRoomTempDesired = no data stored
+- ctlv3 Z1BankHolidayEndPeriod = no data stored
+- ctlv3 Z1BankHolidayEndPeriod = no data stored
+- ctlv3 Z1BankHolidayStartPeriod = no data stored
+- ctlv3 Z1BankHolidayStartPeriod = no data stored
+- ctlv3 Z1CoolingTemp = 23
+- ctlv3 Z1CoolingTemp = no data stored
+- ctlv3 Z1DayTemp = 26
+- ctlv3 Z1DayTemp = no data stored
+- ctlv3 Z1HolidayEndPeriod = 01.01.2019
+- ctlv3 Z1HolidayEndPeriod = no data stored
+- ctlv3 Z1HolidayStartPeriod = 01.01.2019
+- ctlv3 Z1HolidayStartPeriod = no data stored
+- ctlv3 Z1HolidayTemp = 15
+- ctlv3 Z1HolidayTemp = no data stored
+- 'ctlv3 Z1Name1 = Zone '
+- ctlv3 Z1Name1 = no data stored
+- 'ctlv3 Z1Name2 =  (ERR: invalid position for f115b52406020003001800 / 06030318003100)'
+- ctlv3 Z1Name2 = no data stored
+- ctlv3 Z1NightTemp = 15
+- ctlv3 Z1NightTemp = no data stored
+- ctlv3 Z1OpMode = day
+- ctlv3 Z1OpMode = no data stored
+- ctlv3 Z1QuickVetoDuration = 3
+- ctlv3 Z1QuickVetoDuration = no data stored
+- ctlv3 Z1QuickVetoEndDate = 01.01.2019
+- ctlv3 Z1QuickVetoEndTime = 00:00:00
+- ctlv3 Z1QuickVetoTemp = 21
+- ctlv3 Z1QuickVetoTemp = no data stored
+- ctlv3 Z1RoomTemp = 22.5375
+- ctlv3 Z1RoomZoneMapping = VRC700
+- ctlv3 Z1RoomZoneMapping = no data stored
+- ctlv3 Z1SFMode = auto
+- ctlv3 Z1SFMode = no data stored
+- ctlv3 Z1Shortname = no data stored
+- ctlv3 Z1Shortname = no data stored
+- ctlv3 Z1Timer_Config = no data stored
+- ctlv3 Z1Timer_Friday0 = 06:00;22:00;20.0
+- ctlv3 Z1Timer_Friday1 = no data stored
+- ctlv3 Z1Timer_Friday2 = no data stored
+- ctlv3 Z1Timer_Friday = no data stored
+- ctlv3 Z1Timer_Monday0 = 06:00;22:00;20.0
+- ctlv3 Z1Timer_Monday1 = no data stored
+- ctlv3 Z1Timer_Monday2 = no data stored
+- ctlv3 Z1Timer_Monday = no data stored
+- ctlv3 Z1Timer_Saturday0 = 07:30;23:30;20.0
+- ctlv3 Z1Timer_Saturday1 = no data stored
+- ctlv3 Z1Timer_Saturday2 = no data stored
+- ctlv3 Z1Timer_Saturday = no data stored
+- ctlv3 Z1Timer_Sunday0 = 07:30;22:00;20.0
+- ctlv3 Z1Timer_Sunday1 = no data stored
+- ctlv3 Z1Timer_Sunday2 = no data stored
+- ctlv3 Z1Timer_Sunday = no data stored
+- ctlv3 Z1Timer_Thursday0 = 06:00;22:00;20.0
+- ctlv3 Z1Timer_Thursday1 = no data stored
+- ctlv3 Z1Timer_Thursday2 = no data stored
+- ctlv3 Z1Timer_Thursday = no data stored
+- ctlv3 Z1Timer_Timeframes = 1;1;1;1;1;1;1
+- ctlv3 Z1Timer_Tuesday0 = 06:00;22:00;20.0
+- ctlv3 Z1Timer_Tuesday1 = no data stored
+- ctlv3 Z1Timer_Tuesday2 = no data stored
+- ctlv3 Z1Timer_Tuesday = no data stored
+- ctlv3 Z1Timer_Wednesday0 = 06:00;22:00;20.0
+- ctlv3 Z1Timer_Wednesday1 = no data stored
+- ctlv3 Z1Timer_Wednesday2 = no data stored
+- ctlv3 Z1Timer_Wednesday = no data stored
+- ctlv3 Z1ValveStatus = no data stored
+- ctlv3 Z1ValveStatus = no data stored
+- ctlv3 Z2ActualRoomTempDesired = no data stored
+- ctlv3 Z2ActualRoomTempDesired = no data stored
+- ctlv3 Z2BankHolidayEndPeriod = no data stored
+- ctlv3 Z2BankHolidayEndPeriod = no data stored
+- ctlv3 Z2BankHolidayStartPeriod = no data stored
+- ctlv3 Z2BankHolidayStartPeriod = no data stored
+- ctlv3 Z2CoolingTemp = no data stored
+- ctlv3 Z2CoolingTemp = no data stored
+- ctlv3 Z2DayTemp = no data stored
+- ctlv3 Z2DayTemp = no data stored
+- ctlv3 Z2HolidayEndPeriod = no data stored
+- ctlv3 Z2HolidayEndPeriod = no data stored
+- ctlv3 Z2HolidayStartPeriod = no data stored
+- ctlv3 Z2HolidayStartPeriod = no data stored
+- ctlv3 Z2HolidayTemp = no data stored
+- ctlv3 Z2HolidayTemp = no data stored
+- ctlv3 Z2Name1 = no data stored
+- ctlv3 Z2Name1 = no data stored
+- ctlv3 Z2Name2 = no data stored
+- ctlv3 Z2Name2 = no data stored
+- ctlv3 Z2NightTemp = no data stored
+- ctlv3 Z2NightTemp = no data stored
+- ctlv3 Z2OpMode = no data stored
+- ctlv3 Z2OpMode = no data stored
+- ctlv3 Z2QuickVetoDuration = no data stored
+- ctlv3 Z2QuickVetoDuration = no data stored
+- ctlv3 Z2QuickVetoEndDate = no data stored
+- ctlv3 Z2QuickVetoEndTime = no data stored
+- ctlv3 Z2QuickVetoTemp = no data stored
+- ctlv3 Z2QuickVetoTemp = no data stored
+- ctlv3 Z2RoomTemp =  (empty for 3115b52406020003010f00 / 0802030f00ffffff7f)
+- ctlv3 Z2RoomZoneMapping = none
+- ctlv3 Z2RoomZoneMapping = no data stored
+- ctlv3 Z2SFMode = no data stored
+- ctlv3 Z2SFMode = no data stored
+- ctlv3 Z2Shortname = no data stored
+- ctlv3 Z2Shortname = no data stored
+- ctlv3 Z2Timer_Config = no data stored
+- ctlv3 Z2Timer_Friday0 = no data stored
+- ctlv3 Z2Timer_Friday1 = no data stored
+- ctlv3 Z2Timer_Friday2 = no data stored
+- ctlv3 Z2Timer_Friday = no data stored
+- ctlv3 Z2Timer_Monday0 = no data stored
+- ctlv3 Z2Timer_Monday1 = no data stored
+- ctlv3 Z2Timer_Monday2 = no data stored
+- ctlv3 Z2Timer_Monday = no data stored
+- ctlv3 Z2Timer_Saturday0 = no data stored
+- ctlv3 Z2Timer_Saturday1 = no data stored
+- ctlv3 Z2Timer_Saturday2 = no data stored
+- ctlv3 Z2Timer_Saturday = no data stored
+- ctlv3 Z2Timer_Sunday0 = no data stored
+- ctlv3 Z2Timer_Sunday1 = no data stored
+- ctlv3 Z2Timer_Sunday2 = no data stored
+- ctlv3 Z2Timer_Sunday = no data stored
+- ctlv3 Z2Timer_Thursday0 = no data stored
+- ctlv3 Z2Timer_Thursday1 = no data stored
+- ctlv3 Z2Timer_Thursday2 = no data stored
+- ctlv3 Z2Timer_Thursday = no data stored
+- ctlv3 Z2Timer_Timeframes = no data stored
+- ctlv3 Z2Timer_Tuesday0 = no data stored
+- ctlv3 Z2Timer_Tuesday1 = no data stored
+- ctlv3 Z2Timer_Tuesday2 = no data stored
+- ctlv3 Z2Timer_Tuesday = no data stored
+- ctlv3 Z2Timer_Wednesday0 = no data stored
+- ctlv3 Z2Timer_Wednesday1 = no data stored
+- ctlv3 Z2Timer_Wednesday2 = no data stored
+- ctlv3 Z2Timer_Wednesday = no data stored
+- ctlv3 Z2ValveStatus = no data stored
+- ctlv3 Z2ValveStatus = no data stored
+- ctlv3 Z3ActualRoomTempDesired = no data stored
+- ctlv3 Z3ActualRoomTempDesired = no data stored
+- ctlv3 Z3BankHolidayEndPeriod = no data stored
+- ctlv3 Z3BankHolidayEndPeriod = no data stored
+- ctlv3 Z3BankHolidayStartPeriod = no data stored
+- ctlv3 Z3BankHolidayStartPeriod = no data stored
+- ctlv3 Z3DayTemp = no data stored
+- ctlv3 Z3DayTemp = no data stored
+- ctlv3 Z3HolidayEndPeriod = no data stored
+- ctlv3 Z3HolidayEndPeriod = no data stored
+- ctlv3 Z3HolidayStartPeriod = no data stored
+- ctlv3 Z3HolidayStartPeriod = no data stored
+- ctlv3 Z3HolidayTemp = no data stored
+- ctlv3 Z3HolidayTemp = no data stored
+- ctlv3 Z3Name1 = no data stored
+- ctlv3 Z3Name1 = no data stored
+- ctlv3 Z3Name2 = no data stored
+- ctlv3 Z3Name2 = no data stored
+- ctlv3 Z3NightTemp = no data stored
+- ctlv3 Z3NightTemp = no data stored
+- ctlv3 Z3OpMode = no data stored
+- ctlv3 Z3OpMode = no data stored
+- ctlv3 Z3QuickVetoDuration = no data stored
+- ctlv3 Z3QuickVetoDuration = no data stored
+- ctlv3 Z3QuickVetoEndDate = no data stored
+- ctlv3 Z3QuickVetoEndTime = no data stored
+- ctlv3 Z3QuickVetoTemp = no data stored
+- ctlv3 Z3QuickVetoTemp = no data stored
+- ctlv3 Z3RoomTemp = no data stored
+- ctlv3 Z3RoomZoneMapping = none
+- ctlv3 Z3RoomZoneMapping = no data stored
+- ctlv3 Z3SFMode = no data stored
+- ctlv3 Z3SFMode = no data stored
+- ctlv3 Z3Shortname = no data stored
+- ctlv3 Z3Shortname = no data stored
+- ctlv3 Z3Timer_Config = no data stored
+- ctlv3 Z3Timer_Friday0 = no data stored
+- ctlv3 Z3Timer_Friday1 = no data stored
+- ctlv3 Z3Timer_Friday2 = no data stored
+- ctlv3 Z3Timer_Friday = no data stored
+- ctlv3 Z3Timer_Monday0 = no data stored
+- ctlv3 Z3Timer_Monday1 = no data stored
+- ctlv3 Z3Timer_Monday2 = no data stored
+- ctlv3 Z3Timer_Monday = no data stored
+- ctlv3 Z3Timer_Saturday0 = no data stored
+- ctlv3 Z3Timer_Saturday1 = no data stored
+- ctlv3 Z3Timer_Saturday2 = no data stored
+- ctlv3 Z3Timer_Saturday = no data stored
+- ctlv3 Z3Timer_Sunday0 = no data stored
+- ctlv3 Z3Timer_Sunday1 = no data stored
+- ctlv3 Z3Timer_Sunday2 = no data stored
+- ctlv3 Z3Timer_Sunday = no data stored
+- ctlv3 Z3Timer_Thursday0 = no data stored
+- ctlv3 Z3Timer_Thursday1 = no data stored
+- ctlv3 Z3Timer_Thursday2 = no data stored
+- ctlv3 Z3Timer_Thursday = no data stored
+- ctlv3 Z3Timer_Timeframes = no data stored
+- ctlv3 Z3Timer_Tuesday0 = no data stored
+- ctlv3 Z3Timer_Tuesday1 = no data stored
+- ctlv3 Z3Timer_Tuesday2 = no data stored
+- ctlv3 Z3Timer_Tuesday = no data stored
+- ctlv3 Z3Timer_Wednesday0 = no data stored
+- ctlv3 Z3Timer_Wednesday1 = no data stored
+- ctlv3 Z3Timer_Wednesday2 = no data stored
+- ctlv3 Z3Timer_Wednesday = no data stored
+- ctlv3 Z3ValveStatus = no data stored
+- ctlv3 Z3ValveStatus = no data stored
+- General Valuerange = no data stored
+- hmu CoolElecConsDay = 0.0
+- hmu CoolElecConsTotal = 32200
+- hmu CoolEnvYieldDay = 0.0
+- hmu CoolEnvYieldMonth = 0.0
+- hmu CoolEnvYieldTotal = 0.0
+- hmu HcElecConsDay = 340.775
+- hmu HcElecConsTotal = 10977.5
+- hmu HwcElecConsDay = 0.0
+- hmu HwcElecConsTotal = 0.0
+- 'hmu SourceTempInput =  (ERR: invalid position for 3108b51a0405ff3222 / 02ff01)'
+- Memory Eeprom = no data stored
+- Memory Eeprom = no data stored
+- Memory Ram = no data stored
+- Memory Ram = no data stored
+- Scan Id = no data stored
+- scan.04  = Vaillant;NETX3;0129;0404
+- scan.08  = Vaillant;HMUX0;0406;0504
+- scan.15  = Vaillant;CTLV3;0808;8004
+- Scan.15 Id = 21;25;45;0020260913;0953;026479;N3
+- scan.76  = Vaillant;VWZIO;0406;0504
+- Scan.76 Id = 21;26;03;8000035574;0001;005739;N8
+- scan.f6  = Vaillant;NETX3;0129;0404
+- Scan.f6 Id = 21;26;10;0020292012;0933;049007;N4
+- vwzio EnableTestHwcTemp = no data stored
+- vwzio EnableTestOutdoorTemp = no data stored
+- vwzio EnableTestThreeWayValve = no data stored
+- vwzio TestHwcTemp = no data stored
+- vwzio TestOutdoorTemp = no data stored
+- vwzio TestThreeWayValve = no data stored
+- ''

--- a/tests/fixtures/community/ecotec_vrt380_15700_discovery.yaml
+++ b/tests/fixtures/community/ecotec_vrt380_15700_discovery.yaml
@@ -1,0 +1,20490 @@
+# Discovery dump for vaillant_ebus
+# Review this file for sensitive information before sharing
+metadata:
+  timestamp: '2026-09-07T21:46:42.876353'
+  ebusd_version: ebusd 26.1.26.1
+  register_count: 1061
+  grab_duration: 300
+  dump_version: 3
+raw_find_lines:
+- bai AccessoriesOne = no data stored
+- bai AccessoriesOne = no data stored
+- bai AccessoriesTwo = no data stored
+- bai AccessoriesTwo = no data stored
+- bai ACRoomthermostat = no data stored
+- bai APCComStatus = no data stored
+- bai APCLegioProtection = no data stored
+- bai APCLegioProtection = no data stored
+- bai AverageIgnitiontime = no data stored
+- bai BlockTimeHcMax = no data stored
+- bai BlockTimeHcMax = no data stored
+- bai BoilerType = no data stored
+- bai ChangesDSN = no data stored
+- bai CirPump = no data stored
+- bai Clearerrorhistory = no data stored
+- bai CounterStartAttempts1 = no data stored
+- bai CounterStartAttempts2 = no data stored
+- bai CounterStartAttempts3 = no data stored
+- bai CounterStartAttempts4 = no data stored
+- bai Currenterror = -;-;-;-;-
+- bai Date = no data stored (message not available due to condition)
+- bai Date = no data stored (message not available due to condition)
+- bai DateTime = nosignal;-:-:-;-.-.-;23.875
+- bai DcfState = no data stored
+- bai DCFTimeDate = no data stored
+- bai DCRoomthermostat = no data stored
+- bai DeactivationsIFC = no data stored
+- bai DeactivationsTemplimiter = no data stored
+- bai DeltaFlowReturnMax = no data stored
+- bai DisplayMode = no data stored
+- bai DSN = no data stored
+- bai DSNOffset = no data stored
+- bai DSNOffset = no data stored
+- bai DSNStart = no data stored
+- bai EBusHeatcontrol = no data stored
+- bai EbusSourceOn = no data stored
+- bai EbusVoltage = no data stored
+- bai Errorhistory = no data stored
+- bai Expertlevel_ReturnTemp = no data stored
+- bai ExternalFaultmessage = no data stored
+- bai ExternalFlowTempDesired = no data stored
+- bai ExternalHwcSwitch = no data stored
+- bai ExternGasvalve = no data stored
+- bai ExtFlowTempDesiredMin = no data stored
+- bai ExtStorageModulCon = no data stored
+- bai ExtWP = no data stored
+- bai FanHours = 9
+- bai FanMaxSpeedOperation = no data stored
+- bai FanMinSpeedOperation = no data stored
+- bai FanPWMSum = no data stored
+- bai FanPWMTest = no data stored
+- bai FanSpeed = no data stored
+- bai FanSpeedOffsetMax = no data stored
+- bai FanSpeedOffsetMax = no data stored
+- bai FanSpeedOffsetMin = no data stored
+- bai FanSpeedOffsetMin = no data stored
+- bai FanStarts = no data stored
+- bai Flame = no data stored
+- bai FlameSensingASIC = no data stored
+- bai FloorHeatingContact = no data stored
+- bai FlowsetHcMax = no data stored
+- bai FlowsetHcMax = no data stored
+- bai FlowsetHwcMax = no data stored
+- bai FlowsetHwcMax = no data stored
+- bai FlowSetPotmeter = no data stored
+- bai FlowTemp = 45.44;ok
+- bai FlowTempDesired = 0.00
+- bai FlowTempMax = 68.12
+- bai Fluegasvalve = no data stored
+- bai FluegasvalveOpen = no data stored
+- bai Gasvalve3UC = no data stored
+- bai Gasvalve = no data stored
+- bai GasvalveASICFeedback = no data stored
+- bai GasvalveUC = no data stored
+- bai GasvalveUCFeedback = no data stored
+- bai GlobalSystemOff = no data stored (message not available due to condition)
+- bai GlobalSystemOff = no data stored (message not available due to condition)
+- bai HcHours = 0
+- bai HcPumpMode = no data stored
+- bai HcPumpMode = no data stored
+- bai HcPumpStarts = no data stored
+- bai HcStarts = no data stored
+- bai HcUnderHundredStarts = no data stored
+- bai HeatingSwitch = no data stored
+- bai HoursTillService = 2
+- bai HoursTillService = no data stored
+- bai HwcDemand = no data stored
+- bai HwcHours = 7
+- bai HwcImpellorSwitch = no data stored
+- bai HwcPostrunTime = no data stored
+- bai HwcPostrunTime = no data stored
+- bai HwcSetPotmeter = no data stored
+- bai HwcStarts = no data stored
+- bai HwcSwitch = no data stored
+- bai HwcTemp = no data stored
+- bai HwcTempDesired = 0.00
+- bai HwcTempMax = no data stored
+- bai HwcTempMax = no data stored
+- bai HwcTypes = no data stored
+- bai HwcUnderHundredStarts = no data stored
+- bai HwcWaterflow = no data stored
+- bai HwcWaterflowMax = no data stored
+- bai Ignitor = no data stored
+- bai InitialisationEEPROM = no data stored
+- bai IonisationVoltageLevel = no data stored
+- bai Maintenancedata_HwcTempMax = no data stored
+- bai MaxIgnitiontime = no data stored
+- bai MinIgnitiontime = no data stored
+- bai ModulationDesired = no data stored
+- bai OutdoorstempSensor = no data stored
+- bai OverflowCounter = no data stored
+- bai ParamToken = no data stored
+- bai PartloadHcKW = no data stored
+- bai PartloadHcKW = no data stored
+- bai PartloadHwcKW = no data stored
+- bai PartloadHwcKW = no data stored
+- bai PartnumberBox = no data stored
+- bai PositionValveSet = no data stored
+- bai PowerValue = no data stored
+- bai PrAPSCounter = no data stored
+- bai PrAPSSum = no data stored
+- bai PrEnergyCountHc1 = no data stored
+- bai PrEnergyCountHc1 = no data stored
+- bai PrEnergyCountHc2 = no data stored
+- bai PrEnergyCountHc2 = no data stored
+- bai PrEnergyCountHc3 = no data stored
+- bai PrEnergyCountHc3 = no data stored
+- bai PrEnergyCountHwc1 = no data stored
+- bai PrEnergyCountHwc1 = no data stored
+- bai PrEnergyCountHwc2 = no data stored
+- bai PrEnergyCountHwc2 = no data stored
+- bai PrEnergyCountHwc3 = no data stored
+- bai PrEnergyCountHwc3 = no data stored
+- bai PrEnergySumHc1 = no data stored
+- bai PrEnergySumHc1 = no data stored
+- bai PrEnergySumHc2 = no data stored
+- bai PrEnergySumHc2 = no data stored
+- bai PrEnergySumHc3 = no data stored
+- bai PrEnergySumHc3 = no data stored
+- bai PrEnergySumHwc1 = no data stored
+- bai PrEnergySumHwc1 = no data stored
+- bai PrEnergySumHwc2 = no data stored
+- bai PrEnergySumHwc2 = no data stored
+- bai PrEnergySumHwc3 = no data stored
+- bai PrEnergySumHwc3 = no data stored
+- bai PrimaryCircuitFlowrate = no data stored
+- bai ProductionByte = no data stored
+- bai PrVortexFlowSensorValue = no data stored
+- bai PumpHours = 12
+- bai PumpHwcFlowNumber = no data stored
+- bai PumpHwcFlowSum = no data stored
+- bai PumpPower = 0
+- bai PumpPowerDesired = no data stored
+- bai PumpPowerDesired = no data stored
+- bai RemainingBoilerblocktime = no data stored
+- bai ReturnRegulation = no data stored
+- bai ReturnRegulation = no data stored
+- bai ReturnTemp = 44.06;64830;ok
+- bai ReturnTempMax = 60.75
+- bai SecondPumpMode = no data stored
+- bai SecondPumpMode = no data stored
+- bai SerialNumber = no data stored
+- bai SetFactoryValues = no data stored
+- bai SetFactoryValues = no data stored
+- bai SetMode = auto;0.0;-;-;1;0;1;0;0;0
+- bai SetMode = no data stored
+- bai SHEMaxDeltaHwcFlow = no data stored
+- bai SHEMaxFlowTemp = no data stored
+- bai SolPostHeat = no data stored
+- bai SolPostHeat = no data stored
+- bai StatElectricEnergySum = 1.440960050
+- bai StatEnergySumYear = no data stored
+- bai Statenumber = no data stored
+- bai StatEnvironmentEnergySum = 0.000000000
+- bai StatEnvironmentEnergySumHc = 0.000000000
+- bai StatEnvironmentEnergySumHwc = 0.000000000
+- bai StatFuelSum = no data stored
+- bai StatFuelSumHc = no data stored
+- bai StatFuelSumHwc = no data stored
+- bai StatSolarEnergySum = 0.000000000
+- bai StatSolarEnergySumHc = 0.000000000
+- bai StatSolarEnergySumHwc = 0.000000000
+- bai Status01 = 45.0;43.5;23.875;37.5;-;off
+- bai Status02 = auto;60;65.0;70;65.0
+- bai Status16 = no data stored
+- bai Status = no data stored
+- bai StatusCirPump = off
+- bai Storageloadpump = no data stored
+- bai StorageLoadPumpHours = 0
+- bai StorageloadPumpStarts = no data stored
+- bai StorageLoadTimeMax = no data stored
+- bai StorageLoadTimeMax = no data stored
+- bai StoragereleaseClock = no data stored
+- bai StorageTemp = -13.50;cutoff
+- bai StorageTempDesired = 30.00
+- bai StorageTempMax = no data stored
+- bai TargetFanSpeed = no data stored
+- bai TargetFanSpeedOutput = no data stored
+- bai TempDiffBlock = no data stored
+- bai TempDiffFailure = no data stored
+- bai TempGradientFailure = no data stored
+- bai Templimiter = no data stored
+- bai TemplimiterWithNTC = no data stored
+- bai TempMaxDiffExtTFT = no data stored
+- bai Testbyte = no data stored
+- bai Time = no data stored (message not available due to condition)
+- bai Time = no data stored (message not available due to condition)
+- bai TimerInputHc = no data stored
+- bai ValveMode = no data stored
+- bai ValveMode = no data stored
+- bai ValveStarts = no data stored
+- bai VolatileLockout = no data stored
+- bai VolatileLockoutIFCGV = no data stored
+- bai VortexFlowSensor = no data stored
+- bai WarmstartDemand = no data stored
+- bai WarmstartOffset = no data stored
+- bai WarmstartOffset = no data stored
+- bai WaterHcFlowMax = no data stored
+- bai WaterPressure = 1.452;ok
+- bai WaterpressureBranchControlOff = no data stored
+- bai WaterpressureMeasureCounter = no data stored
+- bai WaterpressureVariantSum = no data stored
+- bai WP = no data stored
+- bai WPPostrunTime = no data stored
+- bai WPPostrunTime = no data stored
+- bai WPSecondStage = no data stored
+- bai Z1HolidayTempStatus = no data stored (message not available due to condition)
+- Broadcast Datetime = no data stored
+- Broadcast Error = no data stored
+- Broadcast HwcStatus = no data stored
+- Broadcast Id = no data stored
+- Broadcast IdAnswer = no data stored
+- Broadcast IdQuery = no data stored
+- Broadcast Load = no data stored
+- Broadcast Outsidetemp = 22.875
+- Broadcast Queryexistence = no data stored
+- Broadcast Signoflife = no data stored
+- Broadcast Vdatetime = 21:39:49;07.09.2026
+- Broadcast Vdatetime = no data stored
+- ctlv0 AdaptHeatCurve = yes
+- ctlv0 AdaptHeatCurve = no data stored
+- ctlv0 BankHolidayEndPeriod = no data stored
+- ctlv0 BankHolidayEndPeriod = no data stored
+- ctlv0 BankHolidayStartPeriod = no data stored
+- ctlv0 BankHolidayStartPeriod = no data stored
+- ctlv0 CcTimer_Friday = no data stored
+- ctlv0 CcTimer_Friday = no data stored
+- ctlv0 CcTimer_Monday = no data stored
+- ctlv0 CcTimer_Monday = no data stored
+- ctlv0 CcTimer_Saturday = no data stored
+- ctlv0 CcTimer_Saturday = no data stored
+- ctlv0 CcTimer_Sunday = no data stored
+- ctlv0 CcTimer_Sunday = no data stored
+- ctlv0 CcTimer_Thursday = no data stored
+- ctlv0 CcTimer_Thursday = no data stored
+- ctlv0 CcTimer_Tuesday = no data stored
+- ctlv0 CcTimer_Tuesday = no data stored
+- ctlv0 CcTimer_Wednesday = no data stored
+- ctlv0 CcTimer_Wednesday = no data stored
+- ctlv0 Clearerrorhistory = no data stored
+- ctlv0 ContinuosHeating = no data stored
+- ctlv0 ContinuosHeating = no data stored
+- ctlv0 Currenterror = -;-;-;-;-
+- ctlv0 CylinderChargeHyst = 5
+- ctlv0 CylinderChargeHyst = no data stored
+- ctlv0 CylinderChargeOffset = 25
+- ctlv0 CylinderChargeOffset = no data stored
+- ctlv0 Date = 07.09.2026
+- ctlv0 Date = no data stored
+- ctlv0 DisplayedOutsideTemp = 23.0625
+- ctlv0 Errorhistory = no data stored
+- ctlv0 FrostOverRideTime = 4
+- ctlv0 FrostOverRideTime = no data stored
+- ctlv0 GlobalSystemOff = no data stored
+- ctlv0 GlobalSystemOff = no data stored
+- ctlv0 Hc1ActualFlowTempDesired = 0.0
+- ctlv0 Hc1AutoOffMode = eco
+- ctlv0 Hc1AutoOffMode = no data stored
+- 'ctlv0 Hc1CircuitType =  (ERR: invalid position for 3115b52406020002000200 / 00)'
+- 'ctlv0 Hc1ExcessTemp =  (ERR: invalid position for 3115b52406020002000b00 / 00)'
+- ctlv0 Hc1ExcessTemp = no data stored
+- ctlv0 Hc1FlowTemp = 46
+- ctlv0 Hc1HeatCurve = 0.8
+- ctlv0 Hc1HeatCurve = no data stored
+- ctlv0 Hc1HeatCurveAdaption = 0.0
+- ctlv0 Hc1MaxFlowTempDesired = 90
+- ctlv0 Hc1MaxFlowTempDesired = no data stored
+- ctlv0 Hc1MinFlowTempDesired = 20
+- ctlv0 Hc1MinFlowTempDesired = no data stored
+- 'ctlv0 Hc1MixerMovement =  (ERR: invalid position for 3115b52406020002001a00 / 00)'
+- ctlv0 Hc1PumpStatus = 0
+- ctlv0 Hc1PumpStatus = no data stored
+- ctlv0 Hc1RoomTempSwitchOn = modulating
+- ctlv0 Hc1RoomTempSwitchOn = no data stored
+- 'ctlv0 Hc1Status =  (ERR: invalid position for 3115b52406020002001b00 / 00)'
+- ctlv0 Hc1Status = no data stored
+- ctlv0 Hc1SummerTempLimit = 20
+- ctlv0 Hc1SummerTempLimit = no data stored
+- ctlv0 Hc2ActualFlowTempDesired = 0.0
+- ctlv0 Hc2AutoOffMode = eco
+- ctlv0 Hc2AutoOffMode = no data stored
+- 'ctlv0 Hc2CircuitType =  (ERR: invalid position for 3115b52406020002010200 / 00)'
+- 'ctlv0 Hc2ExcessTemp =  (ERR: invalid position for 3115b52406020002010b00 / 00)'
+- ctlv0 Hc2ExcessTemp = no data stored
+- ctlv0 Hc2FlowTemp =  (empty for 3115b52406020002010800 / 0800020800ffffff7f)
+- ctlv0 Hc2HeatCurve = 1.2
+- ctlv0 Hc2HeatCurve = no data stored
+- ctlv0 Hc2HeatCurveAdaption = 0.0
+- ctlv0 Hc2MaxFlowTempDesired = 90
+- ctlv0 Hc2MaxFlowTempDesired = no data stored
+- ctlv0 Hc2MinFlowTempDesired = 15
+- ctlv0 Hc2MinFlowTempDesired = no data stored
+- 'ctlv0 Hc2MixerMovement =  (ERR: invalid position for 3115b52406020002011a00 / 00)'
+- ctlv0 Hc2PumpStatus = 0
+- ctlv0 Hc2PumpStatus = no data stored
+- ctlv0 Hc2RoomTempSwitchOn = off
+- ctlv0 Hc2RoomTempSwitchOn = no data stored
+- 'ctlv0 Hc2Status =  (ERR: invalid position for 3115b52406020002011b00 / 00)'
+- ctlv0 Hc2Status = no data stored
+- ctlv0 Hc2SummerTempLimit = 21
+- ctlv0 Hc2SummerTempLimit = no data stored
+- ctlv0 Hc3ActualFlowTempDesired = 0.0
+- ctlv0 Hc3AutoOffMode = eco
+- ctlv0 Hc3AutoOffMode = no data stored
+- 'ctlv0 Hc3CircuitType =  (ERR: invalid position for 3115b52406020002020200 / 00)'
+- 'ctlv0 Hc3ExcessTemp =  (ERR: invalid position for 3115b52406020002020b00 / 00)'
+- ctlv0 Hc3ExcessTemp = no data stored
+- ctlv0 Hc3FlowTemp =  (empty for 3115b52406020002020800 / 0800020800ffffff7f)
+- ctlv0 Hc3HeatCurve = 1.2
+- ctlv0 Hc3HeatCurve = no data stored
+- ctlv0 Hc3HeatCurveAdaption = 0.0
+- ctlv0 Hc3MaxFlowTempDesired = 90
+- ctlv0 Hc3MaxFlowTempDesired = no data stored
+- ctlv0 Hc3MinFlowTempDesired = 15
+- ctlv0 Hc3MinFlowTempDesired = no data stored
+- 'ctlv0 Hc3MixerMovement =  (ERR: invalid position for 3115b52406020002021a00 / 00)'
+- ctlv0 Hc3PumpStatus = 0
+- ctlv0 Hc3PumpStatus = no data stored
+- ctlv0 Hc3RoomTempSwitchOn = off
+- ctlv0 Hc3RoomTempSwitchOn = no data stored
+- 'ctlv0 Hc3Status =  (ERR: invalid position for 3115b52406020002021b00 / 00)'
+- ctlv0 Hc3Status = no data stored
+- ctlv0 Hc3SummerTempLimit = 21
+- ctlv0 Hc3SummerTempLimit = no data stored
+- ctlv0 HcStorageTempBottom = no data stored
+- ctlv0 HcStorageTempTop = no data stored
+- ctlv0 HolidayEndPeriod = no data stored
+- ctlv0 HolidayEndPeriod = no data stored
+- ctlv0 HolidayStartPeriod = no data stored
+- ctlv0 HolidayStartPeriod = no data stored
+- ctlv0 HolidayTemp = no data stored
+- ctlv0 HolidayTemp = no data stored
+- ctlv0 HwcBankHolidayEndPeriod = no data stored
+- ctlv0 HwcBankHolidayEndPeriod = no data stored
+- ctlv0 HwcBankHolidayStartPeriod = no data stored
+- ctlv0 HwcBankHolidayStartPeriod = no data stored
+- ctlv0 HwcFlowTemp = 0.0
+- ctlv0 HwcHolidayEndPeriod = 01.01.2019
+- ctlv0 HwcHolidayEndPeriod = no data stored
+- ctlv0 HwcHolidayStartPeriod = 01.01.2019
+- ctlv0 HwcHolidayStartPeriod = no data stored
+- ctlv0 HwcLockTime = 60
+- ctlv0 HwcLockTime = no data stored
+- 'ctlv0 HwcMaxFlowTempDesired =  (ERR: invalid position for 3115b52406020000004600
+  / 00)'
+- ctlv0 HwcMaxFlowTempDesired = no data stored
+- ctlv0 HwcOpMode = day
+- ctlv0 HwcOpMode = no data stored
+- ctlv0 HwcParallelLoading = off
+- ctlv0 HwcParallelLoading = no data stored
+- ctlv0 HwcSFMode = auto
+- ctlv0 HwcSFMode = no data stored
+- ctlv0 HwcStorageTemp =  (empty for 3115b52406020001000500 / 0800010500ffffff7f)
+- 'ctlv0 HwcStorageTempBottom =  (ERR: invalid position for 3115b52406020000009e00
+  / 00)'
+- 'ctlv0 HwcStorageTempTop =  (ERR: invalid position for 3115b52406020000009d00 /
+  00)'
+- ctlv0 HwcTempDesired = 45
+- ctlv0 HwcTempDesired = no data stored
+- ctlv0 HwcTimer_Friday = no data stored
+- ctlv0 HwcTimer_Friday = no data stored
+- ctlv0 HwcTimer_Monday = no data stored
+- ctlv0 HwcTimer_Monday = no data stored
+- ctlv0 HwcTimer_Saturday = no data stored
+- ctlv0 HwcTimer_Saturday = no data stored
+- ctlv0 HwcTimer_Sunday = no data stored
+- ctlv0 HwcTimer_Sunday = no data stored
+- ctlv0 HwcTimer_Thursday = no data stored
+- ctlv0 HwcTimer_Thursday = no data stored
+- ctlv0 HwcTimer_Tuesday = no data stored
+- ctlv0 HwcTimer_Tuesday = no data stored
+- ctlv0 HwcTimer_Wednesday = no data stored
+- ctlv0 HwcTimer_Wednesday = no data stored
+- 'ctlv0 HydraulicScheme =  (ERR: invalid position for 3115b52406020000003600 / 00)'
+- ctlv0 HydraulicScheme = no data stored
+- ctlv0 Installer1 = no data stored
+- ctlv0 Installer1 = no data stored
+- ctlv0 Installer2 = no data stored
+- ctlv0 Installer2 = no data stored
+- ctlv0 KeyCodeforConfigMenu = no data stored
+- ctlv0 KeyCodeforConfigMenu = no data stored
+- ctlv0 MaintenanceDate = no data stored
+- ctlv0 MaintenanceDate = no data stored
+- ctlv0 MaintenanceDue = no data stored
+- ctlv0 ManualCooling = no data stored
+- ctlv0 ManualCooling = no data stored
+- ctlv0 MaxCylinderChargeTime = 60
+- ctlv0 MaxCylinderChargeTime = no data stored
+- 'ctlv0 MaxRoomHumidity =  (ERR: invalid position for 3115b52406020000000e00 / 00)'
+- ctlv0 MaxRoomHumidity = no data stored
+- 'ctlv0 MultiRelaySetting =  (ERR: invalid position for 3115b52406020000004d00 /
+  00)'
+- ctlv0 MultiRelaySetting = no data stored
+- ctlv0 NoiseReductionTimer_Friday = no data stored
+- ctlv0 NoiseReductionTimer_Friday = no data stored
+- ctlv0 NoiseReductionTimer_Monday = no data stored
+- ctlv0 NoiseReductionTimer_Monday = no data stored
+- ctlv0 NoiseReductionTimer_Saturday = no data stored
+- ctlv0 NoiseReductionTimer_Saturday = no data stored
+- ctlv0 NoiseReductionTimer_Sunday = no data stored
+- ctlv0 NoiseReductionTimer_Sunday = no data stored
+- ctlv0 NoiseReductionTimer_Thursday = no data stored
+- ctlv0 NoiseReductionTimer_Thursday = no data stored
+- ctlv0 NoiseReductionTimer_Tuesday = no data stored
+- ctlv0 NoiseReductionTimer_Tuesday = no data stored
+- ctlv0 NoiseReductionTimer_Wednesday = no data stored
+- ctlv0 NoiseReductionTimer_Wednesday = no data stored
+- ctlv0 OpMode = no data stored
+- ctlv0 OpMode = no data stored
+- ctlv0 OpModeCooling = no data stored
+- ctlv0 OpModeCooling = no data stored
+- ctlv0 OpModeEffect = no data stored
+- ctlv0 OpModeEffect = no data stored
+- ctlv0 OpModeVentilation = no data stored
+- ctlv0 OpModeVentilation = no data stored
+- 'ctlv0 OutsideTempAvg =  (ERR: invalid position for 3115b52406020000009500 / 00)'
+- ctlv0 OutsideTempAvg = no data stored
+- ctlv0 PhoneNumber1 = no data stored
+- ctlv0 PhoneNumber1 = no data stored
+- ctlv0 PhoneNumber2 = no data stored
+- ctlv0 PhoneNumber2 = no data stored
+- 'ctlv0 PrEnergySum =  (ERR: invalid position for 3115b52406020000005c00 / 00)'
+- ctlv0 PrEnergySum = no data stored
+- 'ctlv0 PrEnergySumHc =  (ERR: invalid position for 3115b52406020000005700 / 00)'
+- ctlv0 PrEnergySumHc = no data stored
+- 'ctlv0 PrEnergySumHcLastMonth =  (ERR: invalid position for 3115b52406020000005300
+  / 00)'
+- ctlv0 PrEnergySumHcLastMonth = no data stored
+- 'ctlv0 PrEnergySumHcThisMonth =  (ERR: invalid position for 3115b52406020000004f00
+  / 00)'
+- ctlv0 PrEnergySumHcThisMonth = no data stored
+- 'ctlv0 PrEnergySumHwc =  (ERR: invalid position for 3115b52406020000005800 / 00)'
+- ctlv0 PrEnergySumHwc = no data stored
+- 'ctlv0 PrEnergySumHwcLastMonth =  (ERR: invalid position for 3115b52406020000005400
+  / 00)'
+- ctlv0 PrEnergySumHwcLastMonth = no data stored
+- 'ctlv0 PrEnergySumHwcThisMonth =  (ERR: invalid position for 3115b52406020000005000
+  / 00)'
+- ctlv0 PrEnergySumHwcThisMonth = no data stored
+- ctlv0 PrFuelSum = no data stored
+- ctlv0 PrFuelSum = no data stored
+- ctlv0 PrFuelSumHc = no data stored
+- ctlv0 PrFuelSumHc = no data stored
+- ctlv0 PrFuelSumHcLastMonth = no data stored
+- ctlv0 PrFuelSumHcLastMonth = no data stored
+- ctlv0 PrFuelSumHcThisMonth = no data stored
+- ctlv0 PrFuelSumHcThisMonth = no data stored
+- ctlv0 PrFuelSumHwc = no data stored
+- ctlv0 PrFuelSumHwc = no data stored
+- ctlv0 PrFuelSumHwcLastMonth = no data stored
+- ctlv0 PrFuelSumHwcLastMonth = no data stored
+- ctlv0 PrFuelSumHwcThisMonth = no data stored
+- ctlv0 PrFuelSumHwcThisMonth = no data stored
+- ctlv0 PumpAdditionalTime = no data stored
+- ctlv0 PumpAdditionalTime = no data stored
+- ctlv0 RoomHumidity = no data stored
+- ctlv0 SFMode = no data stored
+- ctlv0 SFMode = no data stored
+- ctlv0 SolarYieldTotal = no data stored
+- ctlv0 SolarYieldTotal = no data stored
+- ctlv0 SystemFlowTemp =  (empty for 3115b52406020000004b00 / 0800004b00ffffff7f)
+- ctlv0 TariffTimer_Friday = no data stored
+- ctlv0 TariffTimer_Friday = no data stored
+- ctlv0 TariffTimer_Monday = no data stored
+- ctlv0 TariffTimer_Monday = no data stored
+- ctlv0 TariffTimer_Saturday = no data stored
+- ctlv0 TariffTimer_Saturday = no data stored
+- ctlv0 TariffTimer_Sunday = no data stored
+- ctlv0 TariffTimer_Sunday = no data stored
+- ctlv0 TariffTimer_Thursday = no data stored
+- ctlv0 TariffTimer_Thursday = no data stored
+- ctlv0 TariffTimer_Tuesday = no data stored
+- ctlv0 TariffTimer_Tuesday = no data stored
+- ctlv0 TariffTimer_Wednesday = no data stored
+- ctlv0 TariffTimer_Wednesday = no data stored
+- ctlv0 Time = no data stored
+- ctlv0 Time = no data stored
+- ctlv0 VentilationDay = no data stored
+- ctlv0 VentilationDay = no data stored
+- ctlv0 VentilationNight = no data stored
+- ctlv0 VentilationNight = no data stored
+- ctlv0 VentilationTimer_Friday = no data stored
+- ctlv0 VentilationTimer_Friday = no data stored
+- ctlv0 VentilationTimer_Monday = no data stored
+- ctlv0 VentilationTimer_Monday = no data stored
+- ctlv0 VentilationTimer_Saturday = no data stored
+- ctlv0 VentilationTimer_Saturday = no data stored
+- ctlv0 VentilationTimer_Sunday = no data stored
+- ctlv0 VentilationTimer_Sunday = no data stored
+- ctlv0 VentilationTimer_Thursday = no data stored
+- ctlv0 VentilationTimer_Thursday = no data stored
+- ctlv0 VentilationTimer_Tuesday = no data stored
+- ctlv0 VentilationTimer_Tuesday = no data stored
+- ctlv0 VentilationTimer_Wednesday = no data stored
+- ctlv0 VentilationTimer_Wednesday = no data stored
+- ctlv0 WaterPressure = 1.4
+- 'ctlv0 YieldTotal =  (ERR: invalid position for 3115b52406020000003e00 / 00)'
+- ctlv0 YieldTotal = no data stored
+- ctlv0 Z1ActualRoomTempDesired = 0.0
+- ctlv0 Z1ActualRoomTempDesired = no data stored
+- ctlv0 Z1BankHolidayEndPeriod = no data stored
+- ctlv0 Z1BankHolidayEndPeriod = no data stored
+- ctlv0 Z1BankHolidayStartPeriod = no data stored
+- ctlv0 Z1BankHolidayStartPeriod = no data stored
+- 'ctlv0 Z1CoolingTemp =  (ERR: invalid position for 3115b52406020003000200 / 00)'
+- ctlv0 Z1CoolingTemp = no data stored
+- ctlv0 Z1CoolingTimer_Friday = no data stored
+- ctlv0 Z1CoolingTimer_Friday = no data stored
+- ctlv0 Z1CoolingTimer_Monday = no data stored
+- ctlv0 Z1CoolingTimer_Monday = no data stored
+- ctlv0 Z1CoolingTimer_Saturday = no data stored
+- ctlv0 Z1CoolingTimer_Saturday = no data stored
+- ctlv0 Z1CoolingTimer_Sunday = no data stored
+- ctlv0 Z1CoolingTimer_Sunday = no data stored
+- ctlv0 Z1CoolingTimer_Thursday = no data stored
+- ctlv0 Z1CoolingTimer_Thursday = no data stored
+- ctlv0 Z1CoolingTimer_Tuesday = no data stored
+- ctlv0 Z1CoolingTimer_Tuesday = no data stored
+- ctlv0 Z1CoolingTimer_Wednesday = no data stored
+- ctlv0 Z1CoolingTimer_Wednesday = no data stored
+- 'ctlv0 Z1DayTemp =  (ERR: invalid position for 3115b52406020003000700 / 00)'
+- ctlv0 Z1DayTemp = no data stored
+- ctlv0 Z1HolidayEndPeriod = 01.01.2019
+- ctlv0 Z1HolidayEndPeriod = no data stored
+- ctlv0 Z1HolidayStartPeriod = 01.01.2019
+- ctlv0 Z1HolidayStartPeriod = no data stored
+- ctlv0 Z1HolidayTemp = 15
+- ctlv0 Z1HolidayTemp = no data stored
+- ctlv0 Z1Name1 = no data stored
+- ctlv0 Z1Name1 = no data stored
+- ctlv0 Z1Name2 = no data stored
+- ctlv0 Z1Name2 = no data stored
+- ctlv0 Z1NightTemp = 15
+- ctlv0 Z1NightTemp = no data stored
+- ctlv0 Z1OpMode = off
+- ctlv0 Z1OpMode = no data stored
+- ctlv0 Z1OpModeCooling = no data stored
+- ctlv0 Z1OpModeCooling = no data stored
+- ctlv0 Z1QuickVetoTemp = 21
+- ctlv0 Z1QuickVetoTemp = no data stored
+- ctlv0 Z1RoomTemp = 24.7875
+- ctlv0 Z1RoomZoneMapping = no data stored
+- ctlv0 Z1RoomZoneMapping = no data stored
+- ctlv0 Z1SFMode = auto
+- ctlv0 Z1SFMode = no data stored
+- ctlv0 Z1Shortname = no data stored
+- ctlv0 Z1Shortname = no data stored
+- ctlv0 Z1Timer_Friday = no data stored
+- ctlv0 Z1Timer_Friday = no data stored
+- ctlv0 Z1Timer_Monday = no data stored
+- ctlv0 Z1Timer_Monday = no data stored
+- ctlv0 Z1Timer_Saturday = no data stored
+- ctlv0 Z1Timer_Saturday = no data stored
+- ctlv0 Z1Timer_Sunday = no data stored
+- ctlv0 Z1Timer_Sunday = no data stored
+- ctlv0 Z1Timer_Thursday = no data stored
+- ctlv0 Z1Timer_Thursday = no data stored
+- ctlv0 Z1Timer_Tuesday = no data stored
+- ctlv0 Z1Timer_Tuesday = no data stored
+- ctlv0 Z1Timer_Wednesday = no data stored
+- ctlv0 Z1Timer_Wednesday = no data stored
+- ctlv0 Z1ValveStatus = no data stored
+- ctlv0 Z1ValveStatus = no data stored
+- ctlv0 Z2ActualRoomTempDesired = no data stored
+- ctlv0 Z2ActualRoomTempDesired = no data stored
+- ctlv0 Z2BankHolidayEndPeriod = no data stored
+- ctlv0 Z2BankHolidayEndPeriod = no data stored
+- ctlv0 Z2BankHolidayStartPeriod = no data stored
+- ctlv0 Z2BankHolidayStartPeriod = no data stored
+- ctlv0 Z2CoolingTemp = no data stored
+- ctlv0 Z2CoolingTemp = no data stored
+- ctlv0 Z2CoolingTimer_Friday = no data stored
+- ctlv0 Z2CoolingTimer_Friday = no data stored
+- ctlv0 Z2CoolingTimer_Monday = no data stored
+- ctlv0 Z2CoolingTimer_Monday = no data stored
+- ctlv0 Z2CoolingTimer_Saturday = no data stored
+- ctlv0 Z2CoolingTimer_Saturday = no data stored
+- ctlv0 Z2CoolingTimer_Sunday = no data stored
+- ctlv0 Z2CoolingTimer_Sunday = no data stored
+- ctlv0 Z2CoolingTimer_Thursday = no data stored
+- ctlv0 Z2CoolingTimer_Thursday = no data stored
+- ctlv0 Z2CoolingTimer_Tuesday = no data stored
+- ctlv0 Z2CoolingTimer_Tuesday = no data stored
+- ctlv0 Z2CoolingTimer_Wednesday = no data stored
+- ctlv0 Z2CoolingTimer_Wednesday = no data stored
+- ctlv0 Z2DayTemp = no data stored
+- ctlv0 Z2DayTemp = no data stored
+- ctlv0 Z2HolidayEndPeriod = no data stored
+- ctlv0 Z2HolidayEndPeriod = no data stored
+- ctlv0 Z2HolidayStartPeriod = no data stored
+- ctlv0 Z2HolidayStartPeriod = no data stored
+- ctlv0 Z2HolidayTemp = no data stored
+- ctlv0 Z2HolidayTemp = no data stored
+- ctlv0 Z2Name1 = no data stored
+- ctlv0 Z2Name1 = no data stored
+- ctlv0 Z2Name2 = no data stored
+- ctlv0 Z2Name2 = no data stored
+- ctlv0 Z2NightTemp = no data stored
+- ctlv0 Z2NightTemp = no data stored
+- ctlv0 Z2OpMode = no data stored
+- ctlv0 Z2OpMode = no data stored
+- ctlv0 Z2OpModeCooling = no data stored
+- ctlv0 Z2OpModeCooling = no data stored
+- ctlv0 Z2QuickVetoTemp = no data stored
+- ctlv0 Z2QuickVetoTemp = no data stored
+- ctlv0 Z2RoomTemp =  (empty for 3115b52406020003010f00 / 0800030f00ffffff7f)
+- ctlv0 Z2RoomZoneMapping = no data stored
+- ctlv0 Z2RoomZoneMapping = no data stored
+- ctlv0 Z2SFMode = no data stored
+- ctlv0 Z2SFMode = no data stored
+- ctlv0 Z2Shortname = no data stored
+- ctlv0 Z2Shortname = no data stored
+- ctlv0 Z2Timer_Friday = no data stored
+- ctlv0 Z2Timer_Friday = no data stored
+- ctlv0 Z2Timer_Monday = no data stored
+- ctlv0 Z2Timer_Monday = no data stored
+- ctlv0 Z2Timer_Saturday = no data stored
+- ctlv0 Z2Timer_Saturday = no data stored
+- ctlv0 Z2Timer_Sunday = no data stored
+- ctlv0 Z2Timer_Sunday = no data stored
+- ctlv0 Z2Timer_Thursday = no data stored
+- ctlv0 Z2Timer_Thursday = no data stored
+- ctlv0 Z2Timer_Tuesday = no data stored
+- ctlv0 Z2Timer_Tuesday = no data stored
+- ctlv0 Z2Timer_Wednesday = no data stored
+- ctlv0 Z2Timer_Wednesday = no data stored
+- ctlv0 Z2ValveStatus = no data stored
+- ctlv0 Z2ValveStatus = no data stored
+- ctlv0 Z3ActualRoomTempDesired = no data stored
+- ctlv0 Z3ActualRoomTempDesired = no data stored
+- ctlv0 Z3BankHolidayEndPeriod = no data stored
+- ctlv0 Z3BankHolidayEndPeriod = no data stored
+- ctlv0 Z3BankHolidayStartPeriod = no data stored
+- ctlv0 Z3BankHolidayStartPeriod = no data stored
+- ctlv0 Z3CoolingTemp = no data stored
+- ctlv0 Z3CoolingTemp = no data stored
+- ctlv0 Z3CoolingTimer_Friday = no data stored
+- ctlv0 Z3CoolingTimer_Friday = no data stored
+- ctlv0 Z3CoolingTimer_Monday = no data stored
+- ctlv0 Z3CoolingTimer_Monday = no data stored
+- ctlv0 Z3CoolingTimer_Saturday = no data stored
+- ctlv0 Z3CoolingTimer_Saturday = no data stored
+- ctlv0 Z3CoolingTimer_Sunday = no data stored
+- ctlv0 Z3CoolingTimer_Sunday = no data stored
+- ctlv0 Z3CoolingTimer_Thursday = no data stored
+- ctlv0 Z3CoolingTimer_Thursday = no data stored
+- ctlv0 Z3CoolingTimer_Tuesday = no data stored
+- ctlv0 Z3CoolingTimer_Tuesday = no data stored
+- ctlv0 Z3CoolingTimer_Wednesday = no data stored
+- ctlv0 Z3CoolingTimer_Wednesday = no data stored
+- ctlv0 Z3DayTemp = no data stored
+- ctlv0 Z3DayTemp = no data stored
+- ctlv0 Z3HolidayEndPeriod = no data stored
+- ctlv0 Z3HolidayEndPeriod = no data stored
+- ctlv0 Z3HolidayStartPeriod = no data stored
+- ctlv0 Z3HolidayStartPeriod = no data stored
+- ctlv0 Z3HolidayTemp = no data stored
+- ctlv0 Z3HolidayTemp = no data stored
+- ctlv0 Z3Name1 = no data stored
+- ctlv0 Z3Name1 = no data stored
+- ctlv0 Z3Name2 = no data stored
+- ctlv0 Z3Name2 = no data stored
+- ctlv0 Z3NightTemp = no data stored
+- ctlv0 Z3NightTemp = no data stored
+- ctlv0 Z3OpMode = no data stored
+- ctlv0 Z3OpMode = no data stored
+- ctlv0 Z3OpModeCooling = no data stored
+- ctlv0 Z3OpModeCooling = no data stored
+- ctlv0 Z3QuickVetoTemp = no data stored
+- ctlv0 Z3QuickVetoTemp = no data stored
+- ctlv0 Z3RoomTemp = no data stored
+- ctlv0 Z3RoomZoneMapping = no data stored
+- ctlv0 Z3RoomZoneMapping = no data stored
+- ctlv0 Z3SFMode = no data stored
+- ctlv0 Z3SFMode = no data stored
+- ctlv0 Z3Shortname = no data stored
+- ctlv0 Z3Shortname = no data stored
+- ctlv0 Z3Timer_Friday = no data stored
+- ctlv0 Z3Timer_Friday = no data stored
+- ctlv0 Z3Timer_Monday = no data stored
+- ctlv0 Z3Timer_Monday = no data stored
+- ctlv0 Z3Timer_Saturday = no data stored
+- ctlv0 Z3Timer_Saturday = no data stored
+- ctlv0 Z3Timer_Sunday = no data stored
+- ctlv0 Z3Timer_Sunday = no data stored
+- ctlv0 Z3Timer_Thursday = no data stored
+- ctlv0 Z3Timer_Thursday = no data stored
+- ctlv0 Z3Timer_Tuesday = no data stored
+- ctlv0 Z3Timer_Tuesday = no data stored
+- ctlv0 Z3Timer_Wednesday = no data stored
+- ctlv0 Z3Timer_Wednesday = no data stored
+- ctlv0 Z3ValveStatus = no data stored
+- ctlv0 Z3ValveStatus = no data stored
+- 'ctlv2 Hc1DewPointTemp =  (ERR: invalid position for 3115b52406020002002300 / 00)'
+- 'ctlv2 Hc1FlowTempCalc =  (ERR: invalid position for 3115b52406020002002000 / 00)'
+- 'ctlv2 Hc1Humidity =  (ERR: invalid position for 3115b52406020002002200 / 00)'
+- 'ctlv2 Hc1MixerPosition =  (ERR: invalid position for 3115b52406020002002100 / 00)'
+- 'ctlv2 Hc1PumpHours =  (ERR: invalid position for 3115b52406020002002400 / 00)'
+- 'ctlv2 Hc1PumpStarts =  (ERR: invalid position for 3115b52406020002002500 / 00)'
+- 'ctlv2 Hc2DewPointTemp =  (ERR: invalid position for 3115b52406020002012300 / 00)'
+- 'ctlv2 Hc2FlowTempCalc =  (ERR: invalid position for 3115b52406020002012000 / 00)'
+- 'ctlv2 Hc2Humidity =  (ERR: invalid position for 3115b52406020002012200 / 00)'
+- 'ctlv2 Hc2MixerPosition =  (ERR: invalid position for 3115b52406020002012100 / 00)'
+- 'ctlv2 Hc2PumpHours =  (ERR: invalid position for 3115b52406020002012400 / 00)'
+- 'ctlv2 Hc2PumpStarts =  (ERR: invalid position for 3115b52406020002012500 / 00)'
+- 'ctlv2 ManualCoolingEndDate =  (ERR: invalid position for 3115b5240602000000db00
+  / 00)'
+- ctlv2 ManualCoolingEndDate = no data stored
+- 'ctlv2 ManualCoolingStartDate =  (ERR: invalid position for 3115b5240602000000da00
+  / 00)'
+- ctlv2 ManualCoolingStartDate = no data stored
+- 'ctlv2 z1RoomHumidity =  (ERR: invalid position for 3115b52406020003002800 / 00)'
+- General Valuerange = no data stored
+- hmu CoolElecConsDay = 0.0
+- hmu CoolElecConsTotal = 0.0
+- hmu CoolEnvYieldDay = 0.0
+- hmu CoolEnvYieldMonth = 0.0
+- hmu CoolEnvYieldTotal = 0.0
+- hmu HcElecConsDay = 55.26
+- hmu HcElecConsTotal = 931.91
+- hmu HwcElecConsDay = 24.89
+- hmu HwcElecConsTotal = 508.93
+- 'hmu SourceTempInput =  (ERR: invalid position for 3108b51a0405ff3222 / 02ff01)'
+- Memory Eeprom = no data stored
+- Memory Eeprom = no data stored
+- Memory Ram = no data stored
+- Memory Ram = no data stored
+- sc Clearerrorhistory = no data stored
+- sc Col = no data stored
+- sc ColKickPumpTime = no data stored
+- sc ColKickTempDelta = no data stored
+- sc CollPump = no data stored
+- sc Currenterror = -;-;-;-;-
+- sc D1Temp = no data stored
+- sc D2Temp = no data stored
+- 'sc Date =  (ERR: invalid position for 31ecb509030d0d00 / 00)'
+- sc EDFunction = no data stored
+- sc EDFunction = no data stored
+- sc EnableScProtection = no data stored
+- sc EnableScProtection = no data stored
+- sc Errorhistory = no data stored
+- sc FlowRate = no data stored
+- sc FlowRate = no data stored
+- sc FrostProtectionEnabled = no data stored
+- sc FrostProtectionLimit = no data stored
+- sc Hc1PumpKol1PP1Port = no data stored
+- sc Hc2aLegPumpP2Port = no data stored
+- sc Hc2zPort = no data stored
+- 'sc HydraulicScheme =  (ERR: invalid position for 31ecb509030d2100 / 00)'
+- sc InitCircuit = no data stored
+- sc Iotest = no data stored
+- sc Ioteststop = no data stored
+- sc IsInBoostMode = no data stored
+- sc KickFunction = no data stored
+- sc KickFunction = no data stored
+- sc LpZpMaPort = no data stored
+- sc MAPreferredStorage = no data stored
+- sc MAPreferredStorage = no data stored
+- sc MaximalTemp2 = no data stored
+- sc MaximalTemp2 = no data stored
+- sc MaximalTemp = no data stored
+- sc MaximalTemp = no data stored
+- sc MultifunctionOutput = no data stored
+- sc OMultifunction = no data stored
+- sc OMultifunction = no data stored
+- sc PumpAntiLockingFlags = no data stored
+- sc QuickVetoStart = no data stored
+- sc ResetSolGain = no data stored
+- sc ResetSolGain = no data stored
+- sc RuntimeCollPump = no data stored
+- sc RuntimeCollPumpSeconds = no data stored
+- sc ScProtectionHysteresis = no data stored
+- sc ScProtectionLimit = no data stored
+- sc ScProtectionLimit = no data stored
+- sc ScProtectionTime = no data stored
+- sc SolCollPumpDcIntegrator = no data stored
+- sc SolCollPumpED = no data stored
+- sc SolGain = no data stored
+- sc SolOperationMode = no data stored
+- sc SP1 = no data stored
+- sc SP2 = no data stored
+- sc SumSolGain = no data stored
+- sc SumSolGainDayBefore = no data stored
+- sc SystemMode = no data stored
+- sc TempDifferenceOff2 = no data stored
+- sc TempDifferenceOff2 = no data stored
+- sc TempDifferenceOff = no data stored
+- sc TempDifferenceOff = no data stored
+- sc TempDifferenceOffTD12 = no data stored
+- sc TempDifferenceOffTD12 = no data stored
+- sc TempDifferenceOn2 = no data stored
+- sc TempDifferenceOn2 = no data stored
+- sc TempDifferenceOn = no data stored
+- sc TempDifferenceOn = no data stored
+- sc TempDifferenceOnTD12 = no data stored
+- sc TempDifferenceOnTD12 = no data stored
+- sc Time = no data stored
+- sc Weekday = no data stored
+- sc YieldLastYear = no data stored
+- sc YieldThisYear = no data stored
+- Scan Id = no data stored
+- scan.08  = Vaillant;BAI00;1201;7603
+- Scan.08 Id = xx
+- scan.15  = Vaillant;CTLV0;0313;9103
+- Scan.15 Id = no data stored
+- scan.ec  = Vaillant;SOL00;0313;9103
+- Scan.ec Id = no data stored
+- ''
+before_registers:
+- circuit: Broadcast
+  name: Datetime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Error
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: Broadcast
+  name: HwcStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Id
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: IdAnswer
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: IdQuery
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Load
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Outsidetemp
+  fields:
+  - value
+  values:
+  - '22.875'
+  writable: false
+  has_data: true
+- circuit: Broadcast
+  name: Queryexistence
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Signoflife
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Vdatetime
+  fields:
+  - value
+  values:
+  - 21:39:49;07.09.2026
+  writable: false
+  has_data: true
+- circuit: Broadcast
+  name: Vdatetime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: WaterPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: General
+  name: Valuerange
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Eeprom
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Eeprom
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Ram
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Ram
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Scan
+  name: Id
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Scan.08
+  name: Id
+  fields:
+  - value
+  values:
+  - xx
+  writable: false
+  has_data: true
+- circuit: Scan.15
+  name: Id
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Scan.ec
+  name: Id
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: ACRoomthermostat
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: APCComStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: APCLegioProtection
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: APCLegioProtection
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: AccessoriesOne
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: AccessoriesOne
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: AccessoriesTwo
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: AccessoriesTwo
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: AverageIgnitiontime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: BlockTimeHcMax
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: BlockTimeHcMax
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: BoilerType
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: ChangesDSN
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: CirPump
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: Clearerrorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: CounterStartAttempts1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: CounterStartAttempts2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: CounterStartAttempts3
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: CounterStartAttempts4
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - -;-;-;-;-
+  writable: false
+  has_data: true
+- circuit: bai
+  name: DCFTimeDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: DCRoomthermostat
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: DSN
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: DSNOffset
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: DSNOffset
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: DSNStart
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: Date
+  fields:
+  - value
+  values:
+  - no data stored (message not available due to condition)
+  writable: false
+  has_data: false
+- circuit: bai
+  name: Date
+  fields:
+  - value
+  values:
+  - no data stored (message not available due to condition)
+  writable: false
+  has_data: false
+- circuit: bai
+  name: DateTime
+  fields:
+  - value
+  values:
+  - nosignal;-:-:-;-.-.-;23.875
+  writable: false
+  has_data: true
+- circuit: bai
+  name: DcfState
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: DeactivationsIFC
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: DeactivationsTemplimiter
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: DeltaFlowReturnMax
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: DisplayMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: EBusHeatcontrol
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: EbusSourceOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: EbusVoltage
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: Expertlevel_ReturnTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: ExtFlowTempDesiredMin
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: ExtStorageModulCon
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: ExtWP
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: ExternGasvalve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: ExternalFaultmessage
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: ExternalFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: ExternalHwcSwitch
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: FanHours
+  fields:
+  - value
+  values:
+  - '9'
+  writable: false
+  has_data: true
+- circuit: bai
+  name: FanMaxSpeedOperation
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: FanMinSpeedOperation
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: FanPWMSum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: FanPWMTest
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: FanSpeed
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: FanSpeedOffsetMax
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: FanSpeedOffsetMax
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: FanSpeedOffsetMin
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: FanSpeedOffsetMin
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: FanStarts
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: Flame
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: FlameSensingASIC
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: FloorHeatingContact
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: FlowSetPotmeter
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: FlowTemp
+  fields:
+  - value
+  values:
+  - 45.44;ok
+  writable: false
+  has_data: true
+- circuit: bai
+  name: FlowTempDesired
+  fields:
+  - value
+  values:
+  - '0.00'
+  writable: false
+  has_data: true
+- circuit: bai
+  name: FlowTempMax
+  fields:
+  - value
+  values:
+  - '68.12'
+  writable: false
+  has_data: true
+- circuit: bai
+  name: FlowsetHcMax
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: FlowsetHcMax
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: FlowsetHwcMax
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: FlowsetHwcMax
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: Fluegasvalve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: FluegasvalveOpen
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: Gasvalve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: Gasvalve3UC
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: GasvalveASICFeedback
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: GasvalveUC
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: GasvalveUCFeedback
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: GlobalSystemOff
+  fields:
+  - value
+  values:
+  - no data stored (message not available due to condition)
+  writable: false
+  has_data: false
+- circuit: bai
+  name: GlobalSystemOff
+  fields:
+  - value
+  values:
+  - no data stored (message not available due to condition)
+  writable: false
+  has_data: false
+- circuit: bai
+  name: HcHours
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: bai
+  name: HcPumpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: HcPumpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: HcPumpStarts
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: HcStarts
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: HcUnderHundredStarts
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: HeatingSwitch
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: HoursTillService
+  fields:
+  - value
+  values:
+  - '2'
+  writable: false
+  has_data: true
+- circuit: bai
+  name: HoursTillService
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: HwcDemand
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: HwcHours
+  fields:
+  - value
+  values:
+  - '7'
+  writable: false
+  has_data: true
+- circuit: bai
+  name: HwcImpellorSwitch
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: HwcPostrunTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: HwcPostrunTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: HwcSetPotmeter
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: HwcStarts
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: HwcSwitch
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: HwcTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: HwcTempDesired
+  fields:
+  - value
+  values:
+  - '0.00'
+  writable: false
+  has_data: true
+- circuit: bai
+  name: HwcTempMax
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: HwcTempMax
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: HwcTypes
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: HwcUnderHundredStarts
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: HwcWaterflow
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: HwcWaterflowMax
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: Ignitor
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: InitialisationEEPROM
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: IonisationVoltageLevel
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: Maintenancedata_HwcTempMax
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: MaxIgnitiontime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: MinIgnitiontime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: ModulationDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: OutdoorstempSensor
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: OverflowCounter
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: ParamToken
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PartloadHcKW
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PartloadHcKW
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PartloadHwcKW
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PartloadHwcKW
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PartnumberBox
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PositionValveSet
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PowerValue
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PrAPSCounter
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PrAPSSum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PrEnergyCountHc1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PrEnergyCountHc1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PrEnergyCountHc2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PrEnergyCountHc2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PrEnergyCountHc3
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PrEnergyCountHc3
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PrEnergyCountHwc1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PrEnergyCountHwc1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PrEnergyCountHwc2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PrEnergyCountHwc2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PrEnergyCountHwc3
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PrEnergyCountHwc3
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PrEnergySumHc1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PrEnergySumHc1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PrEnergySumHc2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PrEnergySumHc2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PrEnergySumHc3
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PrEnergySumHc3
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PrEnergySumHwc1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PrEnergySumHwc1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PrEnergySumHwc2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PrEnergySumHwc2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PrEnergySumHwc3
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PrEnergySumHwc3
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PrVortexFlowSensorValue
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PrimaryCircuitFlowrate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: ProductionByte
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PumpHours
+  fields:
+  - value
+  values:
+  - '12'
+  writable: false
+  has_data: true
+- circuit: bai
+  name: PumpHwcFlowNumber
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PumpHwcFlowSum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PumpPower
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: bai
+  name: PumpPowerDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PumpPowerDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: RemainingBoilerblocktime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: ReturnRegulation
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: ReturnRegulation
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: ReturnTemp
+  fields:
+  - value
+  values:
+  - 44.06;64830;ok
+  writable: false
+  has_data: true
+- circuit: bai
+  name: ReturnTempMax
+  fields:
+  - value
+  values:
+  - '60.75'
+  writable: false
+  has_data: true
+- circuit: bai
+  name: SHEMaxDeltaHwcFlow
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: SHEMaxFlowTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: SecondPumpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: SecondPumpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: SerialNumber
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: bai
+  name: SetFactoryValues
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: SetFactoryValues
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: SetMode
+  fields:
+  - value
+  values:
+  - auto;0.0;-;-;1;0;1;0;0;0
+  writable: false
+  has_data: true
+- circuit: bai
+  name: SetMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: SolPostHeat
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: SolPostHeat
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: StatElectricEnergySum
+  fields:
+  - value
+  values:
+  - '1.440960050'
+  writable: false
+  has_data: true
+- circuit: bai
+  name: StatEnergySumYear
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: StatEnvironmentEnergySum
+  fields:
+  - value
+  values:
+  - '0.000000000'
+  writable: false
+  has_data: true
+- circuit: bai
+  name: StatEnvironmentEnergySumHc
+  fields:
+  - value
+  values:
+  - '0.000000000'
+  writable: false
+  has_data: true
+- circuit: bai
+  name: StatEnvironmentEnergySumHwc
+  fields:
+  - value
+  values:
+  - '0.000000000'
+  writable: false
+  has_data: true
+- circuit: bai
+  name: StatFuelSum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: StatFuelSumHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: StatFuelSumHwc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: StatSolarEnergySum
+  fields:
+  - value
+  values:
+  - '0.000000000'
+  writable: false
+  has_data: true
+- circuit: bai
+  name: StatSolarEnergySumHc
+  fields:
+  - value
+  values:
+  - '0.000000000'
+  writable: false
+  has_data: true
+- circuit: bai
+  name: StatSolarEnergySumHwc
+  fields:
+  - value
+  values:
+  - '0.000000000'
+  writable: false
+  has_data: true
+- circuit: bai
+  name: Statenumber
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: Status01
+  fields:
+  - value
+  values:
+  - 45.0;43.5;23.875;37.5;-;off
+  writable: false
+  has_data: true
+- circuit: bai
+  name: Status02
+  fields:
+  - value
+  values:
+  - auto;60;65.0;70;65.0
+  writable: false
+  has_data: true
+- circuit: bai
+  name: Status16
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: StatusCirPump
+  fields:
+  - value
+  values:
+  - 'off'
+  writable: false
+  has_data: true
+- circuit: bai
+  name: StorageLoadPumpHours
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: bai
+  name: StorageLoadTimeMax
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: StorageLoadTimeMax
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: StorageTemp
+  fields:
+  - value
+  values:
+  - -13.50;cutoff
+  writable: false
+  has_data: true
+- circuit: bai
+  name: StorageTempDesired
+  fields:
+  - value
+  values:
+  - '30.00'
+  writable: false
+  has_data: true
+- circuit: bai
+  name: StorageTempMax
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: StorageloadPumpStarts
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: Storageloadpump
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: StoragereleaseClock
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: TargetFanSpeed
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: TargetFanSpeedOutput
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: TempDiffBlock
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: TempDiffFailure
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: TempGradientFailure
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: TempMaxDiffExtTFT
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: Templimiter
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: TemplimiterWithNTC
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: Testbyte
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: Time
+  fields:
+  - value
+  values:
+  - no data stored (message not available due to condition)
+  writable: false
+  has_data: false
+- circuit: bai
+  name: Time
+  fields:
+  - value
+  values:
+  - no data stored (message not available due to condition)
+  writable: false
+  has_data: false
+- circuit: bai
+  name: TimerInputHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: ValveMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: ValveMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: ValveStarts
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: VolatileLockout
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: VolatileLockoutIFCGV
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: VortexFlowSensor
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: WP
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: WPPostrunTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: WPPostrunTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: WPSecondStage
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: WarmstartDemand
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: WarmstartOffset
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: WarmstartOffset
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: WaterHcFlowMax
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: WaterPressure
+  fields:
+  - value
+  values:
+  - 1.452;ok
+  writable: false
+  has_data: true
+- circuit: bai
+  name: WaterpressureBranchControlOff
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: WaterpressureMeasureCounter
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: WaterpressureVariantSum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: Z1HolidayTempStatus
+  fields:
+  - value
+  values:
+  - no data stored (message not available due to condition)
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: AdaptHeatCurve
+  fields:
+  - value
+  values:
+  - 'yes'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: AdaptHeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: CcTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: CcTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: CcTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: CcTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: CcTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: CcTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: CcTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: CcTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: CcTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: CcTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: CcTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: CcTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: CcTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: CcTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Clearerrorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: ContinuosHeating
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: ContinuosHeating
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - -;-;-;-;-
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: CylinderChargeHyst
+  fields:
+  - value
+  values:
+  - '5'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: CylinderChargeHyst
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: CylinderChargeOffset
+  fields:
+  - value
+  values:
+  - '25'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: CylinderChargeOffset
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Date
+  fields:
+  - value
+  values:
+  - 07.09.2026
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Date
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: DisplayedOutsideTemp
+  fields:
+  - value
+  values:
+  - '23.0625'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: FrostOverRideTime
+  fields:
+  - value
+  values:
+  - '4'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: FrostOverRideTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: GlobalSystemOff
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: GlobalSystemOff
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc1ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Hc1AutoOffMode
+  fields:
+  - value
+  values:
+  - eco
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Hc1AutoOffMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc1CircuitType
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002000200 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc1ExcessTemp
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002000b00 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc1ExcessTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc1FlowTemp
+  fields:
+  - value
+  values:
+  - '46'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Hc1HeatCurve
+  fields:
+  - value
+  values:
+  - '0.8'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Hc1HeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc1HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Hc1MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '90'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Hc1MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc1MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - '20'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Hc1MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc1MixerMovement
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002001a00 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc1PumpStatus
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Hc1PumpStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc1RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - modulating
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Hc1RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc1Status
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002001b00 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc1Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc1SummerTempLimit
+  fields:
+  - value
+  values:
+  - '20'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Hc1SummerTempLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc2ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Hc2AutoOffMode
+  fields:
+  - value
+  values:
+  - eco
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Hc2AutoOffMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc2CircuitType
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002010200 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc2ExcessTemp
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002010b00 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc2ExcessTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc2FlowTemp
+  fields:
+  - value
+  values:
+  - (empty for 3115b52406020002010800 / 0800020800ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc2HeatCurve
+  fields:
+  - value
+  values:
+  - '1.2'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Hc2HeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc2HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Hc2MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '90'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Hc2MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc2MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - '15'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Hc2MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc2MixerMovement
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002011a00 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc2PumpStatus
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Hc2PumpStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc2RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'off'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Hc2RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc2Status
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002011b00 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc2Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc2SummerTempLimit
+  fields:
+  - value
+  values:
+  - '21'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Hc2SummerTempLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc3ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Hc3AutoOffMode
+  fields:
+  - value
+  values:
+  - eco
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Hc3AutoOffMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc3CircuitType
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002020200 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc3ExcessTemp
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002020b00 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc3ExcessTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc3FlowTemp
+  fields:
+  - value
+  values:
+  - (empty for 3115b52406020002020800 / 0800020800ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc3HeatCurve
+  fields:
+  - value
+  values:
+  - '1.2'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Hc3HeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc3HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Hc3MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '90'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Hc3MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc3MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - '15'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Hc3MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc3MixerMovement
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002021a00 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc3PumpStatus
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Hc3PumpStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc3RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'off'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Hc3RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc3Status
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002021b00 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc3Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc3SummerTempLimit
+  fields:
+  - value
+  values:
+  - '21'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Hc3SummerTempLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HcStorageTempBottom
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HcStorageTempTop
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcBankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcBankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcBankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcBankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcFlowTemp
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: HwcHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: HwcHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: HwcHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcLockTime
+  fields:
+  - value
+  values:
+  - '60'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: HwcLockTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcMaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020000004600 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcMaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcOpMode
+  fields:
+  - value
+  values:
+  - day
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: HwcOpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcParallelLoading
+  fields:
+  - value
+  values:
+  - 'off'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: HwcParallelLoading
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcSFMode
+  fields:
+  - value
+  values:
+  - auto
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: HwcSFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcStorageTemp
+  fields:
+  - value
+  values:
+  - (empty for 3115b52406020001000500 / 0800010500ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcStorageTempBottom
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020000009e00 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcStorageTempTop
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020000009d00 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcTempDesired
+  fields:
+  - value
+  values:
+  - '45'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: HwcTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HydraulicScheme
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020000003600 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HydraulicScheme
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Installer1
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Installer1
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Installer2
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Installer2
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: KeyCodeforConfigMenu
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: KeyCodeforConfigMenu
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: MaintenanceDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: MaintenanceDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: MaintenanceDue
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: ManualCooling
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: ManualCooling
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: MaxCylinderChargeTime
+  fields:
+  - value
+  values:
+  - '60'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: MaxCylinderChargeTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: MaxRoomHumidity
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020000000e00 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: MaxRoomHumidity
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: MultiRelaySetting
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020000004d00 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: MultiRelaySetting
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: NoiseReductionTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: NoiseReductionTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: NoiseReductionTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: NoiseReductionTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: NoiseReductionTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: NoiseReductionTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: NoiseReductionTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: NoiseReductionTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: NoiseReductionTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: NoiseReductionTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: NoiseReductionTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: NoiseReductionTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: NoiseReductionTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: NoiseReductionTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: OpModeCooling
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: OpModeCooling
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: OpModeEffect
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: OpModeEffect
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: OpModeVentilation
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: OpModeVentilation
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: OutsideTempAvg
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020000009500 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: OutsideTempAvg
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PhoneNumber1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PhoneNumber1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PhoneNumber2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PhoneNumber2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PrEnergySum
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020000005c00 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PrEnergySum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PrEnergySumHc
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020000005700 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PrEnergySumHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PrEnergySumHcLastMonth
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020000005300 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PrEnergySumHcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PrEnergySumHcThisMonth
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020000004f00 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PrEnergySumHcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PrEnergySumHwc
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020000005800 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PrEnergySumHwc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PrEnergySumHwcLastMonth
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020000005400 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PrEnergySumHwcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PrEnergySumHwcThisMonth
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020000005000 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PrEnergySumHwcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PrFuelSum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PrFuelSum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PrFuelSumHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PrFuelSumHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PrFuelSumHcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PrFuelSumHcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PrFuelSumHcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PrFuelSumHcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PrFuelSumHwc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PrFuelSumHwc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PrFuelSumHwcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PrFuelSumHwcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PrFuelSumHwcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PrFuelSumHwcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PumpAdditionalTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PumpAdditionalTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: RoomHumidity
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: SolarYieldTotal
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: SolarYieldTotal
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: SystemFlowTemp
+  fields:
+  - value
+  values:
+  - (empty for 3115b52406020000004b00 / 0800004b00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: TariffTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: TariffTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: TariffTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: TariffTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: TariffTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: TariffTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: TariffTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: TariffTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: TariffTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: TariffTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: TariffTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: TariffTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: TariffTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: TariffTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Time
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Time
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: VentilationDay
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: VentilationDay
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: VentilationNight
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: VentilationNight
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: VentilationTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: VentilationTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: VentilationTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: VentilationTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: VentilationTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: VentilationTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: VentilationTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: VentilationTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: VentilationTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: VentilationTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: VentilationTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: VentilationTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: VentilationTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: VentilationTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: WaterPressure
+  fields:
+  - value
+  values:
+  - '1.4'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: YieldTotal
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020000003e00 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: YieldTotal
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Z1ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1CoolingTemp
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020003000200 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1CoolingTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1CoolingTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1CoolingTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1CoolingTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1CoolingTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1CoolingTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1CoolingTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1CoolingTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1CoolingTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1CoolingTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1CoolingTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1CoolingTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1CoolingTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1CoolingTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1CoolingTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1DayTemp
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020003000700 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Z1HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Z1HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1HolidayTemp
+  fields:
+  - value
+  values:
+  - '15'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Z1HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1NightTemp
+  fields:
+  - value
+  values:
+  - '15'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Z1NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1OpMode
+  fields:
+  - value
+  values:
+  - 'off'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Z1OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1OpModeCooling
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1OpModeCooling
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1QuickVetoTemp
+  fields:
+  - value
+  values:
+  - '21'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Z1QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1RoomTemp
+  fields:
+  - value
+  values:
+  - '24.7875'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Z1RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1SFMode
+  fields:
+  - value
+  values:
+  - auto
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Z1SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2CoolingTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2CoolingTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2CoolingTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2CoolingTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2CoolingTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2CoolingTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2CoolingTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2CoolingTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2CoolingTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2CoolingTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2CoolingTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2CoolingTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2CoolingTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2CoolingTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2CoolingTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2CoolingTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2OpModeCooling
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2OpModeCooling
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2RoomTemp
+  fields:
+  - value
+  values:
+  - (empty for 3115b52406020003010f00 / 0800030f00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3CoolingTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3CoolingTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3CoolingTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3CoolingTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3CoolingTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3CoolingTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3CoolingTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3CoolingTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3CoolingTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3CoolingTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3CoolingTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3CoolingTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3CoolingTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3CoolingTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3CoolingTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3CoolingTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3OpModeCooling
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3OpModeCooling
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3RoomTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: AdaptHeatCurve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: CcTimer_Config
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: CcTimer_Timeframes
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: ContinuousHeating
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: CylinderChargeHyst
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: CylinderChargeOffset
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Date
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: DisplayedOutsideTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: FrostOverRideTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1AutoOffMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1CircuitType
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1CoolingEnabled
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1CoolingFlowTempMin
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1DewPointMonitoring
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1DewPointOffset
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1DewPointTemp
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002300 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1ExcessTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1FlowTempCalc
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002000 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1HeatCurve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1Humidity
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002200 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MixerMovement
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MixerPosition
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002100 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1PumpHours
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002400 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1PumpStarts
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002500 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1PumpStatus
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1RoomTempModulation
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1Status
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1SummerTempLimit
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2AutoOffMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2CircuitType
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2DewPointTemp
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012300 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2ExcessTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2FlowTempCalc
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012000 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2HeatCurve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2Humidity
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012200 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MixerMovement
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MixerPosition
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012100 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2PumpHours
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012400 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2PumpStarts
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012500 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2PumpStatus
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2Status
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2SummerTempLimit
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3AutoOffMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3CircuitType
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3ExcessTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3HeatCurve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MixerMovement
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3PumpStatus
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3Status
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3SummerTempLimit
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HcStorageTempBottom
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: ctlv2
+  name: HcStorageTempTop
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: ctlv2
+  name: HwcFlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcLockTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcMaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcOpMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcParallelLoading
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcSFMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcSfMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcStorageTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcStorageTempBottom
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcStorageTempTop
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HydraulicScheme
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: ManualCoolingEndDate
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b5240602000000db00 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: ManualCoolingEndDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: ManualCoolingStartDate
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b5240602000000da00 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: ManualCoolingStartDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: MaxCylinderChargeTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: MaxRoomHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: MultiRelaySetting
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: OutsideTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: OutsideTempAvg
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySum
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHcLastMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHcThisMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHwcLastMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHwcThisMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: SystemFlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: WaterPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingManualTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingOpMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingSetbackTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1DayTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1HolidayTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1NightTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1OpMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoDuration
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoEndDate
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoEndTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1RoomTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1SFMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z2RoomTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: z1RoomHumidity
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020003002800 / 00)'
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: BuildingCircuitFlow
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: BuildingCircuitPumpSpeed
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: CompressorHc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: CompressorHwc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHwc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: ConsumptionTotal
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CoolElecConsDay
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CoolElecConsTotal
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CoolEnvYieldDay
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CoolEnvYieldMonth
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CoolEnvYieldTotal
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CopCooling
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CopCoolingMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CopHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CopHcMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CopHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CopHwcMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CurrentCompressorUtil
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CurrentConsumedPower
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CurrentYieldPower
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: DateTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: FlowTemperature
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: HcElecConsDay
+  fields:
+  - value
+  values:
+  - '55.26'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: HcElecConsTotal
+  fields:
+  - value
+  values:
+  - '931.91'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: HoursCool
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: HwcElecConsDay
+  fields:
+  - value
+  values:
+  - '24.89'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: HwcElecConsTotal
+  fields:
+  - value
+  values:
+  - '508.93'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: LiveMonitorCurrentConsumedPower
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: PowerConsumptionHmu
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunDataAirInletTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataBuildingCPumpPower
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataCompressorInletTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataCompressorOutletTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataCompressorSpeed
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataEEVOutletTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataEEVPositionAbs
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataElectricPowerConsumption
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataFan1Speed
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataFan2Speed
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataHighPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataLowPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunDataReturnTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataStatuscode
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStats4PortValveHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStats4PortValveSwitches
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsBuildingCPumpStarts
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsBuildingPumpHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunStatsCompressorHc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunStatsCompressorHwc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHwc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorStarts
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsFan1Hours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsFan1Starts
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsFan2Hours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsFan2Starts
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsHMUHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsHcHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsHwcHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: SourceTempInput
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: SourceTempOutput
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatElectricEnergySum
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatElectricEnergySumCool
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatElectricEnergySumHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatElectricEnergySumHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatEnvironmentEnergySum
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatEnvironmentEnergySumCool
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatEnvironmentEnergySumHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatEnvironmentEnergySumHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatSolarEnergySum
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatSolarEnergySumHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatSolarEnergySumHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.pumpstate
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.temp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.temp_1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.temp_2
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: Status01.temp_3
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: Status01.temp_4
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: StatusCirPump
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: SupplyTempWeighted
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: TotalEnergyUsage
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldCoolDay
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldCooling
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldCoolingMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldHcDay
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldHcMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldHwcDay
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldHwcMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: sc
+  name: Clearerrorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: Col
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: ColKickPumpTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: ColKickTempDelta
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: CollPump
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - -;-;-;-;-
+  writable: false
+  has_data: true
+- circuit: sc
+  name: D1Temp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: D2Temp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: Date
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 31ecb509030d0d00 / 00)'
+  writable: false
+  has_data: false
+- circuit: sc
+  name: EDFunction
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: EDFunction
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: EnableScProtection
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: EnableScProtection
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: FlowRate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: FlowRate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: FrostProtectionEnabled
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: FrostProtectionLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: Hc1PumpKol1PP1Port
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: Hc2aLegPumpP2Port
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: Hc2zPort
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: HydraulicScheme
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 31ecb509030d2100 / 00)'
+  writable: false
+  has_data: false
+- circuit: sc
+  name: InitCircuit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: Iotest
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: Ioteststop
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: IsInBoostMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: KickFunction
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: KickFunction
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: LpZpMaPort
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: MAPreferredStorage
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: MAPreferredStorage
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: MaximalTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: MaximalTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: MaximalTemp2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: MaximalTemp2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: MultifunctionOutput
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: OMultifunction
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: OMultifunction
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: PumpAntiLockingFlags
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: QuickVetoStart
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: ResetSolGain
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: ResetSolGain
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: RuntimeCollPump
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: RuntimeCollPumpSeconds
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: SP1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: SP2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: ScProtectionHysteresis
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: ScProtectionLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: ScProtectionLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: ScProtectionTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: SolCollPumpDcIntegrator
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: SolCollPumpED
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: SolGain
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: SolOperationMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: SumSolGain
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: SumSolGainDayBefore
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: SystemMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: TempDifferenceOff
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: TempDifferenceOff
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: TempDifferenceOff2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: TempDifferenceOff2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: TempDifferenceOffTD12
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: TempDifferenceOffTD12
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: TempDifferenceOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: TempDifferenceOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: TempDifferenceOn2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: TempDifferenceOn2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: TempDifferenceOnTD12
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: TempDifferenceOnTD12
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: Time
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: Weekday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: YieldLastYear
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: YieldThisYear
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: BypassPosition
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: ExhaustAirHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: ExhaustAirTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: FanHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: FlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: FlowTempMax
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: HcHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: HoursTillService
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: HwcHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: HwcTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: v32
+  name: Maintenancedata_HwcTempMax
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: v32
+  name: MaxAirHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: MinAirHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: OutdoorstempSensor
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: v32
+  name: OutsideAirTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: PumpHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: PumpPower
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: ReturnTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: ReturnTempMax
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: Status02.hwcmode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: Status02.temp0
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: Status02.temp0_1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: Status02.temp1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: Status02.temp1_1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: StorageLoadPumpHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: StorageTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: StorageTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: SupplyAirTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: VentilationLevelDay
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: VentilationLevelNight
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldToday
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldTotal
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldYear
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Clearerrorhistory
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Mc1Operation
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Mc2Operation
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Mc3Operation
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: SensorData1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: SensorData2
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: SetActorState
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vwz
+  name: TestHwcTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: vwz
+  name: TestOutdoorTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: vwz
+  name: TestThreeWayValve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+grab:
+- '[grab] grab continued'
+- '3108070400 / 0ab5424149303012017603 = 1: scan.08'
+- '3108b5090124 / 09003231323630383030 = 5: Scan.08 Id'
+- '3108b516081000ffff01000000 / 0b1000ff0100273500000000 = 10: bai StatSolarEnergySum'
+- '3108b516081000ffff01030000 / 0b1000ff0103273500000000 = 10: bai StatSolarEnergySumHc'
+- '3108b516081000ffff01040000 / 0b1000ff0104273500000000 = 10: bai StatSolarEnergySumHwc'
+- '3108b516081000ffff02000000 / 0b1000ff0200273500000000 = 10: bai StatEnvironmentEnergySum'
+- '3108b516081000ffff02030000 / 0b1000ff0203273500000000 = 10: bai StatEnvironmentEnergySumHc'
+- '3108b516081001ffff02052735 / 0b1100ff0205273500000000 = 14: hmu CoolEnvYieldDay'
+- '3108b516081000ffff02040000 / 0b1000ff0204273500000000 = 10: bai StatEnvironmentEnergySumHwc'
+- '3108b516081000ffff02050000 / 0b1000ff0205273500000000 = 14: hmu CoolEnvYieldTotal'
+- '3108b516081002ffff02052735 / 0b1200ff0205243500000000 = 14: hmu CoolEnvYieldMonth'
+- '3108b516081000ffff03000000 / 0b0000ff03002735b91eb444 = 10: bai StatElectricEnergySum'
+- '3108b516081001ffff03032735 / 0b0100000303273501005e42 = 14: hmu HcElecConsDay'
+- '3108b516081000ffff03030000 / 0b000000030327359b096944 = 14: hmu HcElecConsTotal'
+- '3108b516081001ffff03052735 / 0b1100ff0305273500000000 = 13: hmu CoolElecConsDay'
+- '3108b516081000ffff03040000 / 0b000003030427350b77fe43 = 13: hmu HwcElecConsTotal'
+- '3108b516081001ffff03042735 / 0b01000303042735b91ec741 = 13: hmu HwcElecConsDay'
+- '3108b516081000ffff03050000 / 0b1000ff0305273500000000 = 14: hmu CoolElecConsTotal'
+- '0315070400 / 0ab543544c563003139103 = 3: scan.15'
+- '3115b5090125 / 09323032363039343330 = 1: Scan.15 Id'
+- '31ec070400 / 0ab5534f4c303003139103 = 1: scan.ec'
+- '31ecb5090126 / 09393533303036373234 = 2: Scan.ec Id'
+- '1008b51009000000ffffff050000 / 0101 = 338: bai SetMode'
+- '1008b512020000 / 00 = 11: bai StatusCirPump'
+- '10feb516080049452107090126 = 56: Broadcast Vdatetime'
+- '10feb5160301e016 = 57: Broadcast Outsidetemp'
+- 1008b5110100 / 09cc020e001f10000000 = 57
+- '1008b5110101 / 095d5aa01859ff0000ff = 2: bai Status01'
+- '1008b5110102 / 06033c8246825a = 1: bai Status02'
+- '3115b5090124 / 09003231323230343030 = 1: Scan.15 Id'
+- '31ecb5090124 / 09003231323230343030 = 1: Scan.ec Id'
+- '1008b5040100 / 0a00ffffffffffffffe017 = 56: bai DateTime'
+- '1008b5110101 / 095955e01749ff0000ff = 337: bai Status01'
+- '1008b5110102 / 06033c8246825a = 111: bai Status02'
+- 1008b5120204ff / 0101 = 11
+- 1008b513020508 / 0101 = 11
+- '3108b503020001 / 0affffffffffffffffffff = 7: bai Currenterror'
+- '3115b503020001 / 0affffffffffffffffffff = 7: ctlv0 Currenterror'
+- '31ecb503020001 / 0affffffffffffffffffff = 9: sc Currenterror'
+- '31ecb509030d3f08 / 00 = 11: sc YieldThisYear'
+- 1008b5100305ff01 / 0101 = 11
+- '3108b509030d0200 / 03ac0500 = 9: bai WaterPressure'
+- '3108b509030d0400 / 02e001 = 10: bai StorageTempDesired'
+- '3108b509030d1400 / 020c00 = 10: bai PumpHours'
+- '3108b509030d1700 / 0328ffaa = 10: bai StorageTemp'
+- '3108b509030d1800 / 03d70200 = 10: bai FlowTemp'
+- '3108b509030d1b00 / 020900 = 10: bai FanHours'
+- '3108b509030d2004 / 0402000000 = 10: bai HoursTillService'
+- '3108b509030d2200 / 020700 = 10: bai HwcHours'
+- '3108b509030d2800 / 020000 = 10: bai HcHours'
+- '3108b509030d3700 / 024204 = 10: bai FlowTempMax'
+- '3108b509030d3900 / 020000 = 10: bai FlowTempDesired'
+- '3108b509030d4c00 / 020000 = 10: bai StorageLoadPumpHours'
+- '3108b509030d7300 / 0100 = 10: bai PumpPower'
+- '3108b509030d9800 / 05b4024bfd00 = 10: bai ReturnTemp'
+- '3108b509030dbe00 / 02cc03 = 10: bai ReturnTempMax'
+- '3108b509030dea03 / 020000 = 9: bai HwcTempDesired'
+- '31ecb509030d0d00 / 00 = 6: sc Date'
+- '31ecb509030d2100 / 00 = 9: sc HydraulicScheme'
+- '1008b51009000000ffffff050000 / 0101 = 2: bai SetMode'
+- '3108b51a0405ff3222 / 02ff01 = 15: hmu SourceTempInput'
+- '3115b52406020002000200 / 00 = 10: ctlv0 Hc1CircuitType'
+- '3115b52406020002010200 / 00 = 10: ctlv0 Hc2CircuitType'
+- '3115b52406020002020200 / 00 = 10: ctlv0 Hc3CircuitType'
+- '3115b52406020003000200 / 00 = 10: ctlv0 Z1CoolingTemp'
+- '3115b52406020000000300 / 06030003000400 = 10: ctlv0 FrostOverRideTime'
+- '3115b52406020001000300 / 06020103000200 = 10: ctlv0 HwcOpMode'
+- '3115b52406020003000300 / 0703030300010113 = 10: ctlv0 Z1HolidayStartPeriod'
+- '3115b52406020003000600 / 06030306000000 = 11: ctlv0 Z1OpMode'
+- '3115b52406020002000700 / 080102070000000000 = 10: ctlv0 Hc1ActualFlowTempDesired'
+- '3115b52406020002010700 / 080002070000000000 = 10: ctlv0 Hc2ActualFlowTempDesired'
+- '3115b52406020002020700 / 080002070000000000 = 10: ctlv0 Hc3ActualFlowTempDesired'
+- '3115b52406020003000700 / 00 = 10: ctlv0 Z1DayTemp'
+- '3115b52406020001000400 / 080201040000003442 = 5: ctlv0 HwcTempDesired'
+- '3115b52406020003000400 / 0703030400010113 = 10: ctlv0 Z1HolidayEndPeriod'
+- '3115b52406020001000500 / 0800010500ffffff7f = 10: ctlv0 HwcStorageTemp'
+- '3115b52406020003000500 / 080303050000007041 = 10: ctlv0 Z1HolidayTemp'
+- '3115b52406020000000a00 / 0502000a0000 = 9: ctlv0 HwcParallelLoading'
+- '3115b52406020001000a00 / 0702010a00010113 = 10: ctlv0 HwcHolidayEndPeriod'
+- '3115b52406020002000b00 / 00 = 10: ctlv0 Hc1ExcessTemp'
+- '3115b52406020002010b00 / 00 = 10: ctlv0 Hc2ExcessTemp'
+- '3115b52406020002020b00 / 00 = 10: ctlv0 Hc3ExcessTemp'
+- '3115b52406020001000800 / 080001080000000000 = 10: ctlv0 HwcFlowTemp'
+- '3115b52406020002000800 / 080002080000003442 = 10: ctlv0 Hc1FlowTemp'
+- '3115b52406020002010800 / 0800020800ffffff7f = 10: ctlv0 Hc2FlowTemp'
+- '3115b52406020002020800 / 0800020800ffffff7f = 10: ctlv0 Hc3FlowTemp'
+- '3115b52406020003000800 / 08030308000000a841 = 10: ctlv0 Z1QuickVetoTemp'
+- '3115b52406020001000900 / 0702010900010113 = 10: ctlv0 HwcHolidayStartPeriod'
+- '3115b52406020003000900 / 080203090000007041 = 10: ctlv0 Z1NightTemp'
+- '3115b52406020000000e00 / 00 = 10: ctlv0 MaxRoomHumidity'
+- '3115b52406020002000e00 / 0603020e000000 = 10: ctlv0 Hc1AutoOffMode'
+- '3115b52406020002010e00 / 0602020e000000 = 10: ctlv0 Hc2AutoOffMode'
+- '3115b52406020002020e00 / 0602020e000000 = 10: ctlv0 Hc3AutoOffMode'
+- '3115b52406020003000e00 / 0503030e0000 = 10: ctlv0 Z1SFMode'
+- '3115b52406020002000f00 / 0803020f00cdcc4c3f = 9: ctlv0 Hc1HeatCurve'
+- '3115b52406020002010f00 / 0802020f009a99993f = 10: ctlv0 Hc2HeatCurve'
+- '3115b52406020002020f00 / 0802020f009a99993f = 10: ctlv0 Hc3HeatCurve'
+- '3115b52406020003000f00 / 0801030f00cd4cc641 = 10: ctlv0 Z1RoomTemp'
+- '3115b52406020003010f00 / 0800030f00ffffff7f = 10: ctlv0 Z2RoomTemp'
+- '3115b52406020001000d00 / 0502010d0000 = 9: ctlv0 HwcSFMode'
+- '3115b52406020002001200 / 08030212000000a041 = 10: ctlv0 Hc1MinFlowTempDesired'
+- '3115b52406020002011200 / 080202120000007041 = 10: ctlv0 Hc2MinFlowTempDesired'
+- '3115b52406020002021200 / 080202120000007041 = 9: ctlv0 Hc3MinFlowTempDesired'
+- '3115b52406020002001000 / 08030210000000b442 = 10: ctlv0 Hc1MaxFlowTempDesired'
+- '3115b52406020002011000 / 08020210000000b442 = 10: ctlv0 Hc2MaxFlowTempDesired'
+- '3115b52406020002021000 / 08020210000000b442 = 10: ctlv0 Hc3MaxFlowTempDesired'
+- '3115b52406020000001700 / 06020017003c00 = 10: ctlv0 MaxCylinderChargeTime'
+- '3115b52406020000001400 / 050300140001 = 9: ctlv0 AdaptHeatCurve'
+- '3115b52406020002001400 / 08030214000000a041 = 10: ctlv0 Hc1SummerTempLimit'
+- '3115b52406020002011400 / 08020214000000a841 = 10: ctlv0 Hc2SummerTempLimit'
+- '3115b52406020002021400 / 08020214000000a841 = 10: ctlv0 Hc3SummerTempLimit'
+- '3115b52406020003001400 / 080103140000000000 = 10: ctlv0 Z1ActualRoomTempDesired'
+- '3115b52406020002001500 / 06030215000100 = 10: ctlv0 Hc1RoomTempSwitchOn'
+- '3115b52406020002011500 / 06020215000000 = 10: ctlv0 Hc2RoomTempSwitchOn'
+- '3115b52406020002021500 / 06020215000000 = 10: ctlv0 Hc3RoomTempSwitchOn'
+- '3115b52406020002001a00 / 00 = 10: ctlv0 Hc1MixerMovement'
+- '3115b52406020002011a00 / 00 = 10: ctlv0 Hc2MixerMovement'
+- '3115b52406020002021a00 / 00 = 10: ctlv0 Hc3MixerMovement'
+- '3115b52406020002001b00 / 00 = 10: ctlv0 Hc1Status'
+- '3115b52406020002011b00 / 00 = 10: ctlv0 Hc2Status'
+- '3115b52406020002021b00 / 00 = 9: ctlv0 Hc3Status'
+- '3115b52406020000001800 / 06020018003c00 = 10: ctlv0 HwcLockTime'
+- '3115b52406020002001e00 / 0601021e000000 = 10: ctlv0 Hc1PumpStatus'
+- '3115b52406020002011e00 / 0600021e000000 = 10: ctlv0 Hc2PumpStatus'
+- '3115b52406020002021e00 / 0600021e000000 = 10: ctlv0 Hc3PumpStatus'
+- '3115b52406020002001c00 / 0801021c0000000000 = 10: ctlv0 Hc1HeatCurveAdaption'
+- '3115b52406020002011c00 / 0800021c0000000000 = 10: ctlv0 Hc2HeatCurveAdaption'
+- '3115b52406020002021c00 / 0800021c0000000000 = 9: ctlv0 Hc3HeatCurveAdaption'
+- '3115b52406020002002200 / 00 = 40: ctlv2 Hc1Humidity'
+- '3115b52406020002012200 / 00 = 31: ctlv2 Hc2Humidity'
+- '3115b52406020002002300 / 00 = 35: ctlv2 Hc1DewPointTemp'
+- '3115b52406020002012300 / 00 = 30: ctlv2 Hc2DewPointTemp'
+- '3115b52406020002002000 / 00 = 30: ctlv2 Hc1FlowTempCalc'
+- '3115b52406020002012000 / 00 = 29: ctlv2 Hc2FlowTempCalc'
+- '3115b52406020002002100 / 00 = 31: ctlv2 Hc1MixerPosition'
+- '3115b52406020002012100 / 00 = 33: ctlv2 Hc2MixerPosition'
+- '3115b52406020000002700 / 08020027000000a040 = 10: ctlv0 CylinderChargeHyst'
+- '3115b52406020002002400 / 00 = 36: ctlv2 Hc1PumpHours'
+- '3115b52406020002012400 / 00 = 28: ctlv2 Hc2PumpHours'
+- '3115b52406020002002500 / 00 = 33: ctlv2 Hc1PumpStarts'
+- '3115b52406020002012500 / 00 = 34: ctlv2 Hc2PumpStarts'
+- '3115b52406020003002800 / 00 = 34: ctlv2 z1RoomHumidity'
+- '3115b52406020000002900 / 08020029000000c841 = 10: ctlv0 CylinderChargeOffset'
+- '3115b52406020000003600 / 00 = 7: ctlv0 HydraulicScheme'
+- '3115b52406020000003400 / 070300340007091a = 9: ctlv0 Date'
+- '3115b52406020000003900 / 08010039003333b33f = 1: ctlv0 WaterPressure'
+- '3115b52406020000003e00 / 00 = 10: ctlv0 YieldTotal'
+- '3115b52406020000004600 / 00 = 10: ctlv0 HwcMaxFlowTempDesired'
+- '3115b52406020000004b00 / 0800004b00ffffff7f = 10: ctlv0 SystemFlowTemp'
+- '3115b52406020000004f00 / 00 = 10: ctlv0 PrEnergySumHcThisMonth'
+- '3115b52406020000004d00 / 00 = 10: ctlv0 MultiRelaySetting'
+- '3115b52406020000005300 / 00 = 10: ctlv0 PrEnergySumHcLastMonth'
+- '3115b52406020000005000 / 00 = 10: ctlv0 PrEnergySumHwcThisMonth'
+- '3115b52406020000005700 / 00 = 10: ctlv0 PrEnergySumHc'
+- '3115b52406020000005400 / 00 = 10: ctlv0 PrEnergySumHwcLastMonth'
+- '3115b52406020000005800 / 00 = 10: ctlv0 PrEnergySumHwc'
+- '3115b52406020000005c00 / 00 = 10: ctlv0 PrEnergySum'
+- '3115b52406020000007300 / 08010073000080b841 = 10: ctlv0 DisplayedOutsideTemp'
+- '3115b52406020000009500 / 00 = 10: ctlv0 OutsideTempAvg'
+- '3115b52406020000009e00 / 00 = 10: ctlv0 HwcStorageTempBottom'
+- '3115b52406020000009d00 / 00 = 10: ctlv0 HwcStorageTempTop'
+- '3115b5240602000000da00 / 00 = 29: ctlv2 ManualCoolingStartDate'
+- '3115b5240602000000db00 / 00 = 35: ctlv2 ManualCoolingEndDate'
+- '3115b524080201030006000000 / 020003 = 2: ctlv0 Z1OpMode'
+- '3115b5240902010000db0001010f / 00 = 3: ctlv2 ManualCoolingEndDate'
+- '[grab stop] grab stopped'
+labeled_telegrams:
+- msgid: '0704'
+  master: '31'
+  slave: 08
+  sub: '00'
+  resp: 0ab5424149303012017603
+  count: '1'
+  label: scan.08
+- msgid: b509
+  master: '31'
+  slave: 08
+  sub: '0124'
+  resp: 09003231323630383030
+  count: '5'
+  label: Scan.08 Id
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081000ffff01000000
+  resp: 0b1000ff0100273500000000
+  count: '10'
+  label: bai StatSolarEnergySum
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081000ffff01030000
+  resp: 0b1000ff0103273500000000
+  count: '10'
+  label: bai StatSolarEnergySumHc
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081000ffff01040000
+  resp: 0b1000ff0104273500000000
+  count: '10'
+  label: bai StatSolarEnergySumHwc
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081000ffff02000000
+  resp: 0b1000ff0200273500000000
+  count: '10'
+  label: bai StatEnvironmentEnergySum
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081000ffff02030000
+  resp: 0b1000ff0203273500000000
+  count: '10'
+  label: bai StatEnvironmentEnergySumHc
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081001ffff02052735
+  resp: 0b1100ff0205273500000000
+  count: '14'
+  label: hmu CoolEnvYieldDay
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081000ffff02040000
+  resp: 0b1000ff0204273500000000
+  count: '10'
+  label: bai StatEnvironmentEnergySumHwc
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081000ffff02050000
+  resp: 0b1000ff0205273500000000
+  count: '14'
+  label: hmu CoolEnvYieldTotal
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081002ffff02052735
+  resp: 0b1200ff0205243500000000
+  count: '14'
+  label: hmu CoolEnvYieldMonth
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081000ffff03000000
+  resp: 0b0000ff03002735b91eb444
+  count: '10'
+  label: bai StatElectricEnergySum
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081001ffff03032735
+  resp: 0b0100000303273501005e42
+  count: '14'
+  label: hmu HcElecConsDay
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081000ffff03030000
+  resp: 0b000000030327359b096944
+  count: '14'
+  label: hmu HcElecConsTotal
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081001ffff03052735
+  resp: 0b1100ff0305273500000000
+  count: '13'
+  label: hmu CoolElecConsDay
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081000ffff03040000
+  resp: 0b000003030427350b77fe43
+  count: '13'
+  label: hmu HwcElecConsTotal
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081001ffff03042735
+  resp: 0b01000303042735b91ec741
+  count: '13'
+  label: hmu HwcElecConsDay
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081000ffff03050000
+  resp: 0b1000ff0305273500000000
+  count: '14'
+  label: hmu CoolElecConsTotal
+- msgid: b509
+  master: '31'
+  slave: '15'
+  sub: '0125'
+  resp: 09323032363039343330
+  count: '1'
+  label: Scan.15 Id
+- msgid: '0704'
+  master: '31'
+  slave: ec
+  sub: '00'
+  resp: 0ab5534f4c303003139103
+  count: '1'
+  label: scan.ec
+- msgid: b509
+  master: '31'
+  slave: ec
+  sub: '0126'
+  resp: 09393533303036373234
+  count: '2'
+  label: Scan.ec Id
+- msgid: b510
+  master: '10'
+  slave: 08
+  sub: 09000000ffffff050000
+  resp: '0101'
+  count: '338'
+  label: bai SetMode
+- msgid: b512
+  master: '10'
+  slave: 08
+  sub: '020000'
+  resp: '00'
+  count: '11'
+  label: bai StatusCirPump
+- msgid: b516
+  master: '10'
+  slave: fe
+  sub: 080049452107090126
+  resp: null
+  count: '56'
+  label: Broadcast Vdatetime
+- msgid: b516
+  master: '10'
+  slave: fe
+  sub: 0301e016
+  resp: null
+  count: '57'
+  label: Broadcast Outsidetemp
+- msgid: b511
+  master: '10'
+  slave: 08
+  sub: '0101'
+  resp: 095d5aa01859ff0000ff
+  count: '2'
+  label: bai Status01
+- msgid: b511
+  master: '10'
+  slave: 08
+  sub: '0102'
+  resp: 06033c8246825a
+  count: '1'
+  label: bai Status02
+- msgid: b509
+  master: '31'
+  slave: '15'
+  sub: '0124'
+  resp: 09003231323230343030
+  count: '1'
+  label: Scan.15 Id
+- msgid: b509
+  master: '31'
+  slave: ec
+  sub: '0124'
+  resp: 09003231323230343030
+  count: '1'
+  label: Scan.ec Id
+- msgid: b504
+  master: '10'
+  slave: 08
+  sub: '0100'
+  resp: 0a00ffffffffffffffe017
+  count: '56'
+  label: bai DateTime
+- msgid: b511
+  master: '10'
+  slave: 08
+  sub: '0101'
+  resp: 095955e01749ff0000ff
+  count: '337'
+  label: bai Status01
+- msgid: b511
+  master: '10'
+  slave: 08
+  sub: '0102'
+  resp: 06033c8246825a
+  count: '111'
+  label: bai Status02
+- msgid: b503
+  master: '31'
+  slave: 08
+  sub: '020001'
+  resp: 0affffffffffffffffffff
+  count: '7'
+  label: bai Currenterror
+- msgid: b503
+  master: '31'
+  slave: '15'
+  sub: '020001'
+  resp: 0affffffffffffffffffff
+  count: '7'
+  label: ctlv0 Currenterror
+- msgid: b503
+  master: '31'
+  slave: ec
+  sub: '020001'
+  resp: 0affffffffffffffffffff
+  count: '9'
+  label: sc Currenterror
+- msgid: b509
+  master: '31'
+  slave: ec
+  sub: 030d3f08
+  resp: '00'
+  count: '11'
+  label: sc YieldThisYear
+- msgid: b509
+  master: '31'
+  slave: 08
+  sub: 030d0200
+  resp: 03ac0500
+  count: '9'
+  label: bai WaterPressure
+- msgid: b509
+  master: '31'
+  slave: 08
+  sub: 030d0400
+  resp: 02e001
+  count: '10'
+  label: bai StorageTempDesired
+- msgid: b509
+  master: '31'
+  slave: 08
+  sub: 030d1400
+  resp: 020c00
+  count: '10'
+  label: bai PumpHours
+- msgid: b509
+  master: '31'
+  slave: 08
+  sub: 030d1700
+  resp: 0328ffaa
+  count: '10'
+  label: bai StorageTemp
+- msgid: b509
+  master: '31'
+  slave: 08
+  sub: 030d1800
+  resp: 03d70200
+  count: '10'
+  label: bai FlowTemp
+- msgid: b509
+  master: '31'
+  slave: 08
+  sub: 030d1b00
+  resp: 020900
+  count: '10'
+  label: bai FanHours
+- msgid: b509
+  master: '31'
+  slave: 08
+  sub: 030d2004
+  resp: '0402000000'
+  count: '10'
+  label: bai HoursTillService
+- msgid: b509
+  master: '31'
+  slave: 08
+  sub: 030d2200
+  resp: '020700'
+  count: '10'
+  label: bai HwcHours
+- msgid: b509
+  master: '31'
+  slave: 08
+  sub: 030d2800
+  resp: '020000'
+  count: '10'
+  label: bai HcHours
+- msgid: b509
+  master: '31'
+  slave: 08
+  sub: 030d3700
+  resp: '024204'
+  count: '10'
+  label: bai FlowTempMax
+- msgid: b509
+  master: '31'
+  slave: 08
+  sub: 030d3900
+  resp: '020000'
+  count: '10'
+  label: bai FlowTempDesired
+- msgid: b509
+  master: '31'
+  slave: 08
+  sub: 030d4c00
+  resp: '020000'
+  count: '10'
+  label: bai StorageLoadPumpHours
+- msgid: b509
+  master: '31'
+  slave: 08
+  sub: 030d7300
+  resp: '0100'
+  count: '10'
+  label: bai PumpPower
+- msgid: b509
+  master: '31'
+  slave: 08
+  sub: 030d9800
+  resp: 05b4024bfd00
+  count: '10'
+  label: bai ReturnTemp
+- msgid: b509
+  master: '31'
+  slave: 08
+  sub: 030dbe00
+  resp: 02cc03
+  count: '10'
+  label: bai ReturnTempMax
+- msgid: b509
+  master: '31'
+  slave: 08
+  sub: 030dea03
+  resp: '020000'
+  count: '9'
+  label: bai HwcTempDesired
+- msgid: b509
+  master: '31'
+  slave: ec
+  sub: 030d0d00
+  resp: '00'
+  count: '6'
+  label: sc Date
+- msgid: b509
+  master: '31'
+  slave: ec
+  sub: 030d2100
+  resp: '00'
+  count: '9'
+  label: sc HydraulicScheme
+- msgid: b510
+  master: '10'
+  slave: 08
+  sub: 09000000ffffff050000
+  resp: '0101'
+  count: '2'
+  label: bai SetMode
+- msgid: b51a
+  master: '31'
+  slave: 08
+  sub: 0405ff3222
+  resp: 02ff01
+  count: '15'
+  label: hmu SourceTempInput
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020002000200'
+  resp: '00'
+  count: '10'
+  label: ctlv0 Hc1CircuitType
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020002010200'
+  resp: '00'
+  count: '10'
+  label: ctlv0 Hc2CircuitType
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020002020200'
+  resp: '00'
+  count: '10'
+  label: ctlv0 Hc3CircuitType
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020003000200'
+  resp: '00'
+  count: '10'
+  label: ctlv0 Z1CoolingTemp
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020000000300'
+  resp: '06030003000400'
+  count: '10'
+  label: ctlv0 FrostOverRideTime
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020001000300'
+  resp: '06020103000200'
+  count: '10'
+  label: ctlv0 HwcOpMode
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020003000300'
+  resp: '0703030300010113'
+  count: '10'
+  label: ctlv0 Z1HolidayStartPeriod
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020003000600'
+  resp: '06030306000000'
+  count: '11'
+  label: ctlv0 Z1OpMode
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020002000700'
+  resp: 080102070000000000
+  count: '10'
+  label: ctlv0 Hc1ActualFlowTempDesired
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020002010700'
+  resp: 080002070000000000
+  count: '10'
+  label: ctlv0 Hc2ActualFlowTempDesired
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020002020700'
+  resp: 080002070000000000
+  count: '10'
+  label: ctlv0 Hc3ActualFlowTempDesired
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020003000700'
+  resp: '00'
+  count: '10'
+  label: ctlv0 Z1DayTemp
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020001000400'
+  resp: 080201040000003442
+  count: '5'
+  label: ctlv0 HwcTempDesired
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020003000400'
+  resp: '0703030400010113'
+  count: '10'
+  label: ctlv0 Z1HolidayEndPeriod
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020001000500'
+  resp: 0800010500ffffff7f
+  count: '10'
+  label: ctlv0 HwcStorageTemp
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020003000500'
+  resp: 080303050000007041
+  count: '10'
+  label: ctlv0 Z1HolidayTemp
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020000000a00
+  resp: 0502000a0000
+  count: '9'
+  label: ctlv0 HwcParallelLoading
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020001000a00
+  resp: 0702010a00010113
+  count: '10'
+  label: ctlv0 HwcHolidayEndPeriod
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020002000b00
+  resp: '00'
+  count: '10'
+  label: ctlv0 Hc1ExcessTemp
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020002010b00
+  resp: '00'
+  count: '10'
+  label: ctlv0 Hc2ExcessTemp
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020002020b00
+  resp: '00'
+  count: '10'
+  label: ctlv0 Hc3ExcessTemp
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020001000800
+  resp: 080001080000000000
+  count: '10'
+  label: ctlv0 HwcFlowTemp
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020002000800
+  resp: 080002080000003442
+  count: '10'
+  label: ctlv0 Hc1FlowTemp
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020002010800
+  resp: 0800020800ffffff7f
+  count: '10'
+  label: ctlv0 Hc2FlowTemp
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020002020800
+  resp: 0800020800ffffff7f
+  count: '10'
+  label: ctlv0 Hc3FlowTemp
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020003000800
+  resp: 08030308000000a841
+  count: '10'
+  label: ctlv0 Z1QuickVetoTemp
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020001000900
+  resp: 0702010900010113
+  count: '10'
+  label: ctlv0 HwcHolidayStartPeriod
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020003000900
+  resp: 080203090000007041
+  count: '10'
+  label: ctlv0 Z1NightTemp
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020000000e00
+  resp: '00'
+  count: '10'
+  label: ctlv0 MaxRoomHumidity
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020002000e00
+  resp: 0603020e000000
+  count: '10'
+  label: ctlv0 Hc1AutoOffMode
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020002010e00
+  resp: 0602020e000000
+  count: '10'
+  label: ctlv0 Hc2AutoOffMode
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020002020e00
+  resp: 0602020e000000
+  count: '10'
+  label: ctlv0 Hc3AutoOffMode
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020003000e00
+  resp: 0503030e0000
+  count: '10'
+  label: ctlv0 Z1SFMode
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020002000f00
+  resp: 0803020f00cdcc4c3f
+  count: '9'
+  label: ctlv0 Hc1HeatCurve
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020002010f00
+  resp: 0802020f009a99993f
+  count: '10'
+  label: ctlv0 Hc2HeatCurve
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020002020f00
+  resp: 0802020f009a99993f
+  count: '10'
+  label: ctlv0 Hc3HeatCurve
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020003000f00
+  resp: 0801030f00cd4cc641
+  count: '10'
+  label: ctlv0 Z1RoomTemp
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020003010f00
+  resp: 0800030f00ffffff7f
+  count: '10'
+  label: ctlv0 Z2RoomTemp
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020001000d00
+  resp: 0502010d0000
+  count: '9'
+  label: ctlv0 HwcSFMode
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020002001200'
+  resp: 08030212000000a041
+  count: '10'
+  label: ctlv0 Hc1MinFlowTempDesired
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020002011200'
+  resp: 080202120000007041
+  count: '10'
+  label: ctlv0 Hc2MinFlowTempDesired
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020002021200'
+  resp: 080202120000007041
+  count: '9'
+  label: ctlv0 Hc3MinFlowTempDesired
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020002001000'
+  resp: 08030210000000b442
+  count: '10'
+  label: ctlv0 Hc1MaxFlowTempDesired
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020002011000'
+  resp: 08020210000000b442
+  count: '10'
+  label: ctlv0 Hc2MaxFlowTempDesired
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020002021000'
+  resp: 08020210000000b442
+  count: '10'
+  label: ctlv0 Hc3MaxFlowTempDesired
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020000001700'
+  resp: 06020017003c00
+  count: '10'
+  label: ctlv0 MaxCylinderChargeTime
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020000001400'
+  resp: '050300140001'
+  count: '9'
+  label: ctlv0 AdaptHeatCurve
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020002001400'
+  resp: 08030214000000a041
+  count: '10'
+  label: ctlv0 Hc1SummerTempLimit
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020002011400'
+  resp: 08020214000000a841
+  count: '10'
+  label: ctlv0 Hc2SummerTempLimit
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020002021400'
+  resp: 08020214000000a841
+  count: '10'
+  label: ctlv0 Hc3SummerTempLimit
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020003001400'
+  resp: 080103140000000000
+  count: '10'
+  label: ctlv0 Z1ActualRoomTempDesired
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020002001500'
+  resp: '06030215000100'
+  count: '10'
+  label: ctlv0 Hc1RoomTempSwitchOn
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020002011500'
+  resp: '06020215000000'
+  count: '10'
+  label: ctlv0 Hc2RoomTempSwitchOn
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020002021500'
+  resp: '06020215000000'
+  count: '10'
+  label: ctlv0 Hc3RoomTempSwitchOn
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020002001a00
+  resp: '00'
+  count: '10'
+  label: ctlv0 Hc1MixerMovement
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020002011a00
+  resp: '00'
+  count: '10'
+  label: ctlv0 Hc2MixerMovement
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020002021a00
+  resp: '00'
+  count: '10'
+  label: ctlv0 Hc3MixerMovement
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020002001b00
+  resp: '00'
+  count: '10'
+  label: ctlv0 Hc1Status
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020002011b00
+  resp: '00'
+  count: '10'
+  label: ctlv0 Hc2Status
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020002021b00
+  resp: '00'
+  count: '9'
+  label: ctlv0 Hc3Status
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020000001800
+  resp: 06020018003c00
+  count: '10'
+  label: ctlv0 HwcLockTime
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020002001e00
+  resp: 0601021e000000
+  count: '10'
+  label: ctlv0 Hc1PumpStatus
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020002011e00
+  resp: 0600021e000000
+  count: '10'
+  label: ctlv0 Hc2PumpStatus
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020002021e00
+  resp: 0600021e000000
+  count: '10'
+  label: ctlv0 Hc3PumpStatus
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020002001c00
+  resp: 0801021c0000000000
+  count: '10'
+  label: ctlv0 Hc1HeatCurveAdaption
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020002011c00
+  resp: 0800021c0000000000
+  count: '10'
+  label: ctlv0 Hc2HeatCurveAdaption
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020002021c00
+  resp: 0800021c0000000000
+  count: '9'
+  label: ctlv0 Hc3HeatCurveAdaption
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020002002200'
+  resp: '00'
+  count: '40'
+  label: ctlv2 Hc1Humidity
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020002012200'
+  resp: '00'
+  count: '31'
+  label: ctlv2 Hc2Humidity
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020002002300'
+  resp: '00'
+  count: '35'
+  label: ctlv2 Hc1DewPointTemp
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020002012300'
+  resp: '00'
+  count: '30'
+  label: ctlv2 Hc2DewPointTemp
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020002002000'
+  resp: '00'
+  count: '30'
+  label: ctlv2 Hc1FlowTempCalc
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020002012000'
+  resp: '00'
+  count: '29'
+  label: ctlv2 Hc2FlowTempCalc
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020002002100'
+  resp: '00'
+  count: '31'
+  label: ctlv2 Hc1MixerPosition
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020002012100'
+  resp: '00'
+  count: '33'
+  label: ctlv2 Hc2MixerPosition
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020000002700'
+  resp: 08020027000000a040
+  count: '10'
+  label: ctlv0 CylinderChargeHyst
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020002002400'
+  resp: '00'
+  count: '36'
+  label: ctlv2 Hc1PumpHours
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020002012400'
+  resp: '00'
+  count: '28'
+  label: ctlv2 Hc2PumpHours
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020002002500'
+  resp: '00'
+  count: '33'
+  label: ctlv2 Hc1PumpStarts
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020002012500'
+  resp: '00'
+  count: '34'
+  label: ctlv2 Hc2PumpStarts
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020003002800
+  resp: '00'
+  count: '34'
+  label: ctlv2 z1RoomHumidity
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020000002900
+  resp: 08020029000000c841
+  count: '10'
+  label: ctlv0 CylinderChargeOffset
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020000003600'
+  resp: '00'
+  count: '7'
+  label: ctlv0 HydraulicScheme
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020000003400'
+  resp: 070300340007091a
+  count: '9'
+  label: ctlv0 Date
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020000003900
+  resp: 08010039003333b33f
+  count: '1'
+  label: ctlv0 WaterPressure
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020000003e00
+  resp: '00'
+  count: '10'
+  label: ctlv0 YieldTotal
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020000004600'
+  resp: '00'
+  count: '10'
+  label: ctlv0 HwcMaxFlowTempDesired
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020000004b00
+  resp: 0800004b00ffffff7f
+  count: '10'
+  label: ctlv0 SystemFlowTemp
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020000004f00
+  resp: '00'
+  count: '10'
+  label: ctlv0 PrEnergySumHcThisMonth
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020000004d00
+  resp: '00'
+  count: '10'
+  label: ctlv0 MultiRelaySetting
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020000005300'
+  resp: '00'
+  count: '10'
+  label: ctlv0 PrEnergySumHcLastMonth
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020000005000'
+  resp: '00'
+  count: '10'
+  label: ctlv0 PrEnergySumHwcThisMonth
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020000005700'
+  resp: '00'
+  count: '10'
+  label: ctlv0 PrEnergySumHc
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020000005400'
+  resp: '00'
+  count: '10'
+  label: ctlv0 PrEnergySumHwcLastMonth
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020000005800
+  resp: '00'
+  count: '10'
+  label: ctlv0 PrEnergySumHwc
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020000005c00
+  resp: '00'
+  count: '10'
+  label: ctlv0 PrEnergySum
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020000007300'
+  resp: 08010073000080b841
+  count: '10'
+  label: ctlv0 DisplayedOutsideTemp
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020000009500
+  resp: '00'
+  count: '10'
+  label: ctlv0 OutsideTempAvg
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020000009e00
+  resp: '00'
+  count: '10'
+  label: ctlv0 HwcStorageTempBottom
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020000009d00
+  resp: '00'
+  count: '10'
+  label: ctlv0 HwcStorageTempTop
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 0602000000da00
+  resp: '00'
+  count: '29'
+  label: ctlv2 ManualCoolingStartDate
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 0602000000db00
+  resp: '00'
+  count: '35'
+  label: ctlv2 ManualCoolingEndDate
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 080201030006000000
+  resp: '020003'
+  count: '2'
+  label: ctlv0 Z1OpMode
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 0902010000db0001010f
+  resp: '00'
+  count: '3'
+  label: ctlv2 ManualCoolingEndDate
+unknown_telegrams:
+- msgid: b511
+  master: '10'
+  slave: 08
+  sub: '0100'
+  resp: 09cc020e001f10000000
+  count: '57'
+  label: null
+- msgid: b512
+  master: '10'
+  slave: 08
+  sub: 0204ff
+  resp: '0101'
+  count: '11'
+  label: null
+- msgid: b513
+  master: '10'
+  slave: 08
+  sub: 020508
+  resp: '0101'
+  count: '11'
+  label: null
+- msgid: b510
+  master: '10'
+  slave: 08
+  sub: 0305ff01
+  resp: '0101'
+  count: '11'
+  label: null
+after_registers:
+- circuit: Broadcast
+  name: Datetime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Error
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: Broadcast
+  name: HwcStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Id
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: IdAnswer
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: IdQuery
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Load
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Outsidetemp
+  fields:
+  - value
+  values:
+  - '22.875'
+  writable: false
+  has_data: true
+- circuit: Broadcast
+  name: Queryexistence
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Signoflife
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Vdatetime
+  fields:
+  - value
+  values:
+  - 21:45:49;07.09.2026
+  writable: false
+  has_data: true
+- circuit: Broadcast
+  name: Vdatetime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: WaterPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: General
+  name: Valuerange
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Eeprom
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Eeprom
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Ram
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Ram
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Scan
+  name: Id
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Scan.08
+  name: Id
+  fields:
+  - value
+  values:
+  - xx
+  writable: false
+  has_data: true
+- circuit: Scan.15
+  name: Id
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Scan.ec
+  name: Id
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: ACRoomthermostat
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: APCComStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: APCLegioProtection
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: APCLegioProtection
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: AccessoriesOne
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: AccessoriesOne
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: AccessoriesTwo
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: AccessoriesTwo
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: AverageIgnitiontime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: BlockTimeHcMax
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: BlockTimeHcMax
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: BoilerType
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: ChangesDSN
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: CirPump
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: Clearerrorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: CounterStartAttempts1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: CounterStartAttempts2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: CounterStartAttempts3
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: CounterStartAttempts4
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - -;-;-;-;-
+  writable: false
+  has_data: true
+- circuit: bai
+  name: DCFTimeDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: DCRoomthermostat
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: DSN
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: DSNOffset
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: DSNOffset
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: DSNStart
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: Date
+  fields:
+  - value
+  values:
+  - no data stored (message not available due to condition)
+  writable: false
+  has_data: false
+- circuit: bai
+  name: Date
+  fields:
+  - value
+  values:
+  - no data stored (message not available due to condition)
+  writable: false
+  has_data: false
+- circuit: bai
+  name: DateTime
+  fields:
+  - value
+  values:
+  - nosignal;-:-:-;-.-.-;23.875
+  writable: false
+  has_data: true
+- circuit: bai
+  name: DcfState
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: DeactivationsIFC
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: DeactivationsTemplimiter
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: DeltaFlowReturnMax
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: DisplayMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: EBusHeatcontrol
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: EbusSourceOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: EbusVoltage
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: Expertlevel_ReturnTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: ExtFlowTempDesiredMin
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: ExtStorageModulCon
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: ExtWP
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: ExternGasvalve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: ExternalFaultmessage
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: ExternalFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: ExternalHwcSwitch
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: FanHours
+  fields:
+  - value
+  values:
+  - '9'
+  writable: false
+  has_data: true
+- circuit: bai
+  name: FanMaxSpeedOperation
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: FanMinSpeedOperation
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: FanPWMSum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: FanPWMTest
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: FanSpeed
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: FanSpeedOffsetMax
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: FanSpeedOffsetMax
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: FanSpeedOffsetMin
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: FanSpeedOffsetMin
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: FanStarts
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: Flame
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: FlameSensingASIC
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: FloorHeatingContact
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: FlowSetPotmeter
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: FlowTemp
+  fields:
+  - value
+  values:
+  - 44.62;ok
+  writable: false
+  has_data: true
+- circuit: bai
+  name: FlowTempDesired
+  fields:
+  - value
+  values:
+  - '0.00'
+  writable: false
+  has_data: true
+- circuit: bai
+  name: FlowTempMax
+  fields:
+  - value
+  values:
+  - '68.12'
+  writable: false
+  has_data: true
+- circuit: bai
+  name: FlowsetHcMax
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: FlowsetHcMax
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: FlowsetHwcMax
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: FlowsetHwcMax
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: Fluegasvalve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: FluegasvalveOpen
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: Gasvalve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: Gasvalve3UC
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: GasvalveASICFeedback
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: GasvalveUC
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: GasvalveUCFeedback
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: GlobalSystemOff
+  fields:
+  - value
+  values:
+  - no data stored (message not available due to condition)
+  writable: false
+  has_data: false
+- circuit: bai
+  name: GlobalSystemOff
+  fields:
+  - value
+  values:
+  - no data stored (message not available due to condition)
+  writable: false
+  has_data: false
+- circuit: bai
+  name: HcHours
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: bai
+  name: HcPumpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: HcPumpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: HcPumpStarts
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: HcStarts
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: HcUnderHundredStarts
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: HeatingSwitch
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: HoursTillService
+  fields:
+  - value
+  values:
+  - '2'
+  writable: false
+  has_data: true
+- circuit: bai
+  name: HoursTillService
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: HwcDemand
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: HwcHours
+  fields:
+  - value
+  values:
+  - '7'
+  writable: false
+  has_data: true
+- circuit: bai
+  name: HwcImpellorSwitch
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: HwcPostrunTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: HwcPostrunTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: HwcSetPotmeter
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: HwcStarts
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: HwcSwitch
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: HwcTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: HwcTempDesired
+  fields:
+  - value
+  values:
+  - '0.00'
+  writable: false
+  has_data: true
+- circuit: bai
+  name: HwcTempMax
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: HwcTempMax
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: HwcTypes
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: HwcUnderHundredStarts
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: HwcWaterflow
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: HwcWaterflowMax
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: Ignitor
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: InitialisationEEPROM
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: IonisationVoltageLevel
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: Maintenancedata_HwcTempMax
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: MaxIgnitiontime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: MinIgnitiontime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: ModulationDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: OutdoorstempSensor
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: OverflowCounter
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: ParamToken
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PartloadHcKW
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PartloadHcKW
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PartloadHwcKW
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PartloadHwcKW
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PartnumberBox
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PositionValveSet
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PowerValue
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PrAPSCounter
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PrAPSSum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PrEnergyCountHc1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PrEnergyCountHc1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PrEnergyCountHc2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PrEnergyCountHc2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PrEnergyCountHc3
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PrEnergyCountHc3
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PrEnergyCountHwc1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PrEnergyCountHwc1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PrEnergyCountHwc2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PrEnergyCountHwc2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PrEnergyCountHwc3
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PrEnergyCountHwc3
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PrEnergySumHc1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PrEnergySumHc1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PrEnergySumHc2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PrEnergySumHc2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PrEnergySumHc3
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PrEnergySumHc3
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PrEnergySumHwc1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PrEnergySumHwc1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PrEnergySumHwc2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PrEnergySumHwc2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PrEnergySumHwc3
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PrEnergySumHwc3
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PrVortexFlowSensorValue
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PrimaryCircuitFlowrate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: ProductionByte
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PumpHours
+  fields:
+  - value
+  values:
+  - '12'
+  writable: false
+  has_data: true
+- circuit: bai
+  name: PumpHwcFlowNumber
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PumpHwcFlowSum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PumpPower
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: bai
+  name: PumpPowerDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PumpPowerDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: RemainingBoilerblocktime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: ReturnRegulation
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: ReturnRegulation
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: ReturnTemp
+  fields:
+  - value
+  values:
+  - 43.25;64843;ok
+  writable: false
+  has_data: true
+- circuit: bai
+  name: ReturnTempMax
+  fields:
+  - value
+  values:
+  - '60.75'
+  writable: false
+  has_data: true
+- circuit: bai
+  name: SHEMaxDeltaHwcFlow
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: SHEMaxFlowTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: SecondPumpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: SecondPumpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: SerialNumber
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: bai
+  name: SetFactoryValues
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: SetFactoryValues
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: SetMode
+  fields:
+  - value
+  values:
+  - auto;0.0;-;-;1;0;1;0;0;0
+  writable: false
+  has_data: true
+- circuit: bai
+  name: SetMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: SolPostHeat
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: SolPostHeat
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: StatElectricEnergySum
+  fields:
+  - value
+  values:
+  - '1.440960050'
+  writable: false
+  has_data: true
+- circuit: bai
+  name: StatEnergySumYear
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: StatEnvironmentEnergySum
+  fields:
+  - value
+  values:
+  - '0.000000000'
+  writable: false
+  has_data: true
+- circuit: bai
+  name: StatEnvironmentEnergySumHc
+  fields:
+  - value
+  values:
+  - '0.000000000'
+  writable: false
+  has_data: true
+- circuit: bai
+  name: StatEnvironmentEnergySumHwc
+  fields:
+  - value
+  values:
+  - '0.000000000'
+  writable: false
+  has_data: true
+- circuit: bai
+  name: StatFuelSum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: StatFuelSumHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: StatFuelSumHwc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: StatSolarEnergySum
+  fields:
+  - value
+  values:
+  - '0.000000000'
+  writable: false
+  has_data: true
+- circuit: bai
+  name: StatSolarEnergySumHc
+  fields:
+  - value
+  values:
+  - '0.000000000'
+  writable: false
+  has_data: true
+- circuit: bai
+  name: StatSolarEnergySumHwc
+  fields:
+  - value
+  values:
+  - '0.000000000'
+  writable: false
+  has_data: true
+- circuit: bai
+  name: Statenumber
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: Status01
+  fields:
+  - value
+  values:
+  - 44.5;42.5;23.875;36.5;-;off
+  writable: false
+  has_data: true
+- circuit: bai
+  name: Status02
+  fields:
+  - value
+  values:
+  - auto;60;65.0;70;65.0
+  writable: false
+  has_data: true
+- circuit: bai
+  name: Status16
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: StatusCirPump
+  fields:
+  - value
+  values:
+  - 'off'
+  writable: false
+  has_data: true
+- circuit: bai
+  name: StorageLoadPumpHours
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: bai
+  name: StorageLoadTimeMax
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: StorageLoadTimeMax
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: StorageTemp
+  fields:
+  - value
+  values:
+  - -13.50;cutoff
+  writable: false
+  has_data: true
+- circuit: bai
+  name: StorageTempDesired
+  fields:
+  - value
+  values:
+  - '30.00'
+  writable: false
+  has_data: true
+- circuit: bai
+  name: StorageTempMax
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: StorageloadPumpStarts
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: Storageloadpump
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: StoragereleaseClock
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: TargetFanSpeed
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: TargetFanSpeedOutput
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: TempDiffBlock
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: TempDiffFailure
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: TempGradientFailure
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: TempMaxDiffExtTFT
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: Templimiter
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: TemplimiterWithNTC
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: Testbyte
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: Time
+  fields:
+  - value
+  values:
+  - no data stored (message not available due to condition)
+  writable: false
+  has_data: false
+- circuit: bai
+  name: Time
+  fields:
+  - value
+  values:
+  - no data stored (message not available due to condition)
+  writable: false
+  has_data: false
+- circuit: bai
+  name: TimerInputHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: ValveMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: ValveMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: ValveStarts
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: VolatileLockout
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: VolatileLockoutIFCGV
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: VortexFlowSensor
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: WP
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: WPPostrunTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: WPPostrunTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: WPSecondStage
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: WarmstartDemand
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: WarmstartOffset
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: WarmstartOffset
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: WaterHcFlowMax
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: WaterPressure
+  fields:
+  - value
+  values:
+  - 1.452;ok
+  writable: false
+  has_data: true
+- circuit: bai
+  name: WaterpressureBranchControlOff
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: WaterpressureMeasureCounter
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: WaterpressureVariantSum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: Z1HolidayTempStatus
+  fields:
+  - value
+  values:
+  - no data stored (message not available due to condition)
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: AdaptHeatCurve
+  fields:
+  - value
+  values:
+  - 'yes'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: AdaptHeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: CcTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: CcTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: CcTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: CcTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: CcTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: CcTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: CcTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: CcTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: CcTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: CcTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: CcTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: CcTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: CcTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: CcTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Clearerrorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: ContinuosHeating
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: ContinuosHeating
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - -;-;-;-;-
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: CylinderChargeHyst
+  fields:
+  - value
+  values:
+  - '5'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: CylinderChargeHyst
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: CylinderChargeOffset
+  fields:
+  - value
+  values:
+  - '25'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: CylinderChargeOffset
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Date
+  fields:
+  - value
+  values:
+  - 07.09.2026
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Date
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: DisplayedOutsideTemp
+  fields:
+  - value
+  values:
+  - '23.0625'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: FrostOverRideTime
+  fields:
+  - value
+  values:
+  - '4'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: FrostOverRideTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: GlobalSystemOff
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: GlobalSystemOff
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc1ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Hc1AutoOffMode
+  fields:
+  - value
+  values:
+  - eco
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Hc1AutoOffMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc1CircuitType
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002000200 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc1ExcessTemp
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002000b00 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc1ExcessTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc1FlowTemp
+  fields:
+  - value
+  values:
+  - '45'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Hc1HeatCurve
+  fields:
+  - value
+  values:
+  - '0.8'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Hc1HeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc1HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Hc1MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '90'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Hc1MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc1MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - '20'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Hc1MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc1MixerMovement
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002001a00 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc1PumpStatus
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Hc1PumpStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc1RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - modulating
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Hc1RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc1Status
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002001b00 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc1Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc1SummerTempLimit
+  fields:
+  - value
+  values:
+  - '20'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Hc1SummerTempLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc2ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Hc2AutoOffMode
+  fields:
+  - value
+  values:
+  - eco
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Hc2AutoOffMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc2CircuitType
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002010200 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc2ExcessTemp
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002010b00 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc2ExcessTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc2FlowTemp
+  fields:
+  - value
+  values:
+  - (empty for 3115b52406020002010800 / 0800020800ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc2HeatCurve
+  fields:
+  - value
+  values:
+  - '1.2'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Hc2HeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc2HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Hc2MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '90'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Hc2MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc2MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - '15'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Hc2MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc2MixerMovement
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002011a00 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc2PumpStatus
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Hc2PumpStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc2RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'off'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Hc2RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc2Status
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002011b00 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc2Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc2SummerTempLimit
+  fields:
+  - value
+  values:
+  - '21'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Hc2SummerTempLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc3ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Hc3AutoOffMode
+  fields:
+  - value
+  values:
+  - eco
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Hc3AutoOffMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc3CircuitType
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002020200 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc3ExcessTemp
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002020b00 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc3ExcessTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc3FlowTemp
+  fields:
+  - value
+  values:
+  - (empty for 3115b52406020002020800 / 0800020800ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc3HeatCurve
+  fields:
+  - value
+  values:
+  - '1.2'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Hc3HeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc3HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Hc3MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '90'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Hc3MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc3MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - '15'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Hc3MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc3MixerMovement
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002021a00 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc3PumpStatus
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Hc3PumpStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc3RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'off'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Hc3RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc3Status
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002021b00 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc3Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc3SummerTempLimit
+  fields:
+  - value
+  values:
+  - '21'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Hc3SummerTempLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HcStorageTempBottom
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HcStorageTempTop
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcBankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcBankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcBankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcBankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcFlowTemp
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: HwcHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: HwcHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: HwcHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcLockTime
+  fields:
+  - value
+  values:
+  - '60'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: HwcLockTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcMaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020000004600 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcMaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcOpMode
+  fields:
+  - value
+  values:
+  - day
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: HwcOpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcParallelLoading
+  fields:
+  - value
+  values:
+  - 'off'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: HwcParallelLoading
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcSFMode
+  fields:
+  - value
+  values:
+  - auto
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: HwcSFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcStorageTemp
+  fields:
+  - value
+  values:
+  - (empty for 3115b52406020001000500 / 0800010500ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcStorageTempBottom
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020000009e00 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcStorageTempTop
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020000009d00 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcTempDesired
+  fields:
+  - value
+  values:
+  - '45'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: HwcTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HydraulicScheme
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020000003600 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HydraulicScheme
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Installer1
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Installer1
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Installer2
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Installer2
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: KeyCodeforConfigMenu
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: KeyCodeforConfigMenu
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: MaintenanceDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: MaintenanceDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: MaintenanceDue
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: ManualCooling
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: ManualCooling
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: MaxCylinderChargeTime
+  fields:
+  - value
+  values:
+  - '60'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: MaxCylinderChargeTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: MaxRoomHumidity
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020000000e00 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: MaxRoomHumidity
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: MultiRelaySetting
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020000004d00 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: MultiRelaySetting
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: NoiseReductionTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: NoiseReductionTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: NoiseReductionTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: NoiseReductionTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: NoiseReductionTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: NoiseReductionTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: NoiseReductionTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: NoiseReductionTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: NoiseReductionTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: NoiseReductionTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: NoiseReductionTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: NoiseReductionTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: NoiseReductionTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: NoiseReductionTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: OpModeCooling
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: OpModeCooling
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: OpModeEffect
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: OpModeEffect
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: OpModeVentilation
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: OpModeVentilation
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: OutsideTempAvg
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020000009500 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: OutsideTempAvg
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PhoneNumber1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PhoneNumber1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PhoneNumber2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PhoneNumber2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PrEnergySum
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020000005c00 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PrEnergySum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PrEnergySumHc
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020000005700 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PrEnergySumHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PrEnergySumHcLastMonth
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020000005300 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PrEnergySumHcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PrEnergySumHcThisMonth
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020000004f00 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PrEnergySumHcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PrEnergySumHwc
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020000005800 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PrEnergySumHwc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PrEnergySumHwcLastMonth
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020000005400 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PrEnergySumHwcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PrEnergySumHwcThisMonth
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020000005000 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PrEnergySumHwcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PrFuelSum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PrFuelSum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PrFuelSumHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PrFuelSumHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PrFuelSumHcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PrFuelSumHcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PrFuelSumHcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PrFuelSumHcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PrFuelSumHwc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PrFuelSumHwc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PrFuelSumHwcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PrFuelSumHwcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PrFuelSumHwcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PrFuelSumHwcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PumpAdditionalTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PumpAdditionalTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: RoomHumidity
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: SolarYieldTotal
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: SolarYieldTotal
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: SystemFlowTemp
+  fields:
+  - value
+  values:
+  - (empty for 3115b52406020000004b00 / 0800004b00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: TariffTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: TariffTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: TariffTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: TariffTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: TariffTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: TariffTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: TariffTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: TariffTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: TariffTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: TariffTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: TariffTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: TariffTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: TariffTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: TariffTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Time
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Time
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: VentilationDay
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: VentilationDay
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: VentilationNight
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: VentilationNight
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: VentilationTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: VentilationTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: VentilationTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: VentilationTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: VentilationTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: VentilationTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: VentilationTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: VentilationTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: VentilationTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: VentilationTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: VentilationTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: VentilationTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: VentilationTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: VentilationTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: WaterPressure
+  fields:
+  - value
+  values:
+  - '1.4'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: YieldTotal
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020000003e00 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: YieldTotal
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Z1ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1CoolingTemp
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020003000200 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1CoolingTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1CoolingTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1CoolingTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1CoolingTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1CoolingTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1CoolingTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1CoolingTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1CoolingTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1CoolingTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1CoolingTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1CoolingTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1CoolingTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1CoolingTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1CoolingTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1CoolingTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1DayTemp
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020003000700 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Z1HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Z1HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1HolidayTemp
+  fields:
+  - value
+  values:
+  - '15'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Z1HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1NightTemp
+  fields:
+  - value
+  values:
+  - '15'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Z1NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1OpMode
+  fields:
+  - value
+  values:
+  - 'off'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Z1OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1OpModeCooling
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1OpModeCooling
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1QuickVetoTemp
+  fields:
+  - value
+  values:
+  - '21'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Z1QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1RoomTemp
+  fields:
+  - value
+  values:
+  - '24.7875'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Z1RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1SFMode
+  fields:
+  - value
+  values:
+  - auto
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Z1SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2CoolingTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2CoolingTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2CoolingTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2CoolingTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2CoolingTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2CoolingTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2CoolingTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2CoolingTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2CoolingTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2CoolingTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2CoolingTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2CoolingTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2CoolingTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2CoolingTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2CoolingTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2CoolingTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2OpModeCooling
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2OpModeCooling
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2RoomTemp
+  fields:
+  - value
+  values:
+  - (empty for 3115b52406020003010f00 / 0800030f00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3CoolingTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3CoolingTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3CoolingTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3CoolingTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3CoolingTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3CoolingTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3CoolingTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3CoolingTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3CoolingTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3CoolingTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3CoolingTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3CoolingTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3CoolingTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3CoolingTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3CoolingTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3CoolingTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3OpModeCooling
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3OpModeCooling
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3RoomTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: AdaptHeatCurve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: CcTimer_Config
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: CcTimer_Timeframes
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: ContinuousHeating
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: CylinderChargeHyst
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: CylinderChargeOffset
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Date
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: DisplayedOutsideTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: FrostOverRideTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1AutoOffMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1CircuitType
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1CoolingEnabled
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1CoolingFlowTempMin
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1DewPointMonitoring
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1DewPointOffset
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1DewPointTemp
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002300 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1ExcessTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1FlowTempCalc
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002000 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1HeatCurve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1Humidity
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002200 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MixerMovement
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MixerPosition
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002100 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1PumpHours
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002400 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1PumpStarts
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002500 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1PumpStatus
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1RoomTempModulation
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1Status
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1SummerTempLimit
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2AutoOffMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2CircuitType
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2DewPointTemp
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012300 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2ExcessTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2FlowTempCalc
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012000 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2HeatCurve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2Humidity
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012200 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MixerMovement
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MixerPosition
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012100 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2PumpHours
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012400 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2PumpStarts
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012500 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2PumpStatus
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2Status
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2SummerTempLimit
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3AutoOffMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3CircuitType
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3ExcessTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3HeatCurve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MixerMovement
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3PumpStatus
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3Status
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3SummerTempLimit
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HcStorageTempBottom
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: ctlv2
+  name: HcStorageTempTop
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: ctlv2
+  name: HwcFlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcLockTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcMaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcOpMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcParallelLoading
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcSFMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcSfMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcStorageTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcStorageTempBottom
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcStorageTempTop
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HydraulicScheme
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: ManualCoolingEndDate
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b5240602000000db00 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: ManualCoolingEndDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: ManualCoolingStartDate
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b5240602000000da00 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: ManualCoolingStartDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: MaxCylinderChargeTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: MaxRoomHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: MultiRelaySetting
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: OutsideTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: OutsideTempAvg
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySum
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHcLastMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHcThisMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHwcLastMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHwcThisMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: SystemFlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: WaterPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingManualTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingOpMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingSetbackTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1DayTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1HolidayTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1NightTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1OpMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoDuration
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoEndDate
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoEndTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1RoomTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1SFMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z2RoomTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: z1RoomHumidity
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020003002800 / 00)'
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: BuildingCircuitFlow
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: BuildingCircuitPumpSpeed
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: CompressorHc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: CompressorHwc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHwc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: ConsumptionTotal
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CoolElecConsDay
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CoolElecConsTotal
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CoolEnvYieldDay
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CoolEnvYieldMonth
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CoolEnvYieldTotal
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CopCooling
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CopCoolingMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CopHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CopHcMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CopHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CopHwcMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CurrentCompressorUtil
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CurrentConsumedPower
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CurrentYieldPower
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: DateTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: FlowTemperature
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: HcElecConsDay
+  fields:
+  - value
+  values:
+  - '55.5'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: HcElecConsTotal
+  fields:
+  - value
+  values:
+  - '932.15'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: HoursCool
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: HwcElecConsDay
+  fields:
+  - value
+  values:
+  - '24.89'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: HwcElecConsTotal
+  fields:
+  - value
+  values:
+  - '508.93'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: LiveMonitorCurrentConsumedPower
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: PowerConsumptionHmu
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunDataAirInletTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataBuildingCPumpPower
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataCompressorInletTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataCompressorOutletTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataCompressorSpeed
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataEEVOutletTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataEEVPositionAbs
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataElectricPowerConsumption
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataFan1Speed
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataFan2Speed
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataHighPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataLowPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunDataReturnTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataStatuscode
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStats4PortValveHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStats4PortValveSwitches
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsBuildingCPumpStarts
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsBuildingPumpHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunStatsCompressorHc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunStatsCompressorHwc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHwc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorStarts
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsFan1Hours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsFan1Starts
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsFan2Hours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsFan2Starts
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsHMUHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsHcHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsHwcHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: SourceTempInput
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: SourceTempOutput
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatElectricEnergySum
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatElectricEnergySumCool
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatElectricEnergySumHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatElectricEnergySumHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatEnvironmentEnergySum
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatEnvironmentEnergySumCool
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatEnvironmentEnergySumHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatEnvironmentEnergySumHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatSolarEnergySum
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatSolarEnergySumHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatSolarEnergySumHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.pumpstate
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.temp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.temp_1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.temp_2
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: Status01.temp_3
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: Status01.temp_4
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: StatusCirPump
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: SupplyTempWeighted
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: TotalEnergyUsage
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldCoolDay
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldCooling
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldCoolingMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldHcDay
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldHcMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldHwcDay
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldHwcMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: sc
+  name: Clearerrorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: Col
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: ColKickPumpTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: ColKickTempDelta
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: CollPump
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - -;-;-;-;-
+  writable: false
+  has_data: true
+- circuit: sc
+  name: D1Temp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: D2Temp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: Date
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 31ecb509030d0d00 / 00)'
+  writable: false
+  has_data: false
+- circuit: sc
+  name: EDFunction
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: EDFunction
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: EnableScProtection
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: EnableScProtection
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: FlowRate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: FlowRate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: FrostProtectionEnabled
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: FrostProtectionLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: Hc1PumpKol1PP1Port
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: Hc2aLegPumpP2Port
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: Hc2zPort
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: HydraulicScheme
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 31ecb509030d2100 / 00)'
+  writable: false
+  has_data: false
+- circuit: sc
+  name: InitCircuit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: Iotest
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: Ioteststop
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: IsInBoostMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: KickFunction
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: KickFunction
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: LpZpMaPort
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: MAPreferredStorage
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: MAPreferredStorage
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: MaximalTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: MaximalTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: MaximalTemp2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: MaximalTemp2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: MultifunctionOutput
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: OMultifunction
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: OMultifunction
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: PumpAntiLockingFlags
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: QuickVetoStart
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: ResetSolGain
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: ResetSolGain
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: RuntimeCollPump
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: RuntimeCollPumpSeconds
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: SP1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: SP2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: ScProtectionHysteresis
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: ScProtectionLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: ScProtectionLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: ScProtectionTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: SolCollPumpDcIntegrator
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: SolCollPumpED
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: SolGain
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: SolOperationMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: SumSolGain
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: SumSolGainDayBefore
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: SystemMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: TempDifferenceOff
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: TempDifferenceOff
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: TempDifferenceOff2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: TempDifferenceOff2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: TempDifferenceOffTD12
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: TempDifferenceOffTD12
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: TempDifferenceOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: TempDifferenceOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: TempDifferenceOn2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: TempDifferenceOn2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: TempDifferenceOnTD12
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: TempDifferenceOnTD12
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: Time
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: Weekday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: YieldLastYear
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: YieldThisYear
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: BypassPosition
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: ExhaustAirHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: ExhaustAirTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: FanHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: FlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: FlowTempMax
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: HcHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: HoursTillService
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: HwcHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: HwcTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: v32
+  name: Maintenancedata_HwcTempMax
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: v32
+  name: MaxAirHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: MinAirHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: OutdoorstempSensor
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: v32
+  name: OutsideAirTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: PumpHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: PumpPower
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: ReturnTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: ReturnTempMax
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: Status02.hwcmode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: Status02.temp0
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: Status02.temp0_1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: Status02.temp1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: Status02.temp1_1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: StorageLoadPumpHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: StorageTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: StorageTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: SupplyAirTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: VentilationLevelDay
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: VentilationLevelNight
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldToday
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldTotal
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldYear
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Clearerrorhistory
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Mc1Operation
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Mc2Operation
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Mc3Operation
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: SensorData1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: SensorData2
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: SetActorState
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vwz
+  name: TestHwcTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: vwz
+  name: TestOutdoorTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: vwz
+  name: TestThreeWayValve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+raw_find_lines_after:
+- bai AccessoriesOne = no data stored
+- bai AccessoriesOne = no data stored
+- bai AccessoriesTwo = no data stored
+- bai AccessoriesTwo = no data stored
+- bai ACRoomthermostat = no data stored
+- bai APCComStatus = no data stored
+- bai APCLegioProtection = no data stored
+- bai APCLegioProtection = no data stored
+- bai AverageIgnitiontime = no data stored
+- bai BlockTimeHcMax = no data stored
+- bai BlockTimeHcMax = no data stored
+- bai BoilerType = no data stored
+- bai ChangesDSN = no data stored
+- bai CirPump = no data stored
+- bai Clearerrorhistory = no data stored
+- bai CounterStartAttempts1 = no data stored
+- bai CounterStartAttempts2 = no data stored
+- bai CounterStartAttempts3 = no data stored
+- bai CounterStartAttempts4 = no data stored
+- bai Currenterror = -;-;-;-;-
+- bai Date = no data stored (message not available due to condition)
+- bai Date = no data stored (message not available due to condition)
+- bai DateTime = nosignal;-:-:-;-.-.-;23.875
+- bai DcfState = no data stored
+- bai DCFTimeDate = no data stored
+- bai DCRoomthermostat = no data stored
+- bai DeactivationsIFC = no data stored
+- bai DeactivationsTemplimiter = no data stored
+- bai DeltaFlowReturnMax = no data stored
+- bai DisplayMode = no data stored
+- bai DSN = no data stored
+- bai DSNOffset = no data stored
+- bai DSNOffset = no data stored
+- bai DSNStart = no data stored
+- bai EBusHeatcontrol = no data stored
+- bai EbusSourceOn = no data stored
+- bai EbusVoltage = no data stored
+- bai Errorhistory = no data stored
+- bai Expertlevel_ReturnTemp = no data stored
+- bai ExternalFaultmessage = no data stored
+- bai ExternalFlowTempDesired = no data stored
+- bai ExternalHwcSwitch = no data stored
+- bai ExternGasvalve = no data stored
+- bai ExtFlowTempDesiredMin = no data stored
+- bai ExtStorageModulCon = no data stored
+- bai ExtWP = no data stored
+- bai FanHours = 9
+- bai FanMaxSpeedOperation = no data stored
+- bai FanMinSpeedOperation = no data stored
+- bai FanPWMSum = no data stored
+- bai FanPWMTest = no data stored
+- bai FanSpeed = no data stored
+- bai FanSpeedOffsetMax = no data stored
+- bai FanSpeedOffsetMax = no data stored
+- bai FanSpeedOffsetMin = no data stored
+- bai FanSpeedOffsetMin = no data stored
+- bai FanStarts = no data stored
+- bai Flame = no data stored
+- bai FlameSensingASIC = no data stored
+- bai FloorHeatingContact = no data stored
+- bai FlowsetHcMax = no data stored
+- bai FlowsetHcMax = no data stored
+- bai FlowsetHwcMax = no data stored
+- bai FlowsetHwcMax = no data stored
+- bai FlowSetPotmeter = no data stored
+- bai FlowTemp = 44.62;ok
+- bai FlowTempDesired = 0.00
+- bai FlowTempMax = 68.12
+- bai Fluegasvalve = no data stored
+- bai FluegasvalveOpen = no data stored
+- bai Gasvalve3UC = no data stored
+- bai Gasvalve = no data stored
+- bai GasvalveASICFeedback = no data stored
+- bai GasvalveUC = no data stored
+- bai GasvalveUCFeedback = no data stored
+- bai GlobalSystemOff = no data stored (message not available due to condition)
+- bai GlobalSystemOff = no data stored (message not available due to condition)
+- bai HcHours = 0
+- bai HcPumpMode = no data stored
+- bai HcPumpMode = no data stored
+- bai HcPumpStarts = no data stored
+- bai HcStarts = no data stored
+- bai HcUnderHundredStarts = no data stored
+- bai HeatingSwitch = no data stored
+- bai HoursTillService = 2
+- bai HoursTillService = no data stored
+- bai HwcDemand = no data stored
+- bai HwcHours = 7
+- bai HwcImpellorSwitch = no data stored
+- bai HwcPostrunTime = no data stored
+- bai HwcPostrunTime = no data stored
+- bai HwcSetPotmeter = no data stored
+- bai HwcStarts = no data stored
+- bai HwcSwitch = no data stored
+- bai HwcTemp = no data stored
+- bai HwcTempDesired = 0.00
+- bai HwcTempMax = no data stored
+- bai HwcTempMax = no data stored
+- bai HwcTypes = no data stored
+- bai HwcUnderHundredStarts = no data stored
+- bai HwcWaterflow = no data stored
+- bai HwcWaterflowMax = no data stored
+- bai Ignitor = no data stored
+- bai InitialisationEEPROM = no data stored
+- bai IonisationVoltageLevel = no data stored
+- bai Maintenancedata_HwcTempMax = no data stored
+- bai MaxIgnitiontime = no data stored
+- bai MinIgnitiontime = no data stored
+- bai ModulationDesired = no data stored
+- bai OutdoorstempSensor = no data stored
+- bai OverflowCounter = no data stored
+- bai ParamToken = no data stored
+- bai PartloadHcKW = no data stored
+- bai PartloadHcKW = no data stored
+- bai PartloadHwcKW = no data stored
+- bai PartloadHwcKW = no data stored
+- bai PartnumberBox = no data stored
+- bai PositionValveSet = no data stored
+- bai PowerValue = no data stored
+- bai PrAPSCounter = no data stored
+- bai PrAPSSum = no data stored
+- bai PrEnergyCountHc1 = no data stored
+- bai PrEnergyCountHc1 = no data stored
+- bai PrEnergyCountHc2 = no data stored
+- bai PrEnergyCountHc2 = no data stored
+- bai PrEnergyCountHc3 = no data stored
+- bai PrEnergyCountHc3 = no data stored
+- bai PrEnergyCountHwc1 = no data stored
+- bai PrEnergyCountHwc1 = no data stored
+- bai PrEnergyCountHwc2 = no data stored
+- bai PrEnergyCountHwc2 = no data stored
+- bai PrEnergyCountHwc3 = no data stored
+- bai PrEnergyCountHwc3 = no data stored
+- bai PrEnergySumHc1 = no data stored
+- bai PrEnergySumHc1 = no data stored
+- bai PrEnergySumHc2 = no data stored
+- bai PrEnergySumHc2 = no data stored
+- bai PrEnergySumHc3 = no data stored
+- bai PrEnergySumHc3 = no data stored
+- bai PrEnergySumHwc1 = no data stored
+- bai PrEnergySumHwc1 = no data stored
+- bai PrEnergySumHwc2 = no data stored
+- bai PrEnergySumHwc2 = no data stored
+- bai PrEnergySumHwc3 = no data stored
+- bai PrEnergySumHwc3 = no data stored
+- bai PrimaryCircuitFlowrate = no data stored
+- bai ProductionByte = no data stored
+- bai PrVortexFlowSensorValue = no data stored
+- bai PumpHours = 12
+- bai PumpHwcFlowNumber = no data stored
+- bai PumpHwcFlowSum = no data stored
+- bai PumpPower = 0
+- bai PumpPowerDesired = no data stored
+- bai PumpPowerDesired = no data stored
+- bai RemainingBoilerblocktime = no data stored
+- bai ReturnRegulation = no data stored
+- bai ReturnRegulation = no data stored
+- bai ReturnTemp = 43.25;64843;ok
+- bai ReturnTempMax = 60.75
+- bai SecondPumpMode = no data stored
+- bai SecondPumpMode = no data stored
+- bai SerialNumber = no data stored
+- bai SetFactoryValues = no data stored
+- bai SetFactoryValues = no data stored
+- bai SetMode = auto;0.0;-;-;1;0;1;0;0;0
+- bai SetMode = no data stored
+- bai SHEMaxDeltaHwcFlow = no data stored
+- bai SHEMaxFlowTemp = no data stored
+- bai SolPostHeat = no data stored
+- bai SolPostHeat = no data stored
+- bai StatElectricEnergySum = 1.440960050
+- bai StatEnergySumYear = no data stored
+- bai Statenumber = no data stored
+- bai StatEnvironmentEnergySum = 0.000000000
+- bai StatEnvironmentEnergySumHc = 0.000000000
+- bai StatEnvironmentEnergySumHwc = 0.000000000
+- bai StatFuelSum = no data stored
+- bai StatFuelSumHc = no data stored
+- bai StatFuelSumHwc = no data stored
+- bai StatSolarEnergySum = 0.000000000
+- bai StatSolarEnergySumHc = 0.000000000
+- bai StatSolarEnergySumHwc = 0.000000000
+- bai Status01 = 44.5;42.5;23.875;36.5;-;off
+- bai Status02 = auto;60;65.0;70;65.0
+- bai Status16 = no data stored
+- bai Status = no data stored
+- bai StatusCirPump = off
+- bai Storageloadpump = no data stored
+- bai StorageLoadPumpHours = 0
+- bai StorageloadPumpStarts = no data stored
+- bai StorageLoadTimeMax = no data stored
+- bai StorageLoadTimeMax = no data stored
+- bai StoragereleaseClock = no data stored
+- bai StorageTemp = -13.50;cutoff
+- bai StorageTempDesired = 30.00
+- bai StorageTempMax = no data stored
+- bai TargetFanSpeed = no data stored
+- bai TargetFanSpeedOutput = no data stored
+- bai TempDiffBlock = no data stored
+- bai TempDiffFailure = no data stored
+- bai TempGradientFailure = no data stored
+- bai Templimiter = no data stored
+- bai TemplimiterWithNTC = no data stored
+- bai TempMaxDiffExtTFT = no data stored
+- bai Testbyte = no data stored
+- bai Time = no data stored (message not available due to condition)
+- bai Time = no data stored (message not available due to condition)
+- bai TimerInputHc = no data stored
+- bai ValveMode = no data stored
+- bai ValveMode = no data stored
+- bai ValveStarts = no data stored
+- bai VolatileLockout = no data stored
+- bai VolatileLockoutIFCGV = no data stored
+- bai VortexFlowSensor = no data stored
+- bai WarmstartDemand = no data stored
+- bai WarmstartOffset = no data stored
+- bai WarmstartOffset = no data stored
+- bai WaterHcFlowMax = no data stored
+- bai WaterPressure = 1.452;ok
+- bai WaterpressureBranchControlOff = no data stored
+- bai WaterpressureMeasureCounter = no data stored
+- bai WaterpressureVariantSum = no data stored
+- bai WP = no data stored
+- bai WPPostrunTime = no data stored
+- bai WPPostrunTime = no data stored
+- bai WPSecondStage = no data stored
+- bai Z1HolidayTempStatus = no data stored (message not available due to condition)
+- Broadcast Datetime = no data stored
+- Broadcast Error = no data stored
+- Broadcast HwcStatus = no data stored
+- Broadcast Id = no data stored
+- Broadcast IdAnswer = no data stored
+- Broadcast IdQuery = no data stored
+- Broadcast Load = no data stored
+- Broadcast Outsidetemp = 22.875
+- Broadcast Queryexistence = no data stored
+- Broadcast Signoflife = no data stored
+- Broadcast Vdatetime = 21:45:49;07.09.2026
+- Broadcast Vdatetime = no data stored
+- ctlv0 AdaptHeatCurve = yes
+- ctlv0 AdaptHeatCurve = no data stored
+- ctlv0 BankHolidayEndPeriod = no data stored
+- ctlv0 BankHolidayEndPeriod = no data stored
+- ctlv0 BankHolidayStartPeriod = no data stored
+- ctlv0 BankHolidayStartPeriod = no data stored
+- ctlv0 CcTimer_Friday = no data stored
+- ctlv0 CcTimer_Friday = no data stored
+- ctlv0 CcTimer_Monday = no data stored
+- ctlv0 CcTimer_Monday = no data stored
+- ctlv0 CcTimer_Saturday = no data stored
+- ctlv0 CcTimer_Saturday = no data stored
+- ctlv0 CcTimer_Sunday = no data stored
+- ctlv0 CcTimer_Sunday = no data stored
+- ctlv0 CcTimer_Thursday = no data stored
+- ctlv0 CcTimer_Thursday = no data stored
+- ctlv0 CcTimer_Tuesday = no data stored
+- ctlv0 CcTimer_Tuesday = no data stored
+- ctlv0 CcTimer_Wednesday = no data stored
+- ctlv0 CcTimer_Wednesday = no data stored
+- ctlv0 Clearerrorhistory = no data stored
+- ctlv0 ContinuosHeating = no data stored
+- ctlv0 ContinuosHeating = no data stored
+- ctlv0 Currenterror = -;-;-;-;-
+- ctlv0 CylinderChargeHyst = 5
+- ctlv0 CylinderChargeHyst = no data stored
+- ctlv0 CylinderChargeOffset = 25
+- ctlv0 CylinderChargeOffset = no data stored
+- ctlv0 Date = 07.09.2026
+- ctlv0 Date = no data stored
+- ctlv0 DisplayedOutsideTemp = 23.0625
+- ctlv0 Errorhistory = no data stored
+- ctlv0 FrostOverRideTime = 4
+- ctlv0 FrostOverRideTime = no data stored
+- ctlv0 GlobalSystemOff = no data stored
+- ctlv0 GlobalSystemOff = no data stored
+- ctlv0 Hc1ActualFlowTempDesired = 0.0
+- ctlv0 Hc1AutoOffMode = eco
+- ctlv0 Hc1AutoOffMode = no data stored
+- 'ctlv0 Hc1CircuitType =  (ERR: invalid position for 3115b52406020002000200 / 00)'
+- 'ctlv0 Hc1ExcessTemp =  (ERR: invalid position for 3115b52406020002000b00 / 00)'
+- ctlv0 Hc1ExcessTemp = no data stored
+- ctlv0 Hc1FlowTemp = 45
+- ctlv0 Hc1HeatCurve = 0.8
+- ctlv0 Hc1HeatCurve = no data stored
+- ctlv0 Hc1HeatCurveAdaption = 0.0
+- ctlv0 Hc1MaxFlowTempDesired = 90
+- ctlv0 Hc1MaxFlowTempDesired = no data stored
+- ctlv0 Hc1MinFlowTempDesired = 20
+- ctlv0 Hc1MinFlowTempDesired = no data stored
+- 'ctlv0 Hc1MixerMovement =  (ERR: invalid position for 3115b52406020002001a00 / 00)'
+- ctlv0 Hc1PumpStatus = 0
+- ctlv0 Hc1PumpStatus = no data stored
+- ctlv0 Hc1RoomTempSwitchOn = modulating
+- ctlv0 Hc1RoomTempSwitchOn = no data stored
+- 'ctlv0 Hc1Status =  (ERR: invalid position for 3115b52406020002001b00 / 00)'
+- ctlv0 Hc1Status = no data stored
+- ctlv0 Hc1SummerTempLimit = 20
+- ctlv0 Hc1SummerTempLimit = no data stored
+- ctlv0 Hc2ActualFlowTempDesired = 0.0
+- ctlv0 Hc2AutoOffMode = eco
+- ctlv0 Hc2AutoOffMode = no data stored
+- 'ctlv0 Hc2CircuitType =  (ERR: invalid position for 3115b52406020002010200 / 00)'
+- 'ctlv0 Hc2ExcessTemp =  (ERR: invalid position for 3115b52406020002010b00 / 00)'
+- ctlv0 Hc2ExcessTemp = no data stored
+- ctlv0 Hc2FlowTemp =  (empty for 3115b52406020002010800 / 0800020800ffffff7f)
+- ctlv0 Hc2HeatCurve = 1.2
+- ctlv0 Hc2HeatCurve = no data stored
+- ctlv0 Hc2HeatCurveAdaption = 0.0
+- ctlv0 Hc2MaxFlowTempDesired = 90
+- ctlv0 Hc2MaxFlowTempDesired = no data stored
+- ctlv0 Hc2MinFlowTempDesired = 15
+- ctlv0 Hc2MinFlowTempDesired = no data stored
+- 'ctlv0 Hc2MixerMovement =  (ERR: invalid position for 3115b52406020002011a00 / 00)'
+- ctlv0 Hc2PumpStatus = 0
+- ctlv0 Hc2PumpStatus = no data stored
+- ctlv0 Hc2RoomTempSwitchOn = off
+- ctlv0 Hc2RoomTempSwitchOn = no data stored
+- 'ctlv0 Hc2Status =  (ERR: invalid position for 3115b52406020002011b00 / 00)'
+- ctlv0 Hc2Status = no data stored
+- ctlv0 Hc2SummerTempLimit = 21
+- ctlv0 Hc2SummerTempLimit = no data stored
+- ctlv0 Hc3ActualFlowTempDesired = 0.0
+- ctlv0 Hc3AutoOffMode = eco
+- ctlv0 Hc3AutoOffMode = no data stored
+- 'ctlv0 Hc3CircuitType =  (ERR: invalid position for 3115b52406020002020200 / 00)'
+- 'ctlv0 Hc3ExcessTemp =  (ERR: invalid position for 3115b52406020002020b00 / 00)'
+- ctlv0 Hc3ExcessTemp = no data stored
+- ctlv0 Hc3FlowTemp =  (empty for 3115b52406020002020800 / 0800020800ffffff7f)
+- ctlv0 Hc3HeatCurve = 1.2
+- ctlv0 Hc3HeatCurve = no data stored
+- ctlv0 Hc3HeatCurveAdaption = 0.0
+- ctlv0 Hc3MaxFlowTempDesired = 90
+- ctlv0 Hc3MaxFlowTempDesired = no data stored
+- ctlv0 Hc3MinFlowTempDesired = 15
+- ctlv0 Hc3MinFlowTempDesired = no data stored
+- 'ctlv0 Hc3MixerMovement =  (ERR: invalid position for 3115b52406020002021a00 / 00)'
+- ctlv0 Hc3PumpStatus = 0
+- ctlv0 Hc3PumpStatus = no data stored
+- ctlv0 Hc3RoomTempSwitchOn = off
+- ctlv0 Hc3RoomTempSwitchOn = no data stored
+- 'ctlv0 Hc3Status =  (ERR: invalid position for 3115b52406020002021b00 / 00)'
+- ctlv0 Hc3Status = no data stored
+- ctlv0 Hc3SummerTempLimit = 21
+- ctlv0 Hc3SummerTempLimit = no data stored
+- ctlv0 HcStorageTempBottom = no data stored
+- ctlv0 HcStorageTempTop = no data stored
+- ctlv0 HolidayEndPeriod = no data stored
+- ctlv0 HolidayEndPeriod = no data stored
+- ctlv0 HolidayStartPeriod = no data stored
+- ctlv0 HolidayStartPeriod = no data stored
+- ctlv0 HolidayTemp = no data stored
+- ctlv0 HolidayTemp = no data stored
+- ctlv0 HwcBankHolidayEndPeriod = no data stored
+- ctlv0 HwcBankHolidayEndPeriod = no data stored
+- ctlv0 HwcBankHolidayStartPeriod = no data stored
+- ctlv0 HwcBankHolidayStartPeriod = no data stored
+- ctlv0 HwcFlowTemp = 0.0
+- ctlv0 HwcHolidayEndPeriod = 01.01.2019
+- ctlv0 HwcHolidayEndPeriod = no data stored
+- ctlv0 HwcHolidayStartPeriod = 01.01.2019
+- ctlv0 HwcHolidayStartPeriod = no data stored
+- ctlv0 HwcLockTime = 60
+- ctlv0 HwcLockTime = no data stored
+- 'ctlv0 HwcMaxFlowTempDesired =  (ERR: invalid position for 3115b52406020000004600
+  / 00)'
+- ctlv0 HwcMaxFlowTempDesired = no data stored
+- ctlv0 HwcOpMode = day
+- ctlv0 HwcOpMode = no data stored
+- ctlv0 HwcParallelLoading = off
+- ctlv0 HwcParallelLoading = no data stored
+- ctlv0 HwcSFMode = auto
+- ctlv0 HwcSFMode = no data stored
+- ctlv0 HwcStorageTemp =  (empty for 3115b52406020001000500 / 0800010500ffffff7f)
+- 'ctlv0 HwcStorageTempBottom =  (ERR: invalid position for 3115b52406020000009e00
+  / 00)'
+- 'ctlv0 HwcStorageTempTop =  (ERR: invalid position for 3115b52406020000009d00 /
+  00)'
+- ctlv0 HwcTempDesired = 45
+- ctlv0 HwcTempDesired = no data stored
+- ctlv0 HwcTimer_Friday = no data stored
+- ctlv0 HwcTimer_Friday = no data stored
+- ctlv0 HwcTimer_Monday = no data stored
+- ctlv0 HwcTimer_Monday = no data stored
+- ctlv0 HwcTimer_Saturday = no data stored
+- ctlv0 HwcTimer_Saturday = no data stored
+- ctlv0 HwcTimer_Sunday = no data stored
+- ctlv0 HwcTimer_Sunday = no data stored
+- ctlv0 HwcTimer_Thursday = no data stored
+- ctlv0 HwcTimer_Thursday = no data stored
+- ctlv0 HwcTimer_Tuesday = no data stored
+- ctlv0 HwcTimer_Tuesday = no data stored
+- ctlv0 HwcTimer_Wednesday = no data stored
+- ctlv0 HwcTimer_Wednesday = no data stored
+- 'ctlv0 HydraulicScheme =  (ERR: invalid position for 3115b52406020000003600 / 00)'
+- ctlv0 HydraulicScheme = no data stored
+- ctlv0 Installer1 = no data stored
+- ctlv0 Installer1 = no data stored
+- ctlv0 Installer2 = no data stored
+- ctlv0 Installer2 = no data stored
+- ctlv0 KeyCodeforConfigMenu = no data stored
+- ctlv0 KeyCodeforConfigMenu = no data stored
+- ctlv0 MaintenanceDate = no data stored
+- ctlv0 MaintenanceDate = no data stored
+- ctlv0 MaintenanceDue = no data stored
+- ctlv0 ManualCooling = no data stored
+- ctlv0 ManualCooling = no data stored
+- ctlv0 MaxCylinderChargeTime = 60
+- ctlv0 MaxCylinderChargeTime = no data stored
+- 'ctlv0 MaxRoomHumidity =  (ERR: invalid position for 3115b52406020000000e00 / 00)'
+- ctlv0 MaxRoomHumidity = no data stored
+- 'ctlv0 MultiRelaySetting =  (ERR: invalid position for 3115b52406020000004d00 /
+  00)'
+- ctlv0 MultiRelaySetting = no data stored
+- ctlv0 NoiseReductionTimer_Friday = no data stored
+- ctlv0 NoiseReductionTimer_Friday = no data stored
+- ctlv0 NoiseReductionTimer_Monday = no data stored
+- ctlv0 NoiseReductionTimer_Monday = no data stored
+- ctlv0 NoiseReductionTimer_Saturday = no data stored
+- ctlv0 NoiseReductionTimer_Saturday = no data stored
+- ctlv0 NoiseReductionTimer_Sunday = no data stored
+- ctlv0 NoiseReductionTimer_Sunday = no data stored
+- ctlv0 NoiseReductionTimer_Thursday = no data stored
+- ctlv0 NoiseReductionTimer_Thursday = no data stored
+- ctlv0 NoiseReductionTimer_Tuesday = no data stored
+- ctlv0 NoiseReductionTimer_Tuesday = no data stored
+- ctlv0 NoiseReductionTimer_Wednesday = no data stored
+- ctlv0 NoiseReductionTimer_Wednesday = no data stored
+- ctlv0 OpMode = no data stored
+- ctlv0 OpMode = no data stored
+- ctlv0 OpModeCooling = no data stored
+- ctlv0 OpModeCooling = no data stored
+- ctlv0 OpModeEffect = no data stored
+- ctlv0 OpModeEffect = no data stored
+- ctlv0 OpModeVentilation = no data stored
+- ctlv0 OpModeVentilation = no data stored
+- 'ctlv0 OutsideTempAvg =  (ERR: invalid position for 3115b52406020000009500 / 00)'
+- ctlv0 OutsideTempAvg = no data stored
+- ctlv0 PhoneNumber1 = no data stored
+- ctlv0 PhoneNumber1 = no data stored
+- ctlv0 PhoneNumber2 = no data stored
+- ctlv0 PhoneNumber2 = no data stored
+- 'ctlv0 PrEnergySum =  (ERR: invalid position for 3115b52406020000005c00 / 00)'
+- ctlv0 PrEnergySum = no data stored
+- 'ctlv0 PrEnergySumHc =  (ERR: invalid position for 3115b52406020000005700 / 00)'
+- ctlv0 PrEnergySumHc = no data stored
+- 'ctlv0 PrEnergySumHcLastMonth =  (ERR: invalid position for 3115b52406020000005300
+  / 00)'
+- ctlv0 PrEnergySumHcLastMonth = no data stored
+- 'ctlv0 PrEnergySumHcThisMonth =  (ERR: invalid position for 3115b52406020000004f00
+  / 00)'
+- ctlv0 PrEnergySumHcThisMonth = no data stored
+- 'ctlv0 PrEnergySumHwc =  (ERR: invalid position for 3115b52406020000005800 / 00)'
+- ctlv0 PrEnergySumHwc = no data stored
+- 'ctlv0 PrEnergySumHwcLastMonth =  (ERR: invalid position for 3115b52406020000005400
+  / 00)'
+- ctlv0 PrEnergySumHwcLastMonth = no data stored
+- 'ctlv0 PrEnergySumHwcThisMonth =  (ERR: invalid position for 3115b52406020000005000
+  / 00)'
+- ctlv0 PrEnergySumHwcThisMonth = no data stored
+- ctlv0 PrFuelSum = no data stored
+- ctlv0 PrFuelSum = no data stored
+- ctlv0 PrFuelSumHc = no data stored
+- ctlv0 PrFuelSumHc = no data stored
+- ctlv0 PrFuelSumHcLastMonth = no data stored
+- ctlv0 PrFuelSumHcLastMonth = no data stored
+- ctlv0 PrFuelSumHcThisMonth = no data stored
+- ctlv0 PrFuelSumHcThisMonth = no data stored
+- ctlv0 PrFuelSumHwc = no data stored
+- ctlv0 PrFuelSumHwc = no data stored
+- ctlv0 PrFuelSumHwcLastMonth = no data stored
+- ctlv0 PrFuelSumHwcLastMonth = no data stored
+- ctlv0 PrFuelSumHwcThisMonth = no data stored
+- ctlv0 PrFuelSumHwcThisMonth = no data stored
+- ctlv0 PumpAdditionalTime = no data stored
+- ctlv0 PumpAdditionalTime = no data stored
+- ctlv0 RoomHumidity = no data stored
+- ctlv0 SFMode = no data stored
+- ctlv0 SFMode = no data stored
+- ctlv0 SolarYieldTotal = no data stored
+- ctlv0 SolarYieldTotal = no data stored
+- ctlv0 SystemFlowTemp =  (empty for 3115b52406020000004b00 / 0800004b00ffffff7f)
+- ctlv0 TariffTimer_Friday = no data stored
+- ctlv0 TariffTimer_Friday = no data stored
+- ctlv0 TariffTimer_Monday = no data stored
+- ctlv0 TariffTimer_Monday = no data stored
+- ctlv0 TariffTimer_Saturday = no data stored
+- ctlv0 TariffTimer_Saturday = no data stored
+- ctlv0 TariffTimer_Sunday = no data stored
+- ctlv0 TariffTimer_Sunday = no data stored
+- ctlv0 TariffTimer_Thursday = no data stored
+- ctlv0 TariffTimer_Thursday = no data stored
+- ctlv0 TariffTimer_Tuesday = no data stored
+- ctlv0 TariffTimer_Tuesday = no data stored
+- ctlv0 TariffTimer_Wednesday = no data stored
+- ctlv0 TariffTimer_Wednesday = no data stored
+- ctlv0 Time = no data stored
+- ctlv0 Time = no data stored
+- ctlv0 VentilationDay = no data stored
+- ctlv0 VentilationDay = no data stored
+- ctlv0 VentilationNight = no data stored
+- ctlv0 VentilationNight = no data stored
+- ctlv0 VentilationTimer_Friday = no data stored
+- ctlv0 VentilationTimer_Friday = no data stored
+- ctlv0 VentilationTimer_Monday = no data stored
+- ctlv0 VentilationTimer_Monday = no data stored
+- ctlv0 VentilationTimer_Saturday = no data stored
+- ctlv0 VentilationTimer_Saturday = no data stored
+- ctlv0 VentilationTimer_Sunday = no data stored
+- ctlv0 VentilationTimer_Sunday = no data stored
+- ctlv0 VentilationTimer_Thursday = no data stored
+- ctlv0 VentilationTimer_Thursday = no data stored
+- ctlv0 VentilationTimer_Tuesday = no data stored
+- ctlv0 VentilationTimer_Tuesday = no data stored
+- ctlv0 VentilationTimer_Wednesday = no data stored
+- ctlv0 VentilationTimer_Wednesday = no data stored
+- ctlv0 WaterPressure = 1.4
+- 'ctlv0 YieldTotal =  (ERR: invalid position for 3115b52406020000003e00 / 00)'
+- ctlv0 YieldTotal = no data stored
+- ctlv0 Z1ActualRoomTempDesired = 0.0
+- ctlv0 Z1ActualRoomTempDesired = no data stored
+- ctlv0 Z1BankHolidayEndPeriod = no data stored
+- ctlv0 Z1BankHolidayEndPeriod = no data stored
+- ctlv0 Z1BankHolidayStartPeriod = no data stored
+- ctlv0 Z1BankHolidayStartPeriod = no data stored
+- 'ctlv0 Z1CoolingTemp =  (ERR: invalid position for 3115b52406020003000200 / 00)'
+- ctlv0 Z1CoolingTemp = no data stored
+- ctlv0 Z1CoolingTimer_Friday = no data stored
+- ctlv0 Z1CoolingTimer_Friday = no data stored
+- ctlv0 Z1CoolingTimer_Monday = no data stored
+- ctlv0 Z1CoolingTimer_Monday = no data stored
+- ctlv0 Z1CoolingTimer_Saturday = no data stored
+- ctlv0 Z1CoolingTimer_Saturday = no data stored
+- ctlv0 Z1CoolingTimer_Sunday = no data stored
+- ctlv0 Z1CoolingTimer_Sunday = no data stored
+- ctlv0 Z1CoolingTimer_Thursday = no data stored
+- ctlv0 Z1CoolingTimer_Thursday = no data stored
+- ctlv0 Z1CoolingTimer_Tuesday = no data stored
+- ctlv0 Z1CoolingTimer_Tuesday = no data stored
+- ctlv0 Z1CoolingTimer_Wednesday = no data stored
+- ctlv0 Z1CoolingTimer_Wednesday = no data stored
+- 'ctlv0 Z1DayTemp =  (ERR: invalid position for 3115b52406020003000700 / 00)'
+- ctlv0 Z1DayTemp = no data stored
+- ctlv0 Z1HolidayEndPeriod = 01.01.2019
+- ctlv0 Z1HolidayEndPeriod = no data stored
+- ctlv0 Z1HolidayStartPeriod = 01.01.2019
+- ctlv0 Z1HolidayStartPeriod = no data stored
+- ctlv0 Z1HolidayTemp = 15
+- ctlv0 Z1HolidayTemp = no data stored
+- ctlv0 Z1Name1 = no data stored
+- ctlv0 Z1Name1 = no data stored
+- ctlv0 Z1Name2 = no data stored
+- ctlv0 Z1Name2 = no data stored
+- ctlv0 Z1NightTemp = 15
+- ctlv0 Z1NightTemp = no data stored
+- ctlv0 Z1OpMode = off
+- ctlv0 Z1OpMode = no data stored
+- ctlv0 Z1OpModeCooling = no data stored
+- ctlv0 Z1OpModeCooling = no data stored
+- ctlv0 Z1QuickVetoTemp = 21
+- ctlv0 Z1QuickVetoTemp = no data stored
+- ctlv0 Z1RoomTemp = 24.7875
+- ctlv0 Z1RoomZoneMapping = no data stored
+- ctlv0 Z1RoomZoneMapping = no data stored
+- ctlv0 Z1SFMode = auto
+- ctlv0 Z1SFMode = no data stored
+- ctlv0 Z1Shortname = no data stored
+- ctlv0 Z1Shortname = no data stored
+- ctlv0 Z1Timer_Friday = no data stored
+- ctlv0 Z1Timer_Friday = no data stored
+- ctlv0 Z1Timer_Monday = no data stored
+- ctlv0 Z1Timer_Monday = no data stored
+- ctlv0 Z1Timer_Saturday = no data stored
+- ctlv0 Z1Timer_Saturday = no data stored
+- ctlv0 Z1Timer_Sunday = no data stored
+- ctlv0 Z1Timer_Sunday = no data stored
+- ctlv0 Z1Timer_Thursday = no data stored
+- ctlv0 Z1Timer_Thursday = no data stored
+- ctlv0 Z1Timer_Tuesday = no data stored
+- ctlv0 Z1Timer_Tuesday = no data stored
+- ctlv0 Z1Timer_Wednesday = no data stored
+- ctlv0 Z1Timer_Wednesday = no data stored
+- ctlv0 Z1ValveStatus = no data stored
+- ctlv0 Z1ValveStatus = no data stored
+- ctlv0 Z2ActualRoomTempDesired = no data stored
+- ctlv0 Z2ActualRoomTempDesired = no data stored
+- ctlv0 Z2BankHolidayEndPeriod = no data stored
+- ctlv0 Z2BankHolidayEndPeriod = no data stored
+- ctlv0 Z2BankHolidayStartPeriod = no data stored
+- ctlv0 Z2BankHolidayStartPeriod = no data stored
+- ctlv0 Z2CoolingTemp = no data stored
+- ctlv0 Z2CoolingTemp = no data stored
+- ctlv0 Z2CoolingTimer_Friday = no data stored
+- ctlv0 Z2CoolingTimer_Friday = no data stored
+- ctlv0 Z2CoolingTimer_Monday = no data stored
+- ctlv0 Z2CoolingTimer_Monday = no data stored
+- ctlv0 Z2CoolingTimer_Saturday = no data stored
+- ctlv0 Z2CoolingTimer_Saturday = no data stored
+- ctlv0 Z2CoolingTimer_Sunday = no data stored
+- ctlv0 Z2CoolingTimer_Sunday = no data stored
+- ctlv0 Z2CoolingTimer_Thursday = no data stored
+- ctlv0 Z2CoolingTimer_Thursday = no data stored
+- ctlv0 Z2CoolingTimer_Tuesday = no data stored
+- ctlv0 Z2CoolingTimer_Tuesday = no data stored
+- ctlv0 Z2CoolingTimer_Wednesday = no data stored
+- ctlv0 Z2CoolingTimer_Wednesday = no data stored
+- ctlv0 Z2DayTemp = no data stored
+- ctlv0 Z2DayTemp = no data stored
+- ctlv0 Z2HolidayEndPeriod = no data stored
+- ctlv0 Z2HolidayEndPeriod = no data stored
+- ctlv0 Z2HolidayStartPeriod = no data stored
+- ctlv0 Z2HolidayStartPeriod = no data stored
+- ctlv0 Z2HolidayTemp = no data stored
+- ctlv0 Z2HolidayTemp = no data stored
+- ctlv0 Z2Name1 = no data stored
+- ctlv0 Z2Name1 = no data stored
+- ctlv0 Z2Name2 = no data stored
+- ctlv0 Z2Name2 = no data stored
+- ctlv0 Z2NightTemp = no data stored
+- ctlv0 Z2NightTemp = no data stored
+- ctlv0 Z2OpMode = no data stored
+- ctlv0 Z2OpMode = no data stored
+- ctlv0 Z2OpModeCooling = no data stored
+- ctlv0 Z2OpModeCooling = no data stored
+- ctlv0 Z2QuickVetoTemp = no data stored
+- ctlv0 Z2QuickVetoTemp = no data stored
+- ctlv0 Z2RoomTemp =  (empty for 3115b52406020003010f00 / 0800030f00ffffff7f)
+- ctlv0 Z2RoomZoneMapping = no data stored
+- ctlv0 Z2RoomZoneMapping = no data stored
+- ctlv0 Z2SFMode = no data stored
+- ctlv0 Z2SFMode = no data stored
+- ctlv0 Z2Shortname = no data stored
+- ctlv0 Z2Shortname = no data stored
+- ctlv0 Z2Timer_Friday = no data stored
+- ctlv0 Z2Timer_Friday = no data stored
+- ctlv0 Z2Timer_Monday = no data stored
+- ctlv0 Z2Timer_Monday = no data stored
+- ctlv0 Z2Timer_Saturday = no data stored
+- ctlv0 Z2Timer_Saturday = no data stored
+- ctlv0 Z2Timer_Sunday = no data stored
+- ctlv0 Z2Timer_Sunday = no data stored
+- ctlv0 Z2Timer_Thursday = no data stored
+- ctlv0 Z2Timer_Thursday = no data stored
+- ctlv0 Z2Timer_Tuesday = no data stored
+- ctlv0 Z2Timer_Tuesday = no data stored
+- ctlv0 Z2Timer_Wednesday = no data stored
+- ctlv0 Z2Timer_Wednesday = no data stored
+- ctlv0 Z2ValveStatus = no data stored
+- ctlv0 Z2ValveStatus = no data stored
+- ctlv0 Z3ActualRoomTempDesired = no data stored
+- ctlv0 Z3ActualRoomTempDesired = no data stored
+- ctlv0 Z3BankHolidayEndPeriod = no data stored
+- ctlv0 Z3BankHolidayEndPeriod = no data stored
+- ctlv0 Z3BankHolidayStartPeriod = no data stored
+- ctlv0 Z3BankHolidayStartPeriod = no data stored
+- ctlv0 Z3CoolingTemp = no data stored
+- ctlv0 Z3CoolingTemp = no data stored
+- ctlv0 Z3CoolingTimer_Friday = no data stored
+- ctlv0 Z3CoolingTimer_Friday = no data stored
+- ctlv0 Z3CoolingTimer_Monday = no data stored
+- ctlv0 Z3CoolingTimer_Monday = no data stored
+- ctlv0 Z3CoolingTimer_Saturday = no data stored
+- ctlv0 Z3CoolingTimer_Saturday = no data stored
+- ctlv0 Z3CoolingTimer_Sunday = no data stored
+- ctlv0 Z3CoolingTimer_Sunday = no data stored
+- ctlv0 Z3CoolingTimer_Thursday = no data stored
+- ctlv0 Z3CoolingTimer_Thursday = no data stored
+- ctlv0 Z3CoolingTimer_Tuesday = no data stored
+- ctlv0 Z3CoolingTimer_Tuesday = no data stored
+- ctlv0 Z3CoolingTimer_Wednesday = no data stored
+- ctlv0 Z3CoolingTimer_Wednesday = no data stored
+- ctlv0 Z3DayTemp = no data stored
+- ctlv0 Z3DayTemp = no data stored
+- ctlv0 Z3HolidayEndPeriod = no data stored
+- ctlv0 Z3HolidayEndPeriod = no data stored
+- ctlv0 Z3HolidayStartPeriod = no data stored
+- ctlv0 Z3HolidayStartPeriod = no data stored
+- ctlv0 Z3HolidayTemp = no data stored
+- ctlv0 Z3HolidayTemp = no data stored
+- ctlv0 Z3Name1 = no data stored
+- ctlv0 Z3Name1 = no data stored
+- ctlv0 Z3Name2 = no data stored
+- ctlv0 Z3Name2 = no data stored
+- ctlv0 Z3NightTemp = no data stored
+- ctlv0 Z3NightTemp = no data stored
+- ctlv0 Z3OpMode = no data stored
+- ctlv0 Z3OpMode = no data stored
+- ctlv0 Z3OpModeCooling = no data stored
+- ctlv0 Z3OpModeCooling = no data stored
+- ctlv0 Z3QuickVetoTemp = no data stored
+- ctlv0 Z3QuickVetoTemp = no data stored
+- ctlv0 Z3RoomTemp = no data stored
+- ctlv0 Z3RoomZoneMapping = no data stored
+- ctlv0 Z3RoomZoneMapping = no data stored
+- ctlv0 Z3SFMode = no data stored
+- ctlv0 Z3SFMode = no data stored
+- ctlv0 Z3Shortname = no data stored
+- ctlv0 Z3Shortname = no data stored
+- ctlv0 Z3Timer_Friday = no data stored
+- ctlv0 Z3Timer_Friday = no data stored
+- ctlv0 Z3Timer_Monday = no data stored
+- ctlv0 Z3Timer_Monday = no data stored
+- ctlv0 Z3Timer_Saturday = no data stored
+- ctlv0 Z3Timer_Saturday = no data stored
+- ctlv0 Z3Timer_Sunday = no data stored
+- ctlv0 Z3Timer_Sunday = no data stored
+- ctlv0 Z3Timer_Thursday = no data stored
+- ctlv0 Z3Timer_Thursday = no data stored
+- ctlv0 Z3Timer_Tuesday = no data stored
+- ctlv0 Z3Timer_Tuesday = no data stored
+- ctlv0 Z3Timer_Wednesday = no data stored
+- ctlv0 Z3Timer_Wednesday = no data stored
+- ctlv0 Z3ValveStatus = no data stored
+- ctlv0 Z3ValveStatus = no data stored
+- 'ctlv2 Hc1DewPointTemp =  (ERR: invalid position for 3115b52406020002002300 / 00)'
+- 'ctlv2 Hc1FlowTempCalc =  (ERR: invalid position for 3115b52406020002002000 / 00)'
+- 'ctlv2 Hc1Humidity =  (ERR: invalid position for 3115b52406020002002200 / 00)'
+- 'ctlv2 Hc1MixerPosition =  (ERR: invalid position for 3115b52406020002002100 / 00)'
+- 'ctlv2 Hc1PumpHours =  (ERR: invalid position for 3115b52406020002002400 / 00)'
+- 'ctlv2 Hc1PumpStarts =  (ERR: invalid position for 3115b52406020002002500 / 00)'
+- 'ctlv2 Hc2DewPointTemp =  (ERR: invalid position for 3115b52406020002012300 / 00)'
+- 'ctlv2 Hc2FlowTempCalc =  (ERR: invalid position for 3115b52406020002012000 / 00)'
+- 'ctlv2 Hc2Humidity =  (ERR: invalid position for 3115b52406020002012200 / 00)'
+- 'ctlv2 Hc2MixerPosition =  (ERR: invalid position for 3115b52406020002012100 / 00)'
+- 'ctlv2 Hc2PumpHours =  (ERR: invalid position for 3115b52406020002012400 / 00)'
+- 'ctlv2 Hc2PumpStarts =  (ERR: invalid position for 3115b52406020002012500 / 00)'
+- 'ctlv2 ManualCoolingEndDate =  (ERR: invalid position for 3115b5240602000000db00
+  / 00)'
+- ctlv2 ManualCoolingEndDate = no data stored
+- 'ctlv2 ManualCoolingStartDate =  (ERR: invalid position for 3115b5240602000000da00
+  / 00)'
+- ctlv2 ManualCoolingStartDate = no data stored
+- 'ctlv2 z1RoomHumidity =  (ERR: invalid position for 3115b52406020003002800 / 00)'
+- General Valuerange = no data stored
+- hmu CoolElecConsDay = 0.0
+- hmu CoolElecConsTotal = 0.0
+- hmu CoolEnvYieldDay = 0.0
+- hmu CoolEnvYieldMonth = 0.0
+- hmu CoolEnvYieldTotal = 0.0
+- hmu HcElecConsDay = 55.5
+- hmu HcElecConsTotal = 932.15
+- hmu HwcElecConsDay = 24.89
+- hmu HwcElecConsTotal = 508.93
+- 'hmu SourceTempInput =  (ERR: invalid position for 3108b51a0405ff3222 / 02ff01)'
+- Memory Eeprom = no data stored
+- Memory Eeprom = no data stored
+- Memory Ram = no data stored
+- Memory Ram = no data stored
+- sc Clearerrorhistory = no data stored
+- sc Col = no data stored
+- sc ColKickPumpTime = no data stored
+- sc ColKickTempDelta = no data stored
+- sc CollPump = no data stored
+- sc Currenterror = -;-;-;-;-
+- sc D1Temp = no data stored
+- sc D2Temp = no data stored
+- 'sc Date =  (ERR: invalid position for 31ecb509030d0d00 / 00)'
+- sc EDFunction = no data stored
+- sc EDFunction = no data stored
+- sc EnableScProtection = no data stored
+- sc EnableScProtection = no data stored
+- sc Errorhistory = no data stored
+- sc FlowRate = no data stored
+- sc FlowRate = no data stored
+- sc FrostProtectionEnabled = no data stored
+- sc FrostProtectionLimit = no data stored
+- sc Hc1PumpKol1PP1Port = no data stored
+- sc Hc2aLegPumpP2Port = no data stored
+- sc Hc2zPort = no data stored
+- 'sc HydraulicScheme =  (ERR: invalid position for 31ecb509030d2100 / 00)'
+- sc InitCircuit = no data stored
+- sc Iotest = no data stored
+- sc Ioteststop = no data stored
+- sc IsInBoostMode = no data stored
+- sc KickFunction = no data stored
+- sc KickFunction = no data stored
+- sc LpZpMaPort = no data stored
+- sc MAPreferredStorage = no data stored
+- sc MAPreferredStorage = no data stored
+- sc MaximalTemp2 = no data stored
+- sc MaximalTemp2 = no data stored
+- sc MaximalTemp = no data stored
+- sc MaximalTemp = no data stored
+- sc MultifunctionOutput = no data stored
+- sc OMultifunction = no data stored
+- sc OMultifunction = no data stored
+- sc PumpAntiLockingFlags = no data stored
+- sc QuickVetoStart = no data stored
+- sc ResetSolGain = no data stored
+- sc ResetSolGain = no data stored
+- sc RuntimeCollPump = no data stored
+- sc RuntimeCollPumpSeconds = no data stored
+- sc ScProtectionHysteresis = no data stored
+- sc ScProtectionLimit = no data stored
+- sc ScProtectionLimit = no data stored
+- sc ScProtectionTime = no data stored
+- sc SolCollPumpDcIntegrator = no data stored
+- sc SolCollPumpED = no data stored
+- sc SolGain = no data stored
+- sc SolOperationMode = no data stored
+- sc SP1 = no data stored
+- sc SP2 = no data stored
+- sc SumSolGain = no data stored
+- sc SumSolGainDayBefore = no data stored
+- sc SystemMode = no data stored
+- sc TempDifferenceOff2 = no data stored
+- sc TempDifferenceOff2 = no data stored
+- sc TempDifferenceOff = no data stored
+- sc TempDifferenceOff = no data stored
+- sc TempDifferenceOffTD12 = no data stored
+- sc TempDifferenceOffTD12 = no data stored
+- sc TempDifferenceOn2 = no data stored
+- sc TempDifferenceOn2 = no data stored
+- sc TempDifferenceOn = no data stored
+- sc TempDifferenceOn = no data stored
+- sc TempDifferenceOnTD12 = no data stored
+- sc TempDifferenceOnTD12 = no data stored
+- sc Time = no data stored
+- sc Weekday = no data stored
+- sc YieldLastYear = no data stored
+- sc YieldThisYear = no data stored
+- Scan Id = no data stored
+- scan.08  = Vaillant;BAI00;1201;7603
+- Scan.08 Id = xx
+- scan.15  = Vaillant;CTLV0;0313;9103
+- Scan.15 Id = no data stored
+- scan.ec  = Vaillant;SOL00;0313;9103
+- Scan.ec Id = no data stored
+- ''

--- a/tests/fixtures/community/ecotec_vrt380_ctlv2_discovery.yaml
+++ b/tests/fixtures/community/ecotec_vrt380_ctlv2_discovery.yaml
@@ -1,0 +1,13312 @@
+# Discovery dump for vaillant_ebus
+# Review this file for sensitive information before sharing
+metadata:
+  timestamp: '2026-09-08T16:27:16.790860'
+  ebusd_version: ebusd 26.1.26.1
+  register_count: 277
+  grab_duration: 300
+  dump_version: 3
+raw_find_lines:
+- bai AccessoriesOne = no data stored
+- bai AccessoriesOne = no data stored
+- bai AccessoriesTwo = no data stored
+- bai AccessoriesTwo = no data stored
+- bai ACRoomthermostat = no data stored
+- bai APCComStatus = no data stored
+- bai APCLegioProtection = no data stored
+- bai APCLegioProtection = no data stored
+- bai AverageIgnitiontime = no data stored
+- bai BlockTimeHcMax = no data stored
+- bai BlockTimeHcMax = no data stored
+- bai BoilerType = no data stored
+- bai ChangesDSN = no data stored
+- bai CirPump = no data stored
+- bai Clearerrorhistory = no data stored
+- bai CounterStartAttempts1 = no data stored
+- bai CounterStartAttempts2 = no data stored
+- bai CounterStartAttempts3 = no data stored
+- bai CounterStartAttempts4 = no data stored
+- bai Currenterror = -;-;-;-;-
+- bai Date = no data stored (message not available due to condition)
+- bai Date = no data stored (message not available due to condition)
+- bai DateTime = nosignal;-:-:-;-.-.-;31.500
+- bai DcfState = no data stored
+- bai DCFTimeDate = no data stored
+- bai DCRoomthermostat = no data stored
+- bai DeactivationsIFC = no data stored
+- bai DeactivationsTemplimiter = no data stored
+- bai DeltaFlowReturnMax = no data stored
+- bai DisplayMode = no data stored
+- bai DSN = no data stored
+- bai DSNOffset = no data stored
+- bai DSNOffset = no data stored
+- bai DSNStart = no data stored
+- bai EBusHeatcontrol = no data stored
+- bai EbusSourceOn = no data stored
+- bai EbusVoltage = no data stored
+- bai Errorhistory = no data stored
+- bai Expertlevel_ReturnTemp = no data stored
+- bai ExternalFaultmessage = no data stored
+- bai ExternalFlowTempDesired = no data stored
+- bai ExternalHwcSwitch = no data stored
+- bai ExternGasvalve = no data stored
+- bai ExtFlowTempDesiredMin = no data stored
+- bai ExtStorageModulCon = no data stored
+- bai ExtWP = no data stored
+- bai FanHours = 10
+- bai FanMaxSpeedOperation = no data stored
+- bai FanMinSpeedOperation = no data stored
+- bai FanPWMSum = no data stored
+- bai FanPWMTest = no data stored
+- bai FanSpeed = no data stored
+- bai FanSpeedOffsetMax = no data stored
+- bai FanSpeedOffsetMax = no data stored
+- bai FanSpeedOffsetMin = no data stored
+- bai FanSpeedOffsetMin = no data stored
+- bai FanStarts = no data stored
+- bai Flame = no data stored
+- bai FlameSensingASIC = no data stored
+- bai FloorHeatingContact = no data stored
+- bai FlowsetHcMax = no data stored
+- bai FlowsetHcMax = no data stored
+- bai FlowsetHwcMax = no data stored
+- bai FlowsetHwcMax = no data stored
+- bai FlowSetPotmeter = no data stored
+- bai FlowTemp = 26.69;ok
+- bai FlowTempDesired = 0.00
+- bai FlowTempMax = 68.12
+- bai Fluegasvalve = no data stored
+- bai FluegasvalveOpen = no data stored
+- bai Gasvalve3UC = no data stored
+- bai Gasvalve = no data stored
+- bai GasvalveASICFeedback = no data stored
+- bai GasvalveUC = no data stored
+- bai GasvalveUCFeedback = no data stored
+- bai GlobalSystemOff = no data stored (message not available due to condition)
+- bai GlobalSystemOff = no data stored (message not available due to condition)
+- bai HcHours = 0
+- bai HcPumpMode = no data stored
+- bai HcPumpMode = no data stored
+- bai HcPumpStarts = no data stored
+- bai HcStarts = no data stored
+- bai HcUnderHundredStarts = no data stored
+- bai HeatingSwitch = no data stored
+- bai HoursTillService = 2
+- bai HoursTillService = no data stored
+- bai HwcDemand = no data stored
+- bai HwcHours = 7
+- bai HwcImpellorSwitch = no data stored
+- bai HwcPostrunTime = no data stored
+- bai HwcPostrunTime = no data stored
+- bai HwcSetPotmeter = no data stored
+- bai HwcStarts = no data stored
+- bai HwcSwitch = no data stored
+- bai HwcTemp = no data stored
+- bai HwcTempDesired = 0.00
+- bai HwcTempMax = no data stored
+- bai HwcTempMax = no data stored
+- bai HwcTypes = no data stored
+- bai HwcUnderHundredStarts = no data stored
+- bai HwcWaterflow = no data stored
+- bai HwcWaterflowMax = no data stored
+- bai Ignitor = no data stored
+- bai InitialisationEEPROM = no data stored
+- bai IonisationVoltageLevel = no data stored
+- bai Maintenancedata_HwcTempMax = no data stored
+- bai MaxIgnitiontime = no data stored
+- bai MinIgnitiontime = no data stored
+- bai ModulationDesired = no data stored
+- bai OutdoorstempSensor = no data stored
+- bai OverflowCounter = no data stored
+- bai ParamToken = no data stored
+- bai PartloadHcKW = no data stored
+- bai PartloadHcKW = no data stored
+- bai PartloadHwcKW = no data stored
+- bai PartloadHwcKW = no data stored
+- bai PartnumberBox = no data stored
+- bai PositionValveSet = no data stored
+- bai PowerValue = no data stored
+- bai PrAPSCounter = no data stored
+- bai PrAPSSum = no data stored
+- bai PrEnergyCountHc1 = no data stored
+- bai PrEnergyCountHc1 = no data stored
+- bai PrEnergyCountHc2 = no data stored
+- bai PrEnergyCountHc2 = no data stored
+- bai PrEnergyCountHc3 = no data stored
+- bai PrEnergyCountHc3 = no data stored
+- bai PrEnergyCountHwc1 = no data stored
+- bai PrEnergyCountHwc1 = no data stored
+- bai PrEnergyCountHwc2 = no data stored
+- bai PrEnergyCountHwc2 = no data stored
+- bai PrEnergyCountHwc3 = no data stored
+- bai PrEnergyCountHwc3 = no data stored
+- bai PrEnergySumHc1 = no data stored
+- bai PrEnergySumHc1 = no data stored
+- bai PrEnergySumHc2 = no data stored
+- bai PrEnergySumHc2 = no data stored
+- bai PrEnergySumHc3 = no data stored
+- bai PrEnergySumHc3 = no data stored
+- bai PrEnergySumHwc1 = no data stored
+- bai PrEnergySumHwc1 = no data stored
+- bai PrEnergySumHwc2 = no data stored
+- bai PrEnergySumHwc2 = no data stored
+- bai PrEnergySumHwc3 = no data stored
+- bai PrEnergySumHwc3 = no data stored
+- bai PrimaryCircuitFlowrate = no data stored
+- bai ProductionByte = no data stored
+- bai PrVortexFlowSensorValue = no data stored
+- bai PumpHours = 14
+- bai PumpHwcFlowNumber = no data stored
+- bai PumpHwcFlowSum = no data stored
+- bai PumpPower = 0
+- bai PumpPowerDesired = no data stored
+- bai PumpPowerDesired = no data stored
+- bai RemainingBoilerblocktime = no data stored
+- bai ReturnRegulation = no data stored
+- bai ReturnRegulation = no data stored
+- bai ReturnTemp = 25.88;65121;ok
+- bai ReturnTempMax = 60.75
+- bai SecondPumpMode = no data stored
+- bai SecondPumpMode = no data stored
+- bai SerialNumber = no data stored
+- bai SetFactoryValues = no data stored
+- bai SetFactoryValues = no data stored
+- bai SetMode = auto;0.0;-;-;1;0;1;0;0;0
+- bai SetMode = no data stored
+- bai SHEMaxDeltaHwcFlow = no data stored
+- bai SHEMaxFlowTemp = no data stored
+- bai SolPostHeat = no data stored
+- bai SolPostHeat = no data stored
+- bai StatElectricEnergySum = 1.555580020
+- bai StatEnergySumYear = no data stored
+- bai Statenumber = no data stored
+- bai StatEnvironmentEnergySum = 0.000000000
+- bai StatEnvironmentEnergySumHc = 0.000000000
+- bai StatEnvironmentEnergySumHwc = 0.000000000
+- bai StatFuelSum = no data stored
+- bai StatFuelSumHc = no data stored
+- bai StatFuelSumHwc = no data stored
+- bai StatSolarEnergySum = 0.000000000
+- bai StatSolarEnergySumHc = 0.000000000
+- bai StatSolarEnergySumHwc = 0.000000000
+- bai Status01 = 26.5;25.5;31.500;26.5;-;off
+- bai Status02 = auto;60;65.0;70;65.0
+- bai Status16 = no data stored
+- bai Status = no data stored
+- bai StatusCirPump = off
+- bai Storageloadpump = no data stored
+- bai StorageLoadPumpHours = 0
+- bai StorageloadPumpStarts = no data stored
+- bai StorageLoadTimeMax = no data stored
+- bai StorageLoadTimeMax = no data stored
+- bai StoragereleaseClock = no data stored
+- bai StorageTemp = -13.50;cutoff
+- bai StorageTempDesired = 30.00
+- bai StorageTempMax = no data stored
+- bai TargetFanSpeed = no data stored
+- bai TargetFanSpeedOutput = no data stored
+- bai TempDiffBlock = no data stored
+- bai TempDiffFailure = no data stored
+- bai TempGradientFailure = no data stored
+- bai Templimiter = no data stored
+- bai TemplimiterWithNTC = no data stored
+- bai TempMaxDiffExtTFT = no data stored
+- bai Testbyte = no data stored
+- bai Time = no data stored (message not available due to condition)
+- bai Time = no data stored (message not available due to condition)
+- bai TimerInputHc = no data stored
+- bai ValveMode = no data stored
+- bai ValveMode = no data stored
+- bai ValveStarts = no data stored
+- bai VolatileLockout = no data stored
+- bai VolatileLockoutIFCGV = no data stored
+- bai VortexFlowSensor = no data stored
+- bai WarmstartDemand = no data stored
+- bai WarmstartOffset = no data stored
+- bai WarmstartOffset = no data stored
+- bai WaterHcFlowMax = no data stored
+- bai WaterPressure = 1.373;ok
+- bai WaterpressureBranchControlOff = no data stored
+- bai WaterpressureMeasureCounter = no data stored
+- bai WaterpressureVariantSum = no data stored
+- bai WP = no data stored
+- bai WPPostrunTime = no data stored
+- bai WPPostrunTime = no data stored
+- bai WPSecondStage = no data stored
+- bai Z1HolidayTempStatus = no data stored (message not available due to condition)
+- Broadcast Datetime = no data stored
+- Broadcast Error = no data stored
+- Broadcast HwcStatus = no data stored
+- Broadcast Id = no data stored
+- Broadcast IdAnswer = no data stored
+- Broadcast IdQuery = no data stored
+- Broadcast Load = no data stored
+- Broadcast Outsidetemp = 30.500
+- Broadcast Queryexistence = no data stored
+- Broadcast Signoflife = no data stored
+- Broadcast Vdatetime = 16:20:49;08.09.2026
+- Broadcast Vdatetime = no data stored
+- ctlv0 AdaptHeatCurve = yes
+- ctlv0 AdaptHeatCurve = no data stored
+- ctlv0 CcTimer_Config = 03 01 01 00 00 00 ff ff 00
+- ctlv0 CcTimer_Friday0 = no data stored
+- ctlv0 CcTimer_Friday1 = no data stored
+- ctlv0 CcTimer_Friday2 = no data stored
+- ctlv0 CcTimer_Friday = no data stored
+- ctlv0 CcTimer_Monday0 = no data stored
+- ctlv0 CcTimer_Monday1 = no data stored
+- ctlv0 CcTimer_Monday2 = no data stored
+- ctlv0 CcTimer_Monday = no data stored
+- ctlv0 CcTimer_Saturday0 = no data stored
+- ctlv0 CcTimer_Saturday1 = no data stored
+- ctlv0 CcTimer_Saturday2 = no data stored
+- ctlv0 CcTimer_Saturday = no data stored
+- ctlv0 CcTimer_Sunday0 = no data stored
+- ctlv0 CcTimer_Sunday1 = no data stored
+- ctlv0 CcTimer_Sunday2 = no data stored
+- ctlv0 CcTimer_Sunday = no data stored
+- ctlv0 CcTimer_Thursday0 = no data stored
+- ctlv0 CcTimer_Thursday1 = no data stored
+- ctlv0 CcTimer_Thursday2 = no data stored
+- ctlv0 CcTimer_Thursday = no data stored
+- ctlv0 CcTimer_Timeframes = 0;0;0;0;0;0;0
+- ctlv0 CcTimer_Tuesday0 = no data stored
+- ctlv0 CcTimer_Tuesday1 = no data stored
+- ctlv0 CcTimer_Tuesday2 = no data stored
+- ctlv0 CcTimer_Tuesday = no data stored
+- ctlv0 CcTimer_Wednesday0 = no data stored
+- ctlv0 CcTimer_Wednesday1 = no data stored
+- ctlv0 CcTimer_Wednesday2 = no data stored
+- ctlv0 CcTimer_Wednesday = no data stored
+- ctlv0 Clearerrorhistory = no data stored
+- ctlv0 ContinuousHeating = -26
+- ctlv0 ContinuousHeating = no data stored
+- ctlv0 Currenterror = -;-;-;-;-
+- ctlv0 CylinderChargeHyst = 5
+- ctlv0 CylinderChargeHyst = no data stored
+- ctlv0 CylinderChargeOffset = 25
+- ctlv0 CylinderChargeOffset = no data stored
+- ctlv0 Date = 08.09.2026
+- ctlv0 Date = no data stored
+- ctlv0 DisplayedOutsideTemp = 30.75
+- ctlv0 Errorhistory = no data stored
+- ctlv0 FrostOverRideTime = 4
+- ctlv0 FrostOverRideTime = no data stored
+- ctlv0 Hc1ActualFlowTempDesired = 0.0
+- ctlv0 Hc1AutoOffMode = eco
+- ctlv0 Hc1AutoOffMode = no data stored
+- 'ctlv0 Hc1CircuitType =  (ERR: invalid position for 3115b52406020002000200 / 00)'
+- 'ctlv0 Hc1ExcessTemp =  (ERR: invalid position for 3115b52406020002000b00 / 00)'
+- ctlv0 Hc1ExcessTemp = no data stored
+- ctlv0 Hc1FlowTemp = 26.5
+- ctlv0 Hc1HeatCurve = 0.8
+- ctlv0 Hc1HeatCurve = no data stored
+- ctlv0 Hc1HeatCurveAdaption = 0.0
+- ctlv0 Hc1MaxFlowTempDesired = 90
+- ctlv0 Hc1MaxFlowTempDesired = no data stored
+- 'ctlv0 Hc1MinCoolingTempDesired =  (ERR: invalid position for 3115b52406020002001100
+  / 00)'
+- ctlv0 Hc1MinCoolingTempDesired = no data stored
+- ctlv0 Hc1MinFlowTempDesired = 15
+- ctlv0 Hc1MinFlowTempDesired = no data stored
+- 'ctlv0 Hc1MixerMovement =  (ERR: invalid position for 3115b52406020002001a00 / 00)'
+- ctlv0 Hc1PumpStatus = 0
+- ctlv0 Hc1PumpStatus = no data stored
+- ctlv0 Hc1RoomTempSwitchOn = modulating
+- ctlv0 Hc1RoomTempSwitchOn = no data stored
+- 'ctlv0 Hc1Status =  (ERR: invalid position for 3115b52406020002001b00 / 00)'
+- ctlv0 Hc1Status = no data stored
+- ctlv0 Hc1SummerTempLimit = 18
+- ctlv0 Hc1SummerTempLimit = no data stored
+- ctlv0 Hc2ActualFlowTempDesired = 0.0
+- ctlv0 Hc2AutoOffMode = eco
+- ctlv0 Hc2AutoOffMode = no data stored
+- 'ctlv0 Hc2CircuitType =  (ERR: invalid position for 3115b52406020002010200 / 00)'
+- 'ctlv0 Hc2ExcessTemp =  (ERR: invalid position for 3115b52406020002010b00 / 00)'
+- ctlv0 Hc2ExcessTemp = no data stored
+- ctlv0 Hc2FlowTemp =  (empty for 3115b52406020002010800 / 0800020800ffffff7f)
+- ctlv0 Hc2HeatCurve = 1.2
+- ctlv0 Hc2HeatCurve = no data stored
+- ctlv0 Hc2HeatCurveAdaption = 0.0
+- ctlv0 Hc2MaxFlowTempDesired = 90
+- ctlv0 Hc2MaxFlowTempDesired = no data stored
+- 'ctlv0 Hc2MinCoolingTempDesired =  (ERR: invalid position for 3115b52406020002011100
+  / 00)'
+- ctlv0 Hc2MinCoolingTempDesired = no data stored
+- ctlv0 Hc2MinFlowTempDesired = 15
+- ctlv0 Hc2MinFlowTempDesired = no data stored
+- 'ctlv0 Hc2MixerMovement =  (ERR: invalid position for 3115b52406020002011a00 / 00)'
+- ctlv0 Hc2PumpStatus = 0
+- ctlv0 Hc2PumpStatus = no data stored
+- ctlv0 Hc2RoomTempSwitchOn = off
+- ctlv0 Hc2RoomTempSwitchOn = no data stored
+- 'ctlv0 Hc2Status =  (ERR: invalid position for 3115b52406020002011b00 / 00)'
+- ctlv0 Hc2Status = no data stored
+- ctlv0 Hc2SummerTempLimit = 21
+- ctlv0 Hc2SummerTempLimit = no data stored
+- ctlv0 Hc3ActualFlowTempDesired = 0.0
+- ctlv0 Hc3AutoOffMode = eco
+- ctlv0 Hc3AutoOffMode = no data stored
+- 'ctlv0 Hc3CircuitType =  (ERR: invalid position for 3115b52406020002020200 / 00)'
+- 'ctlv0 Hc3ExcessTemp =  (ERR: invalid position for 3115b52406020002020b00 / 00)'
+- ctlv0 Hc3ExcessTemp = no data stored
+- ctlv0 Hc3FlowTemp =  (empty for 3115b52406020002020800 / 0800020800ffffff7f)
+- ctlv0 Hc3HeatCurve = 1.2
+- ctlv0 Hc3HeatCurve = no data stored
+- ctlv0 Hc3HeatCurveAdaption = 0.0
+- ctlv0 Hc3MaxFlowTempDesired = 90
+- ctlv0 Hc3MaxFlowTempDesired = no data stored
+- 'ctlv0 Hc3MinCoolingTempDesired =  (ERR: invalid position for 3115b52406020002021100
+  / 00)'
+- ctlv0 Hc3MinCoolingTempDesired = no data stored
+- ctlv0 Hc3MinFlowTempDesired = 15
+- ctlv0 Hc3MinFlowTempDesired = no data stored
+- 'ctlv0 Hc3MixerMovement =  (ERR: invalid position for 3115b52406020002021a00 / 00)'
+- ctlv0 Hc3PumpStatus = 0
+- ctlv0 Hc3PumpStatus = no data stored
+- ctlv0 Hc3RoomTempSwitchOn = off
+- ctlv0 Hc3RoomTempSwitchOn = no data stored
+- 'ctlv0 Hc3Status =  (ERR: invalid position for 3115b52406020002021b00 / 00)'
+- ctlv0 Hc3Status = no data stored
+- ctlv0 Hc3SummerTempLimit = 21
+- ctlv0 Hc3SummerTempLimit = no data stored
+- ctlv0 HcStorageTempBottom = no data stored
+- ctlv0 HcStorageTempTop = no data stored
+- ctlv0 HwcBankHolidayEndPeriod = no data stored
+- ctlv0 HwcBankHolidayEndPeriod = no data stored
+- ctlv0 HwcBankHolidayStartPeriod = no data stored
+- ctlv0 HwcBankHolidayStartPeriod = no data stored
+- ctlv0 HwcFlowTemp = 0.0
+- ctlv0 HwcHolidayEndPeriod = 01.01.2019
+- ctlv0 HwcHolidayEndPeriod = no data stored
+- ctlv0 HwcHolidayStartPeriod = 01.01.2019
+- ctlv0 HwcHolidayStartPeriod = no data stored
+- ctlv0 HwcLockTime = 60
+- ctlv0 HwcLockTime = no data stored
+- 'ctlv0 HwcMaxFlowTempDesired =  (ERR: invalid position for 3115b52406020000004600
+  / 00)'
+- ctlv0 HwcMaxFlowTempDesired = no data stored
+- ctlv0 HwcOpMode = day
+- ctlv0 HwcOpMode = no data stored
+- ctlv0 HwcParallelLoading = off
+- ctlv0 HwcParallelLoading = no data stored
+- ctlv0 HwcSFMode = auto
+- ctlv0 HwcSFMode = no data stored
+- ctlv0 HwcStorageTemp =  (empty for 3115b52406020001000500 / 0800010500ffffff7f)
+- 'ctlv0 HwcStorageTempBottom =  (ERR: invalid position for 3115b52406020000009e00
+  / 00)'
+- 'ctlv0 HwcStorageTempTop =  (ERR: invalid position for 3115b52406020000009d00 /
+  00)'
+- ctlv0 HwcTempDesired = 45
+- ctlv0 HwcTempDesired = no data stored
+- ctlv0 HwcTimer_Config = no data stored
+- ctlv0 HwcTimer_Friday0 = no data stored
+- ctlv0 HwcTimer_Friday1 = no data stored
+- ctlv0 HwcTimer_Friday2 = no data stored
+- ctlv0 HwcTimer_Friday = no data stored
+- ctlv0 HwcTimer_Monday0 = no data stored
+- ctlv0 HwcTimer_Monday1 = no data stored
+- ctlv0 HwcTimer_Monday2 = no data stored
+- ctlv0 HwcTimer_Monday = no data stored
+- ctlv0 HwcTimer_Saturday0 = no data stored
+- ctlv0 HwcTimer_Saturday1 = no data stored
+- ctlv0 HwcTimer_Saturday2 = no data stored
+- ctlv0 HwcTimer_Saturday = no data stored
+- ctlv0 HwcTimer_Sunday0 = no data stored
+- ctlv0 HwcTimer_Sunday1 = no data stored
+- ctlv0 HwcTimer_Sunday2 = no data stored
+- ctlv0 HwcTimer_Sunday = no data stored
+- ctlv0 HwcTimer_Thursday0 = no data stored
+- ctlv0 HwcTimer_Thursday1 = no data stored
+- ctlv0 HwcTimer_Thursday2 = no data stored
+- ctlv0 HwcTimer_Thursday = no data stored
+- ctlv0 HwcTimer_Timeframes = no data stored
+- ctlv0 HwcTimer_Tuesday0 = no data stored
+- ctlv0 HwcTimer_Tuesday1 = no data stored
+- ctlv0 HwcTimer_Tuesday2 = no data stored
+- ctlv0 HwcTimer_Tuesday = no data stored
+- ctlv0 HwcTimer_Wednesday0 = no data stored
+- ctlv0 HwcTimer_Wednesday1 = no data stored
+- ctlv0 HwcTimer_Wednesday2 = no data stored
+- ctlv0 HwcTimer_Wednesday = no data stored
+- 'ctlv0 HydraulicScheme =  (ERR: invalid position for 3115b52406020000003600 / 00)'
+- ctlv0 HydraulicScheme = no data stored
+- ctlv0 Installer1 = no data stored
+- ctlv0 Installer1 = no data stored
+- ctlv0 Installer2 = no data stored
+- ctlv0 Installer2 = no data stored
+- ctlv0 KeyCodeforConfigMenu = no data stored
+- ctlv0 KeyCodeforConfigMenu = no data stored
+- ctlv0 MaintenanceDate = no data stored
+- ctlv0 MaintenanceDate = no data stored
+- ctlv0 MaintenanceDue = no data stored
+- ctlv0 MaxCylinderChargeTime = 60
+- ctlv0 MaxCylinderChargeTime = no data stored
+- 'ctlv0 MaxRoomHumidity =  (ERR: invalid position for 3115b52406020000000e00 / 00)'
+- ctlv0 MaxRoomHumidity = no data stored
+- 'ctlv0 MultiRelaySetting =  (ERR: invalid position for 3115b52406020000004d00 /
+  00)'
+- ctlv0 MultiRelaySetting = no data stored
+- 'ctlv0 OutsideTempAvg =  (ERR: invalid position for 3115b52406020000009500 / 00)'
+- ctlv0 OutsideTempAvg = no data stored
+- ctlv0 PhoneNumber1 = no data stored
+- ctlv0 PhoneNumber1 = no data stored
+- ctlv0 PhoneNumber2 = no data stored
+- ctlv0 PhoneNumber2 = no data stored
+- 'ctlv0 PrEnergySum =  (ERR: invalid position for 3115b52406020000005c00 / 00)'
+- ctlv0 PrEnergySum = no data stored
+- 'ctlv0 PrEnergySumHc =  (ERR: invalid position for 3115b52406020000005700 / 00)'
+- ctlv0 PrEnergySumHc = no data stored
+- 'ctlv0 PrEnergySumHcLastMonth =  (ERR: invalid position for 3115b52406020000005300
+  / 00)'
+- ctlv0 PrEnergySumHcLastMonth = no data stored
+- 'ctlv0 PrEnergySumHcThisMonth =  (ERR: invalid position for 3115b52406020000004f00
+  / 00)'
+- ctlv0 PrEnergySumHcThisMonth = no data stored
+- 'ctlv0 PrEnergySumHwc =  (ERR: invalid position for 3115b52406020000005800 / 00)'
+- ctlv0 PrEnergySumHwc = no data stored
+- 'ctlv0 PrEnergySumHwcLastMonth =  (ERR: invalid position for 3115b52406020000005400
+  / 00)'
+- ctlv0 PrEnergySumHwcLastMonth = no data stored
+- 'ctlv0 PrEnergySumHwcThisMonth =  (ERR: invalid position for 3115b52406020000005000
+  / 00)'
+- ctlv0 PrEnergySumHwcThisMonth = no data stored
+- ctlv0 PrFuelSum = no data stored
+- ctlv0 PrFuelSum = no data stored
+- ctlv0 PrFuelSumHc = no data stored
+- ctlv0 PrFuelSumHc = no data stored
+- ctlv0 PrFuelSumHcLastMonth = no data stored
+- ctlv0 PrFuelSumHcLastMonth = no data stored
+- ctlv0 PrFuelSumHcThisMonth = no data stored
+- ctlv0 PrFuelSumHcThisMonth = no data stored
+- ctlv0 PrFuelSumHwc = no data stored
+- ctlv0 PrFuelSumHwc = no data stored
+- ctlv0 PrFuelSumHwcLastMonth = no data stored
+- ctlv0 PrFuelSumHwcLastMonth = no data stored
+- ctlv0 PrFuelSumHwcThisMonth = no data stored
+- ctlv0 PrFuelSumHwcThisMonth = no data stored
+- ctlv0 PumpAdditionalTime = no data stored
+- ctlv0 PumpAdditionalTime = no data stored
+- ctlv0 SolarYieldTotal = no data stored
+- ctlv0 SolarYieldTotal = no data stored
+- ctlv0 SystemFlowTemp =  (empty for 3115b52406020000004b00 / 0800004b00ffffff7f)
+- ctlv0 Time = no data stored
+- ctlv0 Time = no data stored
+- ctlv0 WaterPressure = 1.3
+- 'ctlv0 YieldTotal =  (ERR: invalid position for 3115b52406020000003e00 / 00)'
+- ctlv0 YieldTotal = no data stored
+- ctlv0 Z1ActualRoomTempDesired = 0.0
+- ctlv0 Z1ActualRoomTempDesired = no data stored
+- ctlv0 Z1BankHolidayEndPeriod = no data stored
+- ctlv0 Z1BankHolidayEndPeriod = no data stored
+- ctlv0 Z1BankHolidayStartPeriod = no data stored
+- ctlv0 Z1BankHolidayStartPeriod = no data stored
+- 'ctlv0 Z1CoolingTemp =  (ERR: invalid position for 3115b52406020003000200 / 00)'
+- ctlv0 Z1CoolingTemp = no data stored
+- ctlv0 Z1DayTemp = 21
+- ctlv0 Z1DayTemp = no data stored
+- ctlv0 Z1HolidayEndPeriod = 01.01.2019
+- ctlv0 Z1HolidayEndPeriod = no data stored
+- ctlv0 Z1HolidayStartPeriod = 01.01.2019
+- ctlv0 Z1HolidayStartPeriod = no data stored
+- ctlv0 Z1HolidayTemp = 15
+- ctlv0 Z1HolidayTemp = no data stored
+- ctlv0 Z1Name1 = no data stored
+- ctlv0 Z1Name1 = no data stored
+- ctlv0 Z1Name2 = no data stored
+- ctlv0 Z1Name2 = no data stored
+- ctlv0 Z1NightTemp = 16.5
+- ctlv0 Z1NightTemp = no data stored
+- ctlv0 Z1OpMode = off
+- ctlv0 Z1OpMode = no data stored
+- ctlv0 Z1QuickVetoDuration = 3
+- ctlv0 Z1QuickVetoDuration = no data stored
+- ctlv0 Z1QuickVetoEndDate = 08.09.2026
+- ctlv0 Z1QuickVetoEndTime = 18:28:00
+- ctlv0 Z1QuickVetoTemp = 22
+- ctlv0 Z1QuickVetoTemp = no data stored
+- ctlv0 Z1RoomTemp = 25.475
+- ctlv0 Z1RoomZoneMapping = no data stored
+- ctlv0 Z1RoomZoneMapping = no data stored
+- ctlv0 Z1SFMode = auto
+- ctlv0 Z1SFMode = no data stored
+- ctlv0 Z1Shortname = no data stored
+- ctlv0 Z1Shortname = no data stored
+- ctlv0 Z1Timer_Config = no data stored
+- ctlv0 Z1Timer_Friday0 = no data stored
+- ctlv0 Z1Timer_Friday1 = no data stored
+- ctlv0 Z1Timer_Friday2 = no data stored
+- ctlv0 Z1Timer_Friday = no data stored
+- ctlv0 Z1Timer_Monday0 = no data stored
+- ctlv0 Z1Timer_Monday1 = no data stored
+- ctlv0 Z1Timer_Monday2 = no data stored
+- ctlv0 Z1Timer_Monday = no data stored
+- ctlv0 Z1Timer_Saturday0 = no data stored
+- ctlv0 Z1Timer_Saturday1 = no data stored
+- ctlv0 Z1Timer_Saturday2 = no data stored
+- ctlv0 Z1Timer_Saturday = no data stored
+- ctlv0 Z1Timer_Sunday0 = no data stored
+- ctlv0 Z1Timer_Sunday1 = no data stored
+- ctlv0 Z1Timer_Sunday2 = no data stored
+- ctlv0 Z1Timer_Sunday = no data stored
+- ctlv0 Z1Timer_Thursday0 = no data stored
+- ctlv0 Z1Timer_Thursday1 = no data stored
+- ctlv0 Z1Timer_Thursday2 = no data stored
+- ctlv0 Z1Timer_Thursday = no data stored
+- ctlv0 Z1Timer_Timeframes = no data stored
+- ctlv0 Z1Timer_Tuesday0 = no data stored
+- ctlv0 Z1Timer_Tuesday1 = no data stored
+- ctlv0 Z1Timer_Tuesday2 = no data stored
+- ctlv0 Z1Timer_Tuesday = no data stored
+- ctlv0 Z1Timer_Wednesday0 = no data stored
+- ctlv0 Z1Timer_Wednesday1 = no data stored
+- ctlv0 Z1Timer_Wednesday2 = no data stored
+- ctlv0 Z1Timer_Wednesday = no data stored
+- ctlv0 Z1ValveStatus = no data stored
+- ctlv0 Z1ValveStatus = no data stored
+- ctlv0 Z2ActualRoomTempDesired = no data stored
+- ctlv0 Z2ActualRoomTempDesired = no data stored
+- ctlv0 Z2BankHolidayEndPeriod = no data stored
+- ctlv0 Z2BankHolidayEndPeriod = no data stored
+- ctlv0 Z2BankHolidayStartPeriod = no data stored
+- ctlv0 Z2BankHolidayStartPeriod = no data stored
+- ctlv0 Z2CoolingTemp = no data stored
+- ctlv0 Z2CoolingTemp = no data stored
+- ctlv0 Z2DayTemp = no data stored
+- ctlv0 Z2DayTemp = no data stored
+- ctlv0 Z2HolidayEndPeriod = no data stored
+- ctlv0 Z2HolidayEndPeriod = no data stored
+- ctlv0 Z2HolidayStartPeriod = no data stored
+- ctlv0 Z2HolidayStartPeriod = no data stored
+- ctlv0 Z2HolidayTemp = no data stored
+- ctlv0 Z2HolidayTemp = no data stored
+- ctlv0 Z2Name1 = no data stored
+- ctlv0 Z2Name1 = no data stored
+- ctlv0 Z2Name2 = no data stored
+- ctlv0 Z2Name2 = no data stored
+- ctlv0 Z2NightTemp = no data stored
+- ctlv0 Z2NightTemp = no data stored
+- ctlv0 Z2OpMode = no data stored
+- ctlv0 Z2OpMode = no data stored
+- ctlv0 Z2QuickVetoDuration = no data stored
+- ctlv0 Z2QuickVetoDuration = no data stored
+- ctlv0 Z2QuickVetoEndDate = no data stored
+- ctlv0 Z2QuickVetoEndTime = no data stored
+- ctlv0 Z2QuickVetoTemp = no data stored
+- ctlv0 Z2QuickVetoTemp = no data stored
+- ctlv0 Z2RoomTemp =  (empty for 3115b52406020003010f00 / 0800030f00ffffff7f)
+- ctlv0 Z2RoomZoneMapping = no data stored
+- ctlv0 Z2RoomZoneMapping = no data stored
+- ctlv0 Z2SFMode = no data stored
+- ctlv0 Z2SFMode = no data stored
+- ctlv0 Z2Shortname = no data stored
+- ctlv0 Z2Shortname = no data stored
+- ctlv0 Z2Timer_Config = no data stored
+- ctlv0 Z2Timer_Friday0 = no data stored
+- ctlv0 Z2Timer_Friday1 = no data stored
+- ctlv0 Z2Timer_Friday2 = no data stored
+- ctlv0 Z2Timer_Friday = no data stored
+- ctlv0 Z2Timer_Monday0 = no data stored
+- ctlv0 Z2Timer_Monday1 = no data stored
+- ctlv0 Z2Timer_Monday2 = no data stored
+- ctlv0 Z2Timer_Monday = no data stored
+- ctlv0 Z2Timer_Saturday0 = no data stored
+- ctlv0 Z2Timer_Saturday1 = no data stored
+- ctlv0 Z2Timer_Saturday2 = no data stored
+- ctlv0 Z2Timer_Saturday = no data stored
+- ctlv0 Z2Timer_Sunday0 = no data stored
+- ctlv0 Z2Timer_Sunday1 = no data stored
+- ctlv0 Z2Timer_Sunday2 = no data stored
+- ctlv0 Z2Timer_Sunday = no data stored
+- ctlv0 Z2Timer_Thursday0 = no data stored
+- ctlv0 Z2Timer_Thursday1 = no data stored
+- ctlv0 Z2Timer_Thursday2 = no data stored
+- ctlv0 Z2Timer_Thursday = no data stored
+- ctlv0 Z2Timer_Timeframes = no data stored
+- ctlv0 Z2Timer_Tuesday0 = no data stored
+- ctlv0 Z2Timer_Tuesday1 = no data stored
+- ctlv0 Z2Timer_Tuesday2 = no data stored
+- ctlv0 Z2Timer_Tuesday = no data stored
+- ctlv0 Z2Timer_Wednesday0 = no data stored
+- ctlv0 Z2Timer_Wednesday1 = no data stored
+- ctlv0 Z2Timer_Wednesday2 = no data stored
+- ctlv0 Z2Timer_Wednesday = no data stored
+- ctlv0 Z2ValveStatus = no data stored
+- ctlv0 Z2ValveStatus = no data stored
+- ctlv0 Z3ActualRoomTempDesired = no data stored
+- ctlv0 Z3ActualRoomTempDesired = no data stored
+- ctlv0 Z3BankHolidayEndPeriod = no data stored
+- ctlv0 Z3BankHolidayEndPeriod = no data stored
+- ctlv0 Z3BankHolidayStartPeriod = no data stored
+- ctlv0 Z3BankHolidayStartPeriod = no data stored
+- ctlv0 Z3DayTemp = no data stored
+- ctlv0 Z3DayTemp = no data stored
+- ctlv0 Z3HolidayEndPeriod = no data stored
+- ctlv0 Z3HolidayEndPeriod = no data stored
+- ctlv0 Z3HolidayStartPeriod = no data stored
+- ctlv0 Z3HolidayStartPeriod = no data stored
+- ctlv0 Z3HolidayTemp = no data stored
+- ctlv0 Z3HolidayTemp = no data stored
+- ctlv0 Z3Name1 = no data stored
+- ctlv0 Z3Name1 = no data stored
+- ctlv0 Z3Name2 = no data stored
+- ctlv0 Z3Name2 = no data stored
+- ctlv0 Z3NightTemp = no data stored
+- ctlv0 Z3NightTemp = no data stored
+- ctlv0 Z3OpMode = no data stored
+- ctlv0 Z3OpMode = no data stored
+- ctlv0 Z3QuickVetoDuration = no data stored
+- ctlv0 Z3QuickVetoDuration = no data stored
+- ctlv0 Z3QuickVetoEndDate = no data stored
+- ctlv0 Z3QuickVetoEndTime = no data stored
+- ctlv0 Z3QuickVetoTemp = no data stored
+- ctlv0 Z3QuickVetoTemp = no data stored
+- ctlv0 Z3RoomTemp = no data stored
+- ctlv0 Z3RoomZoneMapping = no data stored
+- ctlv0 Z3RoomZoneMapping = no data stored
+- ctlv0 Z3SFMode = no data stored
+- ctlv0 Z3SFMode = no data stored
+- ctlv0 Z3Shortname = no data stored
+- ctlv0 Z3Shortname = no data stored
+- ctlv0 Z3Timer_Config = no data stored
+- ctlv0 Z3Timer_Friday0 = no data stored
+- ctlv0 Z3Timer_Friday1 = no data stored
+- ctlv0 Z3Timer_Friday2 = no data stored
+- ctlv0 Z3Timer_Friday = no data stored
+- ctlv0 Z3Timer_Monday0 = no data stored
+- ctlv0 Z3Timer_Monday1 = no data stored
+- ctlv0 Z3Timer_Monday2 = no data stored
+- ctlv0 Z3Timer_Monday = no data stored
+- ctlv0 Z3Timer_Saturday0 = no data stored
+- ctlv0 Z3Timer_Saturday1 = no data stored
+- ctlv0 Z3Timer_Saturday2 = no data stored
+- ctlv0 Z3Timer_Saturday = no data stored
+- ctlv0 Z3Timer_Sunday0 = no data stored
+- ctlv0 Z3Timer_Sunday1 = no data stored
+- ctlv0 Z3Timer_Sunday2 = no data stored
+- ctlv0 Z3Timer_Sunday = no data stored
+- ctlv0 Z3Timer_Thursday0 = no data stored
+- ctlv0 Z3Timer_Thursday1 = no data stored
+- ctlv0 Z3Timer_Thursday2 = no data stored
+- ctlv0 Z3Timer_Thursday = no data stored
+- ctlv0 Z3Timer_Timeframes = no data stored
+- ctlv0 Z3Timer_Tuesday0 = no data stored
+- ctlv0 Z3Timer_Tuesday1 = no data stored
+- ctlv0 Z3Timer_Tuesday2 = no data stored
+- ctlv0 Z3Timer_Tuesday = no data stored
+- ctlv0 Z3Timer_Wednesday0 = no data stored
+- ctlv0 Z3Timer_Wednesday1 = no data stored
+- ctlv0 Z3Timer_Wednesday2 = no data stored
+- ctlv0 Z3Timer_Wednesday = no data stored
+- ctlv0 Z3ValveStatus = no data stored
+- ctlv0 Z3ValveStatus = no data stored
+- 'ctlv2 Hc1DewPointTemp =  (ERR: invalid position for 3115b52406020002002300 / 00)'
+- 'ctlv2 Hc1FlowTempCalc =  (ERR: invalid position for 3115b52406020002002000 / 00)'
+- 'ctlv2 Hc1Humidity =  (ERR: invalid position for 3115b52406020002002200 / 00)'
+- 'ctlv2 Hc1MixerPosition =  (ERR: invalid position for 3115b52406020002002100 / 00)'
+- 'ctlv2 Hc1PumpHours =  (ERR: invalid position for 3115b52406020002002400 / 00)'
+- 'ctlv2 Hc1PumpStarts =  (ERR: invalid position for 3115b52406020002002500 / 00)'
+- 'ctlv2 Hc2DewPointTemp =  (ERR: invalid position for 3115b52406020002012300 / 00)'
+- 'ctlv2 Hc2FlowTempCalc =  (ERR: invalid position for 3115b52406020002012000 / 00)'
+- 'ctlv2 Hc2Humidity =  (ERR: invalid position for 3115b52406020002012200 / 00)'
+- 'ctlv2 Hc2MixerPosition =  (ERR: invalid position for 3115b52406020002012100 / 00)'
+- 'ctlv2 Hc2PumpHours =  (ERR: invalid position for 3115b52406020002012400 / 00)'
+- 'ctlv2 Hc2PumpStarts =  (ERR: invalid position for 3115b52406020002012500 / 00)'
+- 'ctlv2 ManualCoolingEndDate =  (ERR: invalid position for 3115b5240602000000db00
+  / 00)'
+- ctlv2 ManualCoolingEndDate = no data stored
+- 'ctlv2 ManualCoolingStartDate =  (ERR: invalid position for 3115b5240602000000da00
+  / 00)'
+- ctlv2 ManualCoolingStartDate = no data stored
+- 'ctlv2 z1RoomHumidity =  (ERR: invalid position for 3115b52406020003002800 / 00)'
+- General Valuerange = no data stored
+- hmu CoolElecConsDay = 0.0
+- hmu CoolElecConsTotal = 0.0
+- hmu CoolEnvYieldDay = 0.0
+- hmu CoolEnvYieldMonth = 0.0
+- hmu CoolEnvYieldTotal = 0.0
+- hmu HcElecConsDay = 83.55
+- hmu HcElecConsTotal = 1019.87
+- hmu HwcElecConsDay = 6.69
+- hmu HwcElecConsTotal = 535.81
+- 'hmu SourceTempInput =  (ERR: invalid position for 3108b51a0405ff3222 / 02ff01)'
+- Memory Eeprom = no data stored
+- Memory Eeprom = no data stored
+- Memory Ram = no data stored
+- Memory Ram = no data stored
+- sc Clearerrorhistory = no data stored
+- sc Col = no data stored
+- sc ColKickPumpTime = no data stored
+- sc ColKickTempDelta = no data stored
+- sc CollPump = no data stored
+- sc Currenterror = -;-;-;-;-
+- sc D1Temp = no data stored
+- sc D2Temp = no data stored
+- 'sc Date =  (ERR: invalid position for 31ecb509030d0d00 / 00)'
+- sc EDFunction = no data stored
+- sc EDFunction = no data stored
+- sc EnableScProtection = no data stored
+- sc EnableScProtection = no data stored
+- sc Errorhistory = no data stored
+- sc FlowRate = no data stored
+- sc FlowRate = no data stored
+- sc FrostProtectionEnabled = no data stored
+- sc FrostProtectionLimit = no data stored
+- sc Hc1PumpKol1PP1Port = no data stored
+- sc Hc2aLegPumpP2Port = no data stored
+- sc Hc2zPort = no data stored
+- 'sc HydraulicScheme =  (ERR: invalid position for 31ecb509030d2100 / 00)'
+- sc InitCircuit = no data stored
+- sc Iotest = no data stored
+- sc Ioteststop = no data stored
+- sc IsInBoostMode = no data stored
+- sc KickFunction = no data stored
+- sc KickFunction = no data stored
+- sc LpZpMaPort = no data stored
+- sc MAPreferredStorage = no data stored
+- sc MAPreferredStorage = no data stored
+- sc MaximalTemp2 = no data stored
+- sc MaximalTemp2 = no data stored
+- sc MaximalTemp = no data stored
+- sc MaximalTemp = no data stored
+- sc MultifunctionOutput = no data stored
+- sc OMultifunction = no data stored
+- sc OMultifunction = no data stored
+- sc PumpAntiLockingFlags = no data stored
+- sc QuickVetoStart = no data stored
+- sc ResetSolGain = no data stored
+- sc ResetSolGain = no data stored
+- sc RuntimeCollPump = no data stored
+- sc RuntimeCollPumpSeconds = no data stored
+- sc ScProtectionHysteresis = no data stored
+- sc ScProtectionLimit = no data stored
+- sc ScProtectionLimit = no data stored
+- sc ScProtectionTime = no data stored
+- sc SolCollPumpDcIntegrator = no data stored
+- sc SolCollPumpED = no data stored
+- sc SolGain = no data stored
+- sc SolOperationMode = no data stored
+- sc SP1 = no data stored
+- sc SP2 = no data stored
+- sc SumSolGain = no data stored
+- sc SumSolGainDayBefore = no data stored
+- sc SystemMode = no data stored
+- sc TempDifferenceOff2 = no data stored
+- sc TempDifferenceOff2 = no data stored
+- sc TempDifferenceOff = no data stored
+- sc TempDifferenceOff = no data stored
+- sc TempDifferenceOffTD12 = no data stored
+- sc TempDifferenceOffTD12 = no data stored
+- sc TempDifferenceOn2 = no data stored
+- sc TempDifferenceOn2 = no data stored
+- sc TempDifferenceOn = no data stored
+- sc TempDifferenceOn = no data stored
+- sc TempDifferenceOnTD12 = no data stored
+- sc TempDifferenceOnTD12 = no data stored
+- sc Time = no data stored
+- sc Weekday = no data stored
+- sc YieldLastYear = no data stored
+- sc YieldThisYear = no data stored
+- Scan Id = no data stored
+- scan.08  = Vaillant;BAI00;1201;7603
+- Scan.08 Id = xx
+- scan.15  = Vaillant;CTLV0;0313;9103
+- Scan.15 Id = no data stored
+- scan.ec  = Vaillant;SOL00;0313;9103
+- Scan.ec Id = no data stored
+- ''
+before_registers:
+- circuit: Broadcast
+  name: Datetime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Error
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: Broadcast
+  name: HwcStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Id
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: IdAnswer
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: IdQuery
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Load
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Outsidetemp
+  fields:
+  - value
+  values:
+  - '30.500'
+  writable: false
+  has_data: true
+- circuit: Broadcast
+  name: Queryexistence
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Signoflife
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: Vdatetime
+  fields:
+  - value
+  values:
+  - 16:20:49;08.09.2026
+  writable: false
+  has_data: true
+- circuit: Broadcast
+  name: Vdatetime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Broadcast
+  name: WaterPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: General
+  name: Valuerange
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Eeprom
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Eeprom
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Ram
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Memory
+  name: Ram
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Scan
+  name: Id
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Scan.08
+  name: Id
+  fields:
+  - value
+  values:
+  - xx
+  writable: false
+  has_data: true
+- circuit: Scan.15
+  name: Id
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: Scan.ec
+  name: Id
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: ACRoomthermostat
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: APCComStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: APCLegioProtection
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: APCLegioProtection
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: AccessoriesOne
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: AccessoriesOne
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: AccessoriesTwo
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: AccessoriesTwo
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: AverageIgnitiontime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: BlockTimeHcMax
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: BlockTimeHcMax
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: BoilerType
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: ChangesDSN
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: CirPump
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: Clearerrorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: CounterStartAttempts1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: CounterStartAttempts2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: CounterStartAttempts3
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: CounterStartAttempts4
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - -;-;-;-;-
+  writable: false
+  has_data: true
+- circuit: bai
+  name: DCFTimeDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: DCRoomthermostat
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: DSN
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: DSNOffset
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: DSNOffset
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: DSNStart
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: Date
+  fields:
+  - value
+  values:
+  - no data stored (message not available due to condition)
+  writable: false
+  has_data: false
+- circuit: bai
+  name: Date
+  fields:
+  - value
+  values:
+  - no data stored (message not available due to condition)
+  writable: false
+  has_data: false
+- circuit: bai
+  name: DateTime
+  fields:
+  - value
+  values:
+  - nosignal;-:-:-;-.-.-;31.500
+  writable: false
+  has_data: true
+- circuit: bai
+  name: DcfState
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: DeactivationsIFC
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: DeactivationsTemplimiter
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: DeltaFlowReturnMax
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: DisplayMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: EBusHeatcontrol
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: EbusSourceOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: EbusVoltage
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: Expertlevel_ReturnTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: ExtFlowTempDesiredMin
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: ExtStorageModulCon
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: ExtWP
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: ExternGasvalve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: ExternalFaultmessage
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: ExternalFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: ExternalHwcSwitch
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: FanHours
+  fields:
+  - value
+  values:
+  - '10'
+  writable: false
+  has_data: true
+- circuit: bai
+  name: FanMaxSpeedOperation
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: FanMinSpeedOperation
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: FanPWMSum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: FanPWMTest
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: FanSpeed
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: FanSpeedOffsetMax
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: FanSpeedOffsetMax
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: FanSpeedOffsetMin
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: FanSpeedOffsetMin
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: FanStarts
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: Flame
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: FlameSensingASIC
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: FloorHeatingContact
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: FlowSetPotmeter
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: FlowTemp
+  fields:
+  - value
+  values:
+  - 26.69;ok
+  writable: false
+  has_data: true
+- circuit: bai
+  name: FlowTempDesired
+  fields:
+  - value
+  values:
+  - '0.00'
+  writable: false
+  has_data: true
+- circuit: bai
+  name: FlowTempMax
+  fields:
+  - value
+  values:
+  - '68.12'
+  writable: false
+  has_data: true
+- circuit: bai
+  name: FlowsetHcMax
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: FlowsetHcMax
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: FlowsetHwcMax
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: FlowsetHwcMax
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: Fluegasvalve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: FluegasvalveOpen
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: Gasvalve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: Gasvalve3UC
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: GasvalveASICFeedback
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: GasvalveUC
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: GasvalveUCFeedback
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: GlobalSystemOff
+  fields:
+  - value
+  values:
+  - no data stored (message not available due to condition)
+  writable: false
+  has_data: false
+- circuit: bai
+  name: GlobalSystemOff
+  fields:
+  - value
+  values:
+  - no data stored (message not available due to condition)
+  writable: false
+  has_data: false
+- circuit: bai
+  name: HcHours
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: bai
+  name: HcPumpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: HcPumpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: HcPumpStarts
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: HcStarts
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: HcUnderHundredStarts
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: HeatingSwitch
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: HoursTillService
+  fields:
+  - value
+  values:
+  - '2'
+  writable: false
+  has_data: true
+- circuit: bai
+  name: HoursTillService
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: HwcDemand
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: HwcHours
+  fields:
+  - value
+  values:
+  - '7'
+  writable: false
+  has_data: true
+- circuit: bai
+  name: HwcImpellorSwitch
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: HwcPostrunTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: HwcPostrunTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: HwcSetPotmeter
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: HwcStarts
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: HwcSwitch
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: HwcTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: HwcTempDesired
+  fields:
+  - value
+  values:
+  - '0.00'
+  writable: false
+  has_data: true
+- circuit: bai
+  name: HwcTempMax
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: HwcTempMax
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: HwcTypes
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: HwcUnderHundredStarts
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: HwcWaterflow
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: HwcWaterflowMax
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: Ignitor
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: InitialisationEEPROM
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: IonisationVoltageLevel
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: Maintenancedata_HwcTempMax
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: MaxIgnitiontime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: MinIgnitiontime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: ModulationDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: OutdoorstempSensor
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: OverflowCounter
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: ParamToken
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PartloadHcKW
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PartloadHcKW
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PartloadHwcKW
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PartloadHwcKW
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PartnumberBox
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PositionValveSet
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PowerValue
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PrAPSCounter
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PrAPSSum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PrEnergyCountHc1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PrEnergyCountHc1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PrEnergyCountHc2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PrEnergyCountHc2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PrEnergyCountHc3
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PrEnergyCountHc3
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PrEnergyCountHwc1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PrEnergyCountHwc1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PrEnergyCountHwc2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PrEnergyCountHwc2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PrEnergyCountHwc3
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PrEnergyCountHwc3
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PrEnergySumHc1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PrEnergySumHc1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PrEnergySumHc2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PrEnergySumHc2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PrEnergySumHc3
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PrEnergySumHc3
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PrEnergySumHwc1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PrEnergySumHwc1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PrEnergySumHwc2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PrEnergySumHwc2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PrEnergySumHwc3
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PrEnergySumHwc3
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PrVortexFlowSensorValue
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PrimaryCircuitFlowrate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: ProductionByte
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PumpHours
+  fields:
+  - value
+  values:
+  - '14'
+  writable: false
+  has_data: true
+- circuit: bai
+  name: PumpHwcFlowNumber
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PumpHwcFlowSum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PumpPower
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: bai
+  name: PumpPowerDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: PumpPowerDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: RemainingBoilerblocktime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: ReturnRegulation
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: ReturnRegulation
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: ReturnTemp
+  fields:
+  - value
+  values:
+  - 25.88;65121;ok
+  writable: false
+  has_data: true
+- circuit: bai
+  name: ReturnTempMax
+  fields:
+  - value
+  values:
+  - '60.75'
+  writable: false
+  has_data: true
+- circuit: bai
+  name: SHEMaxDeltaHwcFlow
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: SHEMaxFlowTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: SecondPumpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: SecondPumpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: SerialNumber
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: bai
+  name: SetFactoryValues
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: SetFactoryValues
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: SetMode
+  fields:
+  - value
+  values:
+  - auto;0.0;-;-;1;0;1;0;0;0
+  writable: false
+  has_data: true
+- circuit: bai
+  name: SetMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: SolPostHeat
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: SolPostHeat
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: StatElectricEnergySum
+  fields:
+  - value
+  values:
+  - '1.555580020'
+  writable: false
+  has_data: true
+- circuit: bai
+  name: StatEnergySumYear
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: StatEnvironmentEnergySum
+  fields:
+  - value
+  values:
+  - '0.000000000'
+  writable: false
+  has_data: true
+- circuit: bai
+  name: StatEnvironmentEnergySumHc
+  fields:
+  - value
+  values:
+  - '0.000000000'
+  writable: false
+  has_data: true
+- circuit: bai
+  name: StatEnvironmentEnergySumHwc
+  fields:
+  - value
+  values:
+  - '0.000000000'
+  writable: false
+  has_data: true
+- circuit: bai
+  name: StatFuelSum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: StatFuelSumHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: StatFuelSumHwc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: StatSolarEnergySum
+  fields:
+  - value
+  values:
+  - '0.000000000'
+  writable: false
+  has_data: true
+- circuit: bai
+  name: StatSolarEnergySumHc
+  fields:
+  - value
+  values:
+  - '0.000000000'
+  writable: false
+  has_data: true
+- circuit: bai
+  name: StatSolarEnergySumHwc
+  fields:
+  - value
+  values:
+  - '0.000000000'
+  writable: false
+  has_data: true
+- circuit: bai
+  name: Statenumber
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: Status01
+  fields:
+  - value
+  values:
+  - 26.5;25.5;31.500;26.5;-;off
+  writable: false
+  has_data: true
+- circuit: bai
+  name: Status02
+  fields:
+  - value
+  values:
+  - auto;60;65.0;70;65.0
+  writable: false
+  has_data: true
+- circuit: bai
+  name: Status16
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: StatusCirPump
+  fields:
+  - value
+  values:
+  - 'off'
+  writable: false
+  has_data: true
+- circuit: bai
+  name: StorageLoadPumpHours
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: bai
+  name: StorageLoadTimeMax
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: StorageLoadTimeMax
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: StorageTemp
+  fields:
+  - value
+  values:
+  - -13.50;cutoff
+  writable: false
+  has_data: true
+- circuit: bai
+  name: StorageTempDesired
+  fields:
+  - value
+  values:
+  - '30.00'
+  writable: false
+  has_data: true
+- circuit: bai
+  name: StorageTempMax
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: StorageloadPumpStarts
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: Storageloadpump
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: StoragereleaseClock
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: TargetFanSpeed
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: TargetFanSpeedOutput
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: TempDiffBlock
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: TempDiffFailure
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: TempGradientFailure
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: TempMaxDiffExtTFT
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: Templimiter
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: TemplimiterWithNTC
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: Testbyte
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: Time
+  fields:
+  - value
+  values:
+  - no data stored (message not available due to condition)
+  writable: false
+  has_data: false
+- circuit: bai
+  name: Time
+  fields:
+  - value
+  values:
+  - no data stored (message not available due to condition)
+  writable: false
+  has_data: false
+- circuit: bai
+  name: TimerInputHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: ValveMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: ValveMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: ValveStarts
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: VolatileLockout
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: VolatileLockoutIFCGV
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: VortexFlowSensor
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: WP
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: WPPostrunTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: WPPostrunTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: WPSecondStage
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: WarmstartDemand
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: WarmstartOffset
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: WarmstartOffset
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: WaterHcFlowMax
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: WaterPressure
+  fields:
+  - value
+  values:
+  - 1.373;ok
+  writable: false
+  has_data: true
+- circuit: bai
+  name: WaterpressureBranchControlOff
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: WaterpressureMeasureCounter
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: WaterpressureVariantSum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: bai
+  name: Z1HolidayTempStatus
+  fields:
+  - value
+  values:
+  - no data stored (message not available due to condition)
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: AdaptHeatCurve
+  fields:
+  - value
+  values:
+  - 'yes'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: AdaptHeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: CcTimer_Config
+  fields:
+  - value
+  values:
+  - 03 01 01 00 00 00 ff ff 00
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: CcTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: CcTimer_Friday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: CcTimer_Friday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: CcTimer_Friday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: CcTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: CcTimer_Monday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: CcTimer_Monday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: CcTimer_Monday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: CcTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: CcTimer_Saturday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: CcTimer_Saturday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: CcTimer_Saturday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: CcTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: CcTimer_Sunday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: CcTimer_Sunday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: CcTimer_Sunday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: CcTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: CcTimer_Thursday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: CcTimer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: CcTimer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: CcTimer_Timeframes
+  fields:
+  - value
+  values:
+  - 0;0;0;0;0;0;0
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: CcTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: CcTimer_Tuesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: CcTimer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: CcTimer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: CcTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: CcTimer_Wednesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: CcTimer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: CcTimer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Clearerrorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: ContinuousHeating
+  fields:
+  - value
+  values:
+  - '-26'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: ContinuousHeating
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - -;-;-;-;-
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: CylinderChargeHyst
+  fields:
+  - value
+  values:
+  - '5'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: CylinderChargeHyst
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: CylinderChargeOffset
+  fields:
+  - value
+  values:
+  - '25'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: CylinderChargeOffset
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Date
+  fields:
+  - value
+  values:
+  - 08.09.2026
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Date
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: DisplayedOutsideTemp
+  fields:
+  - value
+  values:
+  - '30.75'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: FrostOverRideTime
+  fields:
+  - value
+  values:
+  - '4'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: FrostOverRideTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc1ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Hc1AutoOffMode
+  fields:
+  - value
+  values:
+  - eco
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Hc1AutoOffMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc1CircuitType
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002000200 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc1ExcessTemp
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002000b00 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc1ExcessTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc1FlowTemp
+  fields:
+  - value
+  values:
+  - '26.5'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Hc1HeatCurve
+  fields:
+  - value
+  values:
+  - '0.8'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Hc1HeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc1HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Hc1MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '90'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Hc1MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc1MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002001100 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc1MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc1MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - '15'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Hc1MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc1MixerMovement
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002001a00 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc1PumpStatus
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Hc1PumpStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc1RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - modulating
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Hc1RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc1Status
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002001b00 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc1Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc1SummerTempLimit
+  fields:
+  - value
+  values:
+  - '18'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Hc1SummerTempLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc2ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Hc2AutoOffMode
+  fields:
+  - value
+  values:
+  - eco
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Hc2AutoOffMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc2CircuitType
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002010200 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc2ExcessTemp
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002010b00 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc2ExcessTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc2FlowTemp
+  fields:
+  - value
+  values:
+  - (empty for 3115b52406020002010800 / 0800020800ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc2HeatCurve
+  fields:
+  - value
+  values:
+  - '1.2'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Hc2HeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc2HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Hc2MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '90'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Hc2MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc2MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002011100 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc2MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc2MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - '15'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Hc2MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc2MixerMovement
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002011a00 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc2PumpStatus
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Hc2PumpStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc2RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'off'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Hc2RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc2Status
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002011b00 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc2Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc2SummerTempLimit
+  fields:
+  - value
+  values:
+  - '21'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Hc2SummerTempLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc3ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Hc3AutoOffMode
+  fields:
+  - value
+  values:
+  - eco
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Hc3AutoOffMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc3CircuitType
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002020200 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc3ExcessTemp
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002020b00 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc3ExcessTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc3FlowTemp
+  fields:
+  - value
+  values:
+  - (empty for 3115b52406020002020800 / 0800020800ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc3HeatCurve
+  fields:
+  - value
+  values:
+  - '1.2'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Hc3HeatCurve
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc3HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Hc3MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '90'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Hc3MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc3MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002021100 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc3MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc3MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - '15'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Hc3MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc3MixerMovement
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002021a00 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc3PumpStatus
+  fields:
+  - value
+  values:
+  - '0'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Hc3PumpStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc3RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'off'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Hc3RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc3Status
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002021b00 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc3Status
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Hc3SummerTempLimit
+  fields:
+  - value
+  values:
+  - '21'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Hc3SummerTempLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HcStorageTempBottom
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HcStorageTempTop
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcBankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcBankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcBankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcBankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcFlowTemp
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: HwcHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: HwcHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: HwcHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcLockTime
+  fields:
+  - value
+  values:
+  - '60'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: HwcLockTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcMaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020000004600 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcMaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcOpMode
+  fields:
+  - value
+  values:
+  - day
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: HwcOpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcParallelLoading
+  fields:
+  - value
+  values:
+  - 'off'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: HwcParallelLoading
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcSFMode
+  fields:
+  - value
+  values:
+  - auto
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: HwcSFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcStorageTemp
+  fields:
+  - value
+  values:
+  - (empty for 3115b52406020001000500 / 0800010500ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcStorageTempBottom
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020000009e00 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcStorageTempTop
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020000009d00 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcTempDesired
+  fields:
+  - value
+  values:
+  - '45'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: HwcTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcTimer_Config
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcTimer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcTimer_Friday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcTimer_Friday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcTimer_Friday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcTimer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcTimer_Monday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcTimer_Monday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcTimer_Monday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcTimer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcTimer_Saturday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcTimer_Saturday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcTimer_Saturday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcTimer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcTimer_Sunday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcTimer_Sunday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcTimer_Sunday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcTimer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcTimer_Thursday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcTimer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcTimer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcTimer_Timeframes
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcTimer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcTimer_Tuesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcTimer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcTimer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcTimer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcTimer_Wednesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcTimer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HwcTimer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HydraulicScheme
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020000003600 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: HydraulicScheme
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Installer1
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Installer1
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Installer2
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Installer2
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: KeyCodeforConfigMenu
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: KeyCodeforConfigMenu
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: MaintenanceDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: MaintenanceDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: MaintenanceDue
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: MaxCylinderChargeTime
+  fields:
+  - value
+  values:
+  - '60'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: MaxCylinderChargeTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: MaxRoomHumidity
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020000000e00 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: MaxRoomHumidity
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: MultiRelaySetting
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020000004d00 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: MultiRelaySetting
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: OutsideTempAvg
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020000009500 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: OutsideTempAvg
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PhoneNumber1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PhoneNumber1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PhoneNumber2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PhoneNumber2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PrEnergySum
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020000005c00 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PrEnergySum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PrEnergySumHc
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020000005700 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PrEnergySumHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PrEnergySumHcLastMonth
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020000005300 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PrEnergySumHcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PrEnergySumHcThisMonth
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020000004f00 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PrEnergySumHcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PrEnergySumHwc
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020000005800 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PrEnergySumHwc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PrEnergySumHwcLastMonth
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020000005400 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PrEnergySumHwcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PrEnergySumHwcThisMonth
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020000005000 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PrEnergySumHwcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PrFuelSum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PrFuelSum
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PrFuelSumHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PrFuelSumHc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PrFuelSumHcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PrFuelSumHcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PrFuelSumHcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PrFuelSumHcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PrFuelSumHwc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PrFuelSumHwc
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PrFuelSumHwcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PrFuelSumHwcLastMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PrFuelSumHwcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PrFuelSumHwcThisMonth
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PumpAdditionalTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: PumpAdditionalTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: SolarYieldTotal
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: SolarYieldTotal
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: SystemFlowTemp
+  fields:
+  - value
+  values:
+  - (empty for 3115b52406020000004b00 / 0800004b00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Time
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Time
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: WaterPressure
+  fields:
+  - value
+  values:
+  - '1.3'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: YieldTotal
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020000003e00 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: YieldTotal
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Z1ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1CoolingTemp
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020003000200 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1CoolingTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1DayTemp
+  fields:
+  - value
+  values:
+  - '21'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Z1DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Z1HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 01.01.2019
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Z1HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1HolidayTemp
+  fields:
+  - value
+  values:
+  - '15'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Z1HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1NightTemp
+  fields:
+  - value
+  values:
+  - '16.5'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Z1NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1OpMode
+  fields:
+  - value
+  values:
+  - 'off'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Z1OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1QuickVetoDuration
+  fields:
+  - value
+  values:
+  - '3'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Z1QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1QuickVetoEndDate
+  fields:
+  - value
+  values:
+  - 08.09.2026
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Z1QuickVetoEndTime
+  fields:
+  - value
+  values:
+  - '18:28:00'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Z1QuickVetoTemp
+  fields:
+  - value
+  values:
+  - '22'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Z1QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1RoomTemp
+  fields:
+  - value
+  values:
+  - '25.475'
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Z1RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1SFMode
+  fields:
+  - value
+  values:
+  - auto
+  writable: false
+  has_data: true
+- circuit: ctlv0
+  name: Z1SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1Timer_Config
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1Timer_Friday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1Timer_Friday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1Timer_Friday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1Timer_Monday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1Timer_Monday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1Timer_Monday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1Timer_Saturday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1Timer_Saturday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1Timer_Saturday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1Timer_Sunday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1Timer_Sunday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1Timer_Sunday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1Timer_Thursday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1Timer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1Timer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1Timer_Timeframes
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1Timer_Tuesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1Timer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1Timer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1Timer_Wednesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1Timer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1Timer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z1ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2CoolingTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2CoolingTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2QuickVetoEndDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2QuickVetoEndTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2RoomTemp
+  fields:
+  - value
+  values:
+  - (empty for 3115b52406020003010f00 / 0800030f00ffffff7f)
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2Timer_Config
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2Timer_Friday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2Timer_Friday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2Timer_Friday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2Timer_Monday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2Timer_Monday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2Timer_Monday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2Timer_Saturday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2Timer_Saturday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2Timer_Saturday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2Timer_Sunday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2Timer_Sunday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2Timer_Sunday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2Timer_Thursday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2Timer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2Timer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2Timer_Timeframes
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2Timer_Tuesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2Timer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2Timer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2Timer_Wednesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2Timer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2Timer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z2ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3BankHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3BankHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3DayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3HolidayTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3Name1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3Name2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3NightTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3OpMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3QuickVetoDuration
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3QuickVetoEndDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3QuickVetoEndTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3QuickVetoTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3RoomTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3RoomZoneMapping
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3SFMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3Shortname
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3Timer_Config
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3Timer_Friday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3Timer_Friday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3Timer_Friday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3Timer_Friday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3Timer_Monday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3Timer_Monday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3Timer_Monday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3Timer_Monday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3Timer_Saturday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3Timer_Saturday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3Timer_Saturday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3Timer_Saturday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3Timer_Sunday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3Timer_Sunday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3Timer_Sunday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3Timer_Sunday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3Timer_Thursday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3Timer_Thursday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3Timer_Thursday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3Timer_Thursday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3Timer_Timeframes
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3Timer_Tuesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3Timer_Tuesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3Timer_Tuesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3Timer_Tuesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3Timer_Wednesday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3Timer_Wednesday0
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3Timer_Wednesday1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3Timer_Wednesday2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv0
+  name: Z3ValveStatus
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: AdaptHeatCurve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: CcTimer_Config
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: CcTimer_Timeframes
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: ContinuousHeating
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: CylinderChargeHyst
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: CylinderChargeOffset
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Date
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: DisplayedOutsideTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: FrostOverRideTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1AutoOffMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1CircuitType
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1CoolingEnabled
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1CoolingFlowTempMin
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1DewPointMonitoring
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1DewPointOffset
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1DewPointTemp
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002300 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1ExcessTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1FlowTempCalc
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002000 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1HeatCurve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1Humidity
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002200 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MixerMovement
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MixerPosition
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002100 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1PumpHours
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002400 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1PumpStarts
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002002500 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc1PumpStatus
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1RoomTempModulation
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1Status
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc1SummerTempLimit
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2AutoOffMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2CircuitType
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2DewPointTemp
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012300 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2ExcessTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2FlowTempCalc
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012000 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2HeatCurve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2Humidity
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012200 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MixerMovement
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MixerPosition
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012100 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2PumpHours
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012400 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2PumpStarts
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020002012500 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: Hc2PumpStatus
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2Status
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc2SummerTempLimit
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3AutoOffMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3CircuitType
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3ExcessTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3HeatCurve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MixerMovement
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3PumpStatus
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3Status
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Hc3SummerTempLimit
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HcStorageTempBottom
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: ctlv2
+  name: HcStorageTempTop
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: ctlv2
+  name: HwcFlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcLockTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcMaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcOpMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcParallelLoading
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcSFMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcSfMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcStorageTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcStorageTempBottom
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcStorageTempTop
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HwcTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: HydraulicScheme
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: ManualCoolingEndDate
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b5240602000000db00 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: ManualCoolingEndDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: ManualCoolingStartDate
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b5240602000000da00 / 00)'
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: ManualCoolingStartDate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: ctlv2
+  name: MaxCylinderChargeTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: MaxRoomHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: MultiRelaySetting
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: OutsideTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: OutsideTempAvg
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySum
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHcLastMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHcThisMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHwcLastMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHwcThisMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: SystemFlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: WaterPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingManualTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingOpMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingSetbackTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1DayTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1HolidayTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1NightTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1OpMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoDuration
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoEndDate
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoEndTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: true
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1RoomTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z1SFMode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: Z2RoomTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: ctlv2
+  name: z1RoomHumidity
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 3115b52406020003002800 / 00)'
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: BuildingCircuitFlow
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: BuildingCircuitPumpSpeed
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: CompressorHc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: CompressorHwc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CompressorHwc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: ConsumptionTotal
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CoolElecConsDay
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CoolElecConsTotal
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CoolEnvYieldDay
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CoolEnvYieldMonth
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CoolEnvYieldTotal
+  fields:
+  - value
+  values:
+  - '0.0'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: CopCooling
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CopCoolingMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CopHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CopHcMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CopHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CopHwcMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CurrentCompressorUtil
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CurrentConsumedPower
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: CurrentYieldPower
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: DateTime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: FlowTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: FlowTemperature
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: HcElecConsDay
+  fields:
+  - value
+  values:
+  - '83.55'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: HcElecConsTotal
+  fields:
+  - value
+  values:
+  - '1019.87'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: HoursCool
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: HwcElecConsDay
+  fields:
+  - value
+  values:
+  - '6.69'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: HwcElecConsTotal
+  fields:
+  - value
+  values:
+  - '535.81'
+  writable: false
+  has_data: true
+- circuit: hmu
+  name: LiveMonitorCurrentConsumedPower
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: PowerConsumptionHmu
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunDataAirInletTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataBuildingCPumpPower
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataCompressorInletTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataCompressorOutletTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataCompressorSpeed
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataEEVOutletTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataEEVPositionAbs
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataElectricPowerConsumption
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataFan1Speed
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataFan2Speed
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataHighPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataLowPressure
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunDataReturnTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunDataStatuscode
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStats4PortValveHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStats4PortValveSwitches
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsBuildingCPumpStarts
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsBuildingPumpHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunStatsCompressorHc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunStatsCompressorHwc.cycles
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHwc.runtime
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorStarts
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsFan1Hours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsFan1Starts
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsFan2Hours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsFan2Starts
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsHMUHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsHcHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: RunStatsHwcHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: SourceTempInput
+  fields:
+  - value
+  values:
+  - <redacted>
+  writable: false
+  has_data: false
+- circuit: hmu
+  name: SourceTempOutput
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatElectricEnergySum
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatElectricEnergySumCool
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatElectricEnergySumHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatElectricEnergySumHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatEnvironmentEnergySum
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatEnvironmentEnergySumCool
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatEnvironmentEnergySumHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatEnvironmentEnergySumHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatSolarEnergySum
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatSolarEnergySumHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: StatSolarEnergySumHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.pumpstate
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.temp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.temp_1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: Status01.temp_2
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: Status01.temp_3
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: Status01.temp_4
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: StatusCirPump
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: SupplyTempWeighted
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: TotalEnergyUsage
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldCoolDay
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldCooling
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldCoolingMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldHc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldHcDay
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldHcMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldHwc
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldHwcDay
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: hmu
+  name: YieldHwcMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: sc
+  name: Clearerrorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: Col
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: ColKickPumpTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: ColKickTempDelta
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: CollPump
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - -;-;-;-;-
+  writable: false
+  has_data: true
+- circuit: sc
+  name: D1Temp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: D2Temp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: Date
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 31ecb509030d0d00 / 00)'
+  writable: false
+  has_data: false
+- circuit: sc
+  name: EDFunction
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: EDFunction
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: EnableScProtection
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: EnableScProtection
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: FlowRate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: FlowRate
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: FrostProtectionEnabled
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: FrostProtectionLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: Hc1PumpKol1PP1Port
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: Hc2aLegPumpP2Port
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: Hc2zPort
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: HydraulicScheme
+  fields:
+  - value
+  values:
+  - '(ERR: invalid position for 31ecb509030d2100 / 00)'
+  writable: false
+  has_data: false
+- circuit: sc
+  name: InitCircuit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: Iotest
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: Ioteststop
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: IsInBoostMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: KickFunction
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: KickFunction
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: LpZpMaPort
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: MAPreferredStorage
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: MAPreferredStorage
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: MaximalTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: MaximalTemp
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: MaximalTemp2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: MaximalTemp2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: MultifunctionOutput
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: OMultifunction
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: OMultifunction
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: PumpAntiLockingFlags
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: QuickVetoStart
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: ResetSolGain
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: ResetSolGain
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: RuntimeCollPump
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: RuntimeCollPumpSeconds
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: SP1
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: SP2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: ScProtectionHysteresis
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: ScProtectionLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: ScProtectionLimit
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: ScProtectionTime
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: SolCollPumpDcIntegrator
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: SolCollPumpED
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: SolGain
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: SolOperationMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: SumSolGain
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: SumSolGainDayBefore
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: SystemMode
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: TempDifferenceOff
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: TempDifferenceOff
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: TempDifferenceOff2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: TempDifferenceOff2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: TempDifferenceOffTD12
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: TempDifferenceOffTD12
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: TempDifferenceOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: TempDifferenceOn
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: TempDifferenceOn2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: TempDifferenceOn2
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: TempDifferenceOnTD12
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: TempDifferenceOnTD12
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: Time
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: Weekday
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: YieldLastYear
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: sc
+  name: YieldThisYear
+  fields:
+  - value
+  values:
+  - no data stored
+  writable: false
+  has_data: false
+- circuit: v32
+  name: BypassPosition
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: ExhaustAirHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: ExhaustAirTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: FanHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: FlowTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: FlowTempMax
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: HcHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: HoursTillService
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: HwcHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: HwcTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: v32
+  name: Maintenancedata_HwcTempMax
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: v32
+  name: MaxAirHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: MinAirHumidity
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: OutdoorstempSensor
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: v32
+  name: OutsideAirTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: PumpHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: PumpPower
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: ReturnTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: ReturnTempMax
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: Status02.hwcmode
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: Status02.temp0
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: Status02.temp0_1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: Status02.temp1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: Status02.temp1_1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: StorageLoadPumpHours
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: StorageTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: StorageTempDesired
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: SupplyAirTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: VentilationLevelDay
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: VentilationLevelNight
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldMonth
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldToday
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldTotal
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: v32
+  name: YieldYear
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Clearerrorhistory
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Mc1Operation
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Mc2Operation
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: Mc3Operation
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: SensorData1
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: SensorData2
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vr_71
+  name: SetActorState
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+- circuit: vwz
+  name: TestHwcTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: vwz
+  name: TestOutdoorTemp
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+- circuit: vwz
+  name: TestThreeWayValve
+  fields:
+  - value
+  values:
+  - 'ERR: element not found'
+  writable: false
+  has_data: true
+  from_map: true
+  disabled: true
+grab:
+- '[grab] grab continued'
+- '3108070400 / 0ab5424149303012017603 = 1: scan.08'
+- '3108b5090125 / 09313030323230323230 = 6: Scan.08 Id'
+- '3108b516081000ffff01000000 / 0b1000ff0100283500000000 = 10: bai StatSolarEnergySum'
+- '3108b516081000ffff01030000 / 0b1000ff0103283500000000 = 11: bai StatSolarEnergySumHc'
+- '3108b516081000ffff01040000 / 0b1000ff0104283500000000 = 11: bai StatSolarEnergySumHwc'
+- '3108b516081000ffff02000000 / 0b1000ff0200283500000000 = 11: bai StatEnvironmentEnergySum'
+- '3108b516081000ffff02030000 / 0b1000ff0203283500000000 = 11: bai StatEnvironmentEnergySumHc'
+- '3108b516081001ffff02052835 / 0b1100ff0205283500000000 = 10: hmu CoolEnvYieldDay'
+- '3108b516081000ffff02040000 / 0b1000ff0204283500000000 = 12: bai StatEnvironmentEnergySumHwc'
+- '3108b516081000ffff02050000 / 0b1000ff0205283500000000 = 9: hmu CoolEnvYieldTotal'
+- '3108b516081002ffff02052835 / 0b1200ff0205243500000000 = 8: hmu CoolEnvYieldMonth'
+- '3108b516081000ffff03000000 / 0b0000ff030028359072c244 = 10: bai StatElectricEnergySum'
+- '3108b516081001ffff03032835 / 0b010000030328359a19a742 = 9: hmu HcElecConsDay'
+- '3108b516081000ffff03030000 / 0b00000003032835af077f44 = 9: hmu HcElecConsTotal'
+- '3108b516081001ffff03052835 / 0b1100ff0305283500000000 = 11: hmu CoolElecConsDay'
+- '3108b516081000ffff03040000 / 0b00000303042835d8f30544 = 8: hmu HwcElecConsTotal'
+- '3108b516081001ffff03042835 / 0b010003030428357c14d640 = 10: hmu HwcElecConsDay'
+- '3108b516081000ffff03050000 / 0b1000ff0305283500000000 = 9: hmu CoolElecConsTotal'
+- '0315070400 / 0ab543544c563003139103 = 6: scan.15'
+- '3115b5090126 / 09393533303036373234 = 2: Scan.15 Id'
+- '31ec070400 / 0ab5534f4c303003139103 = 1: scan.ec'
+- '1008b51009000000ffffff050000 / 0101 = 932: bai SetMode'
+- '1008b512020000 / 00 = 32: bai StatusCirPump'
+- '10feb516080049251608090226 = 157: Broadcast Vdatetime'
+- '10feb5160301501e = 158: Broadcast Outsidetemp'
+- '1008b5040100 / 0a00ffffffffffffffe01e = 1: bai DateTime'
+- 1008b5110100 / 09ab010d001f10000000 = 157
+- '1008b5110101 / 093533e01e35ff0000ff = 2: bai Status01'
+- '1008b5110102 / 06033c8246825a = 1: bai Status02'
+- '3115b5090124 / 09003231323230343030 = 1: Scan.15 Id'
+- '31ecb5090124 / 09003231323230343030 = 1: Scan.ec Id'
+- '1008b5040100 / 0a00ffffffffffffff801f = 155: bai DateTime'
+- '1008b5110101 / 093533501f35ff0000ff = 934: bai Status01'
+- '1008b5110102 / 06033c8246825a = 309: bai Status02'
+- 1008b5120204ff / 0101 = 32
+- 1008b513020508 / 0101 = 32
+- '3108b503020001 / 0affffffffffffffffffff = 4: bai Currenterror'
+- '3115b503020001 / 0affffffffffffffffffff = 5: ctlv0 Currenterror'
+- '31ecb503020001 / 0affffffffffffffffffff = 12: sc Currenterror'
+- '31ecb509030d3f18 / 00 = 1421: sc YieldThisYear'
+- 1008b5100305ff01 / 0101 = 32
+- '3108b509030d0200 / 035d0500 = 12: bai WaterPressure'
+- '3108b509030d0400 / 02e001 = 12: bai StorageTempDesired'
+- '3108b509030d1400 / 020e00 = 10: bai PumpHours'
+- '3108b509030d1700 / 0328ffaa = 12: bai StorageTemp'
+- '3108b509030d1800 / 03ab0100 = 11: bai FlowTemp'
+- '3108b509030d1b00 / 020a00 = 11: bai FanHours'
+- '3108b509030d2004 / 0402000000 = 12: bai HoursTillService'
+- '3108b509030d2200 / 020700 = 12: bai HwcHours'
+- '3108b509030d2800 / 020000 = 12: bai HcHours'
+- '3108b509030d3700 / 024204 = 11: bai FlowTempMax'
+- '3108b509030d3900 / 020000 = 11: bai FlowTempDesired'
+- '3108b509030d4c00 / 020000 = 12: bai StorageLoadPumpHours'
+- '3108b509030d7300 / 0100 = 12: bai PumpPower'
+- '3108b509030d9800 / 059e0161fe00 = 12: bai ReturnTemp'
+- '3108b509030dbe00 / 02cc03 = 10: bai ReturnTempMax'
+- '3108b509030dea03 / 020000 = 11: bai HwcTempDesired'
+- '3115b55503a30003 / 09030101000000ffff00 = 11: ctlv0 CcTimer_Config'
+- '3115b55503a40003 / 09030000000000000000 = 12: ctlv0 CcTimer_Timeframes'
+- '31ecb509030d0d00 / 00 = 5: sc Date'
+- '31ecb509030d2100 / 00 = 5: sc HydraulicScheme'
+- '1008b51009000000ffffff050000 / 0101 = 2: bai SetMode'
+- '3108b51a0405ff3222 / 02ff01 = 12: hmu SourceTempInput'
+- '3115b52406020000000200 / 08030002000000d0c1 = 11: ctlv0 ContinuousHeating'
+- '3115b52406020002000200 / 00 = 12: ctlv0 Hc1CircuitType'
+- '3115b52406020002010200 / 00 = 12: ctlv0 Hc2CircuitType'
+- '3115b52406020002020200 / 00 = 11: ctlv0 Hc3CircuitType'
+- '3115b52406020003000200 / 00 = 11: ctlv0 Z1CoolingTemp'
+- '3115b52406020000000300 / 06030003000400 = 10: ctlv0 FrostOverRideTime'
+- '3115b52406020001000300 / 06020103000200 = 10: ctlv0 HwcOpMode'
+- '3115b52406020003000300 / 0703030300010113 = 10: ctlv0 Z1HolidayStartPeriod'
+- '3115b52406020003000600 / 06030306000000 = 13: ctlv0 Z1OpMode'
+- '3115b52406020002000700 / 080102070000000000 = 12: ctlv0 Hc1ActualFlowTempDesired'
+- '3115b52406020002010700 / 080002070000000000 = 11: ctlv0 Hc2ActualFlowTempDesired'
+- '3115b52406020002020700 / 080002070000000000 = 10: ctlv0 Hc3ActualFlowTempDesired'
+- '3115b52406020001000400 / 080201040000003442 = 1: ctlv0 HwcTempDesired'
+- '3115b52406020003000400 / 0703030400010113 = 12: ctlv0 Z1HolidayEndPeriod'
+- '3115b52406020001000500 / 0800010500ffffff7f = 11: ctlv0 HwcStorageTemp'
+- '3115b52406020003000500 / 080303050000007041 = 11: ctlv0 Z1HolidayTemp'
+- '3115b52406020000000a00 / 0502000a0000 = 10: ctlv0 HwcParallelLoading'
+- '3115b52406020001000a00 / 0702010a00010113 = 12: ctlv0 HwcHolidayEndPeriod'
+- '3115b52406020002000b00 / 00 = 12: ctlv0 Hc1ExcessTemp'
+- '3115b52406020002010b00 / 00 = 11: ctlv0 Hc2ExcessTemp'
+- '3115b52406020002020b00 / 00 = 12: ctlv0 Hc3ExcessTemp'
+- '3115b52406020001000800 / 080001080000000000 = 12: ctlv0 HwcFlowTemp'
+- '3115b52406020002000800 / 08000208000000d441 = 12: ctlv0 Hc1FlowTemp'
+- '3115b52406020002010800 / 0800020800ffffff7f = 11: ctlv0 Hc2FlowTemp'
+- '3115b52406020002020800 / 0800020800ffffff7f = 11: ctlv0 Hc3FlowTemp'
+- '3115b52406020003000800 / 08030308000000b041 = 14: ctlv0 Z1QuickVetoTemp'
+- '3115b52406020001000900 / 0702010900010113 = 12: ctlv0 HwcHolidayStartPeriod'
+- '3115b52406020003000900 / 080203090000008441 = 10: ctlv0 Z1NightTemp'
+- '3115b52406020000000e00 / 00 = 12: ctlv0 MaxRoomHumidity'
+- '3115b52406020002000e00 / 0603020e000000 = 10: ctlv0 Hc1AutoOffMode'
+- '3115b52406020002010e00 / 0602020e000000 = 11: ctlv0 Hc2AutoOffMode'
+- '3115b52406020002020e00 / 0602020e000000 = 11: ctlv0 Hc3AutoOffMode'
+- '3115b52406020003000e00 / 0503030e0000 = 12: ctlv0 Z1SFMode'
+- '3115b52406020002000f00 / 0803020f00cdcc4c3f = 11: ctlv0 Hc1HeatCurve'
+- '3115b52406020002010f00 / 0802020f009a99993f = 12: ctlv0 Hc2HeatCurve'
+- '3115b52406020002020f00 / 0802020f009a99993f = 10: ctlv0 Hc3HeatCurve'
+- '3115b52406020003000f00 / 0801030f00cdcccb41 = 12: ctlv0 Z1RoomTemp'
+- '3115b52406020003010f00 / 0800030f00ffffff7f = 12: ctlv0 Z2RoomTemp'
+- '3115b52406020001000d00 / 0502010d0000 = 11: ctlv0 HwcSFMode'
+- '3115b52406020002001200 / 080302120000007041 = 11: ctlv0 Hc1MinFlowTempDesired'
+- '3115b52406020002011200 / 080202120000007041 = 11: ctlv0 Hc2MinFlowTempDesired'
+- '3115b52406020002021200 / 080202120000007041 = 12: ctlv0 Hc3MinFlowTempDesired'
+- '3115b52406020002001000 / 08030210000000b442 = 10: ctlv0 Hc1MaxFlowTempDesired'
+- '3115b52406020002011000 / 08020210000000b442 = 11: ctlv0 Hc2MaxFlowTempDesired'
+- '3115b52406020002021000 / 08020210000000b442 = 12: ctlv0 Hc3MaxFlowTempDesired'
+- '3115b52406020002001100 / 00 = 11: ctlv0 Hc1MinCoolingTempDesired'
+- '3115b52406020002011100 / 00 = 11: ctlv0 Hc2MinCoolingTempDesired'
+- '3115b52406020002021100 / 00 = 11: ctlv0 Hc3MinCoolingTempDesired'
+- '3115b52406020000001700 / 06020017003c00 = 10: ctlv0 MaxCylinderChargeTime'
+- '3115b52406020000001400 / 050300140001 = 11: ctlv0 AdaptHeatCurve'
+- '3115b52406020002001400 / 080302140000009041 = 11: ctlv0 Hc1SummerTempLimit'
+- '3115b52406020002011400 / 08020214000000a841 = 12: ctlv0 Hc2SummerTempLimit'
+- '3115b52406020002021400 / 08020214000000a841 = 10: ctlv0 Hc3SummerTempLimit'
+- '3115b52406020003001400 / 080103140000000000 = 11: ctlv0 Z1ActualRoomTempDesired'
+- '3115b52406020002001500 / 06030215000100 = 11: ctlv0 Hc1RoomTempSwitchOn'
+- '3115b52406020002011500 / 06020215000000 = 10: ctlv0 Hc2RoomTempSwitchOn'
+- '3115b52406020002021500 / 06020215000000 = 11: ctlv0 Hc3RoomTempSwitchOn'
+- '3115b52406020002001a00 / 00 = 11: ctlv0 Hc1MixerMovement'
+- '3115b52406020002011a00 / 00 = 11: ctlv0 Hc2MixerMovement'
+- '3115b52406020002021a00 / 00 = 11: ctlv0 Hc3MixerMovement'
+- '3115b52406020002001b00 / 00 = 11: ctlv0 Hc1Status'
+- '3115b52406020002011b00 / 00 = 12: ctlv0 Hc2Status'
+- '3115b52406020002021b00 / 00 = 12: ctlv0 Hc3Status'
+- '3115b52406020000001800 / 06020018003c00 = 11: ctlv0 HwcLockTime'
+- '3115b52406020002001e00 / 0601021e000000 = 11: ctlv0 Hc1PumpStatus'
+- '3115b52406020002011e00 / 0600021e000000 = 12: ctlv0 Hc2PumpStatus'
+- '3115b52406020002021e00 / 0600021e000000 = 11: ctlv0 Hc3PumpStatus'
+- '3115b52406020003001e00 / 0703031e00121c00 = 10: ctlv0 Z1QuickVetoEndTime'
+- '3115b52406020002001c00 / 0801021c0000000000 = 11: ctlv0 Hc1HeatCurveAdaption'
+- '3115b52406020002011c00 / 0800021c0000000000 = 11: ctlv0 Hc2HeatCurveAdaption'
+- '3115b52406020002021c00 / 0800021c0000000000 = 11: ctlv0 Hc3HeatCurveAdaption'
+- '3115b52406020002002200 / 00 = 19: ctlv2 Hc1Humidity'
+- '3115b52406020002012200 / 00 = 20: ctlv2 Hc2Humidity'
+- '3115b52406020003002200 / 08020322000000a841 = 11: ctlv0 Z1DayTemp'
+- '3115b52406020002002300 / 00 = 23: ctlv2 Hc1DewPointTemp'
+- '3115b52406020002012300 / 00 = 15: ctlv2 Hc2DewPointTemp'
+- '3115b52406020002002000 / 00 = 20: ctlv2 Hc1FlowTempCalc'
+- '3115b52406020002012000 / 00 = 20: ctlv2 Hc2FlowTempCalc'
+- '3115b52406020002002100 / 00 = 19: ctlv2 Hc1MixerPosition'
+- '3115b52406020002012100 / 00 = 16: ctlv2 Hc2MixerPosition'
+- '3115b52406020003002600 / 080303260000004040 = 10: ctlv0 Z1QuickVetoDuration'
+- '3115b52406020000002700 / 08020027000000a040 = 12: ctlv0 CylinderChargeHyst'
+- '3115b52406020002002400 / 00 = 18: ctlv2 Hc1PumpHours'
+- '3115b52406020002012400 / 00 = 20: ctlv2 Hc2PumpHours'
+- '3115b52406020003002400 / 070303240008091a = 11: ctlv0 Z1QuickVetoEndDate'
+- '3115b52406020002002500 / 00 = 20: ctlv2 Hc1PumpStarts'
+- '3115b52406020002012500 / 00 = 19: ctlv2 Hc2PumpStarts'
+- '3115b52406020003002800 / 00 = 20: ctlv2 z1RoomHumidity'
+- '3115b52406020000002900 / 08020029000000c841 = 10: ctlv0 CylinderChargeOffset'
+- '3115b52406020000003600 / 00 = 11: ctlv0 HydraulicScheme'
+- '3115b52406020000003400 / 070300340008091a = 12: ctlv0 Date'
+- '3115b52406020000003900 / 08010039006666a63f = 1: ctlv0 WaterPressure'
+- '3115b52406020000003e00 / 00 = 11: ctlv0 YieldTotal'
+- '3115b52406020000004600 / 00 = 11: ctlv0 HwcMaxFlowTempDesired'
+- '3115b52406020000004b00 / 0800004b00ffffff7f = 10: ctlv0 SystemFlowTemp'
+- '3115b52406020000004f00 / 00 = 11: ctlv0 PrEnergySumHcThisMonth'
+- '3115b52406020000004d00 / 00 = 11: ctlv0 MultiRelaySetting'
+- '3115b52406020000005300 / 00 = 11: ctlv0 PrEnergySumHcLastMonth'
+- '3115b52406020000005000 / 00 = 12: ctlv0 PrEnergySumHwcThisMonth'
+- '3115b52406020000005700 / 00 = 10: ctlv0 PrEnergySumHc'
+- '3115b52406020000005400 / 00 = 12: ctlv0 PrEnergySumHwcLastMonth'
+- '3115b52406020000005800 / 00 = 11: ctlv0 PrEnergySumHwc'
+- '3115b52406020000005c00 / 00 = 11: ctlv0 PrEnergySum'
+- '3115b52406020000007300 / 08010073000000f441 = 11: ctlv0 DisplayedOutsideTemp'
+- '3115b52406020000009500 / 00 = 11: ctlv0 OutsideTempAvg'
+- '3115b52406020000009e00 / 00 = 11: ctlv0 HwcStorageTempBottom'
+- '3115b52406020000009d00 / 00 = 12: ctlv0 HwcStorageTempTop'
+- '3115b5240602000000da00 / 00 = 23: ctlv2 ManualCoolingStartDate'
+- '3115b5240602000000db00 / 00 = 18: ctlv2 ManualCoolingEndDate'
+- '3115b524080201030006000000 / 020003 = 2: ctlv0 Z1OpMode'
+- '3115b5240a0201030008000000b041 / 020003 = 4: ctlv0 Z1QuickVetoTemp'
+- '3115b5240a0201030022000000a841 / 020003 = 3: ctlv0 Z1DayTemp'
+- '3115b5240a02010300260000004040 / 020003 = 1: ctlv0 Z1QuickVetoDuration'
+- '3115b5240902010000db0001010f / 00 = 1: ctlv2 ManualCoolingEndDate'
+- '[grab stop] grab stopped'
+labeled_telegrams:
+- msgid: '0704'
+  master: '31'
+  slave: 08
+  sub: '00'
+  resp: 0ab5424149303012017603
+  count: '1'
+  label: scan.08
+- msgid: b509
+  master: '31'
+  slave: 08
+  sub: '0125'
+  resp: 09313030323230323230
+  count: '6'
+  label: Scan.08 Id
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081000ffff01000000
+  resp: 0b1000ff0100283500000000
+  count: '10'
+  label: bai StatSolarEnergySum
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081000ffff01030000
+  resp: 0b1000ff0103283500000000
+  count: '11'
+  label: bai StatSolarEnergySumHc
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081000ffff01040000
+  resp: 0b1000ff0104283500000000
+  count: '11'
+  label: bai StatSolarEnergySumHwc
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081000ffff02000000
+  resp: 0b1000ff0200283500000000
+  count: '11'
+  label: bai StatEnvironmentEnergySum
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081000ffff02030000
+  resp: 0b1000ff0203283500000000
+  count: '11'
+  label: bai StatEnvironmentEnergySumHc
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081001ffff02052835
+  resp: 0b1100ff0205283500000000
+  count: '10'
+  label: hmu CoolEnvYieldDay
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081000ffff02040000
+  resp: 0b1000ff0204283500000000
+  count: '12'
+  label: bai StatEnvironmentEnergySumHwc
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081000ffff02050000
+  resp: 0b1000ff0205283500000000
+  count: '9'
+  label: hmu CoolEnvYieldTotal
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081002ffff02052835
+  resp: 0b1200ff0205243500000000
+  count: '8'
+  label: hmu CoolEnvYieldMonth
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081000ffff03000000
+  resp: 0b0000ff030028359072c244
+  count: '10'
+  label: bai StatElectricEnergySum
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081001ffff03032835
+  resp: 0b010000030328359a19a742
+  count: '9'
+  label: hmu HcElecConsDay
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081000ffff03030000
+  resp: 0b00000003032835af077f44
+  count: '9'
+  label: hmu HcElecConsTotal
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081001ffff03052835
+  resp: 0b1100ff0305283500000000
+  count: '11'
+  label: hmu CoolElecConsDay
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081000ffff03040000
+  resp: 0b00000303042835d8f30544
+  count: '8'
+  label: hmu HwcElecConsTotal
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081001ffff03042835
+  resp: 0b010003030428357c14d640
+  count: '10'
+  label: hmu HwcElecConsDay
+- msgid: b516
+  master: '31'
+  slave: 08
+  sub: 081000ffff03050000
+  resp: 0b1000ff0305283500000000
+  count: '9'
+  label: hmu CoolElecConsTotal
+- msgid: b509
+  master: '31'
+  slave: '15'
+  sub: '0126'
+  resp: 09393533303036373234
+  count: '2'
+  label: Scan.15 Id
+- msgid: '0704'
+  master: '31'
+  slave: ec
+  sub: '00'
+  resp: 0ab5534f4c303003139103
+  count: '1'
+  label: scan.ec
+- msgid: b510
+  master: '10'
+  slave: 08
+  sub: 09000000ffffff050000
+  resp: '0101'
+  count: '932'
+  label: bai SetMode
+- msgid: b512
+  master: '10'
+  slave: 08
+  sub: '020000'
+  resp: '00'
+  count: '32'
+  label: bai StatusCirPump
+- msgid: b516
+  master: '10'
+  slave: fe
+  sub: 080049251608090226
+  resp: null
+  count: '157'
+  label: Broadcast Vdatetime
+- msgid: b516
+  master: '10'
+  slave: fe
+  sub: 0301501e
+  resp: null
+  count: '158'
+  label: Broadcast Outsidetemp
+- msgid: b504
+  master: '10'
+  slave: 08
+  sub: '0100'
+  resp: 0a00ffffffffffffffe01e
+  count: '1'
+  label: bai DateTime
+- msgid: b511
+  master: '10'
+  slave: 08
+  sub: '0101'
+  resp: 093533e01e35ff0000ff
+  count: '2'
+  label: bai Status01
+- msgid: b511
+  master: '10'
+  slave: 08
+  sub: '0102'
+  resp: 06033c8246825a
+  count: '1'
+  label: bai Status02
+- msgid: b509
+  master: '31'
+  slave: '15'
+  sub: '0124'
+  resp: 09003231323230343030
+  count: '1'
+  label: Scan.15 Id
+- msgid: b509
+  master: '31'
+  slave: ec
+  sub: '0124'
+  resp: 09003231323230343030
+  count: '1'
+  label: Scan.ec Id
+- msgid: b504
+  master: '10'
+  slave: 08
+  sub: '0100'
+  resp: 0a00ffffffffffffff801f
+  count: '155'
+  label: bai DateTime
+- msgid: b511
+  master: '10'
+  slave: 08
+  sub: '0101'
+  resp: 093533501f35ff0000ff
+  count: '934'
+  label: bai Status01
+- msgid: b511
+  master: '10'
+  slave: 08
+  sub: '0102'
+  resp: 06033c8246825a
+  count: '309'
+  label: bai Status02
+- msgid: b503
+  master: '31'
+  slave: 08
+  sub: '020001'
+  resp: 0affffffffffffffffffff
+  count: '4'
+  label: bai Currenterror
+- msgid: b503
+  master: '31'
+  slave: '15'
+  sub: '020001'
+  resp: 0affffffffffffffffffff
+  count: '5'
+  label: ctlv0 Currenterror
+- msgid: b503
+  master: '31'
+  slave: ec
+  sub: '020001'
+  resp: 0affffffffffffffffffff
+  count: '12'
+  label: sc Currenterror
+- msgid: b509
+  master: '31'
+  slave: ec
+  sub: 030d3f18
+  resp: '00'
+  count: '1421'
+  label: sc YieldThisYear
+- msgid: b509
+  master: '31'
+  slave: 08
+  sub: 030d0200
+  resp: 035d0500
+  count: '12'
+  label: bai WaterPressure
+- msgid: b509
+  master: '31'
+  slave: 08
+  sub: 030d0400
+  resp: 02e001
+  count: '12'
+  label: bai StorageTempDesired
+- msgid: b509
+  master: '31'
+  slave: 08
+  sub: 030d1400
+  resp: 020e00
+  count: '10'
+  label: bai PumpHours
+- msgid: b509
+  master: '31'
+  slave: 08
+  sub: 030d1700
+  resp: 0328ffaa
+  count: '12'
+  label: bai StorageTemp
+- msgid: b509
+  master: '31'
+  slave: 08
+  sub: 030d1800
+  resp: 03ab0100
+  count: '11'
+  label: bai FlowTemp
+- msgid: b509
+  master: '31'
+  slave: 08
+  sub: 030d1b00
+  resp: 020a00
+  count: '11'
+  label: bai FanHours
+- msgid: b509
+  master: '31'
+  slave: 08
+  sub: 030d2004
+  resp: '0402000000'
+  count: '12'
+  label: bai HoursTillService
+- msgid: b509
+  master: '31'
+  slave: 08
+  sub: 030d2200
+  resp: '020700'
+  count: '12'
+  label: bai HwcHours
+- msgid: b509
+  master: '31'
+  slave: 08
+  sub: 030d2800
+  resp: '020000'
+  count: '12'
+  label: bai HcHours
+- msgid: b509
+  master: '31'
+  slave: 08
+  sub: 030d3700
+  resp: '024204'
+  count: '11'
+  label: bai FlowTempMax
+- msgid: b509
+  master: '31'
+  slave: 08
+  sub: 030d3900
+  resp: '020000'
+  count: '11'
+  label: bai FlowTempDesired
+- msgid: b509
+  master: '31'
+  slave: 08
+  sub: 030d4c00
+  resp: '020000'
+  count: '12'
+  label: bai StorageLoadPumpHours
+- msgid: b509
+  master: '31'
+  slave: 08
+  sub: 030d7300
+  resp: '0100'
+  count: '12'
+  label: bai PumpPower
+- msgid: b509
+  master: '31'
+  slave: 08
+  sub: 030d9800
+  resp: 059e0161fe00
+  count: '12'
+  label: bai ReturnTemp
+- msgid: b509
+  master: '31'
+  slave: 08
+  sub: 030dbe00
+  resp: 02cc03
+  count: '10'
+  label: bai ReturnTempMax
+- msgid: b509
+  master: '31'
+  slave: 08
+  sub: 030dea03
+  resp: '020000'
+  count: '11'
+  label: bai HwcTempDesired
+- msgid: b555
+  master: '31'
+  slave: '15'
+  sub: 03a30003
+  resp: 09030101000000ffff00
+  count: '11'
+  label: ctlv0 CcTimer_Config
+- msgid: b555
+  master: '31'
+  slave: '15'
+  sub: 03a40003
+  resp: 09030000000000000000
+  count: '12'
+  label: ctlv0 CcTimer_Timeframes
+- msgid: b509
+  master: '31'
+  slave: ec
+  sub: 030d0d00
+  resp: '00'
+  count: '5'
+  label: sc Date
+- msgid: b509
+  master: '31'
+  slave: ec
+  sub: 030d2100
+  resp: '00'
+  count: '5'
+  label: sc HydraulicScheme
+- msgid: b510
+  master: '10'
+  slave: 08
+  sub: 09000000ffffff050000
+  resp: '0101'
+  count: '2'
+  label: bai SetMode
+- msgid: b51a
+  master: '31'
+  slave: 08
+  sub: 0405ff3222
+  resp: 02ff01
+  count: '12'
+  label: hmu SourceTempInput
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020000000200'
+  resp: 08030002000000d0c1
+  count: '11'
+  label: ctlv0 ContinuousHeating
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020002000200'
+  resp: '00'
+  count: '12'
+  label: ctlv0 Hc1CircuitType
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020002010200'
+  resp: '00'
+  count: '12'
+  label: ctlv0 Hc2CircuitType
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020002020200'
+  resp: '00'
+  count: '11'
+  label: ctlv0 Hc3CircuitType
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020003000200'
+  resp: '00'
+  count: '11'
+  label: ctlv0 Z1CoolingTemp
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020000000300'
+  resp: '06030003000400'
+  count: '10'
+  label: ctlv0 FrostOverRideTime
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020001000300'
+  resp: '06020103000200'
+  count: '10'
+  label: ctlv0 HwcOpMode
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020003000300'
+  resp: '0703030300010113'
+  count: '10'
+  label: ctlv0 Z1HolidayStartPeriod
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020003000600'
+  resp: '06030306000000'
+  count: '13'
+  label: ctlv0 Z1OpMode
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020002000700'
+  resp: 080102070000000000
+  count: '12'
+  label: ctlv0 Hc1ActualFlowTempDesired
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020002010700'
+  resp: 080002070000000000
+  count: '11'
+  label: ctlv0 Hc2ActualFlowTempDesired
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020002020700'
+  resp: 080002070000000000
+  count: '10'
+  label: ctlv0 Hc3ActualFlowTempDesired
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020001000400'
+  resp: 080201040000003442
+  count: '1'
+  label: ctlv0 HwcTempDesired
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020003000400'
+  resp: '0703030400010113'
+  count: '12'
+  label: ctlv0 Z1HolidayEndPeriod
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020001000500'
+  resp: 0800010500ffffff7f
+  count: '11'
+  label: ctlv0 HwcStorageTemp
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020003000500'
+  resp: 080303050000007041
+  count: '11'
+  label: ctlv0 Z1HolidayTemp
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020000000a00
+  resp: 0502000a0000
+  count: '10'
+  label: ctlv0 HwcParallelLoading
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020001000a00
+  resp: 0702010a00010113
+  count: '12'
+  label: ctlv0 HwcHolidayEndPeriod
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020002000b00
+  resp: '00'
+  count: '12'
+  label: ctlv0 Hc1ExcessTemp
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020002010b00
+  resp: '00'
+  count: '11'
+  label: ctlv0 Hc2ExcessTemp
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020002020b00
+  resp: '00'
+  count: '12'
+  label: ctlv0 Hc3ExcessTemp
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020001000800
+  resp: 080001080000000000
+  count: '12'
+  label: ctlv0 HwcFlowTemp
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020002000800
+  resp: 08000208000000d441
+  count: '12'
+  label: ctlv0 Hc1FlowTemp
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020002010800
+  resp: 0800020800ffffff7f
+  count: '11'
+  label: ctlv0 Hc2FlowTemp
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020002020800
+  resp: 0800020800ffffff7f
+  count: '11'
+  label: ctlv0 Hc3FlowTemp
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020003000800
+  resp: 08030308000000b041
+  count: '14'
+  label: ctlv0 Z1QuickVetoTemp
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020001000900
+  resp: 0702010900010113
+  count: '12'
+  label: ctlv0 HwcHolidayStartPeriod
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020003000900
+  resp: 080203090000008441
+  count: '10'
+  label: ctlv0 Z1NightTemp
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020000000e00
+  resp: '00'
+  count: '12'
+  label: ctlv0 MaxRoomHumidity
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020002000e00
+  resp: 0603020e000000
+  count: '10'
+  label: ctlv0 Hc1AutoOffMode
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020002010e00
+  resp: 0602020e000000
+  count: '11'
+  label: ctlv0 Hc2AutoOffMode
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020002020e00
+  resp: 0602020e000000
+  count: '11'
+  label: ctlv0 Hc3AutoOffMode
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020003000e00
+  resp: 0503030e0000
+  count: '12'
+  label: ctlv0 Z1SFMode
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020002000f00
+  resp: 0803020f00cdcc4c3f
+  count: '11'
+  label: ctlv0 Hc1HeatCurve
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020002010f00
+  resp: 0802020f009a99993f
+  count: '12'
+  label: ctlv0 Hc2HeatCurve
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020002020f00
+  resp: 0802020f009a99993f
+  count: '10'
+  label: ctlv0 Hc3HeatCurve
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020003000f00
+  resp: 0801030f00cdcccb41
+  count: '12'
+  label: ctlv0 Z1RoomTemp
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020003010f00
+  resp: 0800030f00ffffff7f
+  count: '12'
+  label: ctlv0 Z2RoomTemp
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020001000d00
+  resp: 0502010d0000
+  count: '11'
+  label: ctlv0 HwcSFMode
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020002001200'
+  resp: 080302120000007041
+  count: '11'
+  label: ctlv0 Hc1MinFlowTempDesired
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020002011200'
+  resp: 080202120000007041
+  count: '11'
+  label: ctlv0 Hc2MinFlowTempDesired
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020002021200'
+  resp: 080202120000007041
+  count: '12'
+  label: ctlv0 Hc3MinFlowTempDesired
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020002001000'
+  resp: 08030210000000b442
+  count: '10'
+  label: ctlv0 Hc1MaxFlowTempDesired
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020002011000'
+  resp: 08020210000000b442
+  count: '11'
+  label: ctlv0 Hc2MaxFlowTempDesired
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020002021000'
+  resp: 08020210000000b442
+  count: '12'
+  label: ctlv0 Hc3MaxFlowTempDesired
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020002001100'
+  resp: '00'
+  count: '11'
+  label: ctlv0 Hc1MinCoolingTempDesired
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020002011100'
+  resp: '00'
+  count: '11'
+  label: ctlv0 Hc2MinCoolingTempDesired
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020002021100'
+  resp: '00'
+  count: '11'
+  label: ctlv0 Hc3MinCoolingTempDesired
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020000001700'
+  resp: 06020017003c00
+  count: '10'
+  label: ctlv0 MaxCylinderChargeTime
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020000001400'
+  resp: '050300140001'
+  count: '11'
+  label: ctlv0 AdaptHeatCurve
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020002001400'
+  resp: 080302140000009041
+  count: '11'
+  label: ctlv0 Hc1SummerTempLimit
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020002011400'
+  resp: 08020214000000a841
+  count: '12'
+  label: ctlv0 Hc2SummerTempLimit
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020002021400'
+  resp: 08020214000000a841
+  count: '10'
+  label: ctlv0 Hc3SummerTempLimit
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020003001400'
+  resp: 080103140000000000
+  count: '11'
+  label: ctlv0 Z1ActualRoomTempDesired
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020002001500'
+  resp: '06030215000100'
+  count: '11'
+  label: ctlv0 Hc1RoomTempSwitchOn
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020002011500'
+  resp: '06020215000000'
+  count: '10'
+  label: ctlv0 Hc2RoomTempSwitchOn
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020002021500'
+  resp: '06020215000000'
+  count: '11'
+  label: ctlv0 Hc3RoomTempSwitchOn
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020002001a00
+  resp: '00'
+  count: '11'
+  label: ctlv0 Hc1MixerMovement
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020002011a00
+  resp: '00'
+  count: '11'
+  label: ctlv0 Hc2MixerMovement
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020002021a00
+  resp: '00'
+  count: '11'
+  label: ctlv0 Hc3MixerMovement
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020002001b00
+  resp: '00'
+  count: '11'
+  label: ctlv0 Hc1Status
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020002011b00
+  resp: '00'
+  count: '12'
+  label: ctlv0 Hc2Status
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020002021b00
+  resp: '00'
+  count: '12'
+  label: ctlv0 Hc3Status
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020000001800
+  resp: 06020018003c00
+  count: '11'
+  label: ctlv0 HwcLockTime
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020002001e00
+  resp: 0601021e000000
+  count: '11'
+  label: ctlv0 Hc1PumpStatus
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020002011e00
+  resp: 0600021e000000
+  count: '12'
+  label: ctlv0 Hc2PumpStatus
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020002021e00
+  resp: 0600021e000000
+  count: '11'
+  label: ctlv0 Hc3PumpStatus
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020003001e00
+  resp: 0703031e00121c00
+  count: '10'
+  label: ctlv0 Z1QuickVetoEndTime
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020002001c00
+  resp: 0801021c0000000000
+  count: '11'
+  label: ctlv0 Hc1HeatCurveAdaption
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020002011c00
+  resp: 0800021c0000000000
+  count: '11'
+  label: ctlv0 Hc2HeatCurveAdaption
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020002021c00
+  resp: 0800021c0000000000
+  count: '11'
+  label: ctlv0 Hc3HeatCurveAdaption
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020002002200'
+  resp: '00'
+  count: '19'
+  label: ctlv2 Hc1Humidity
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020002012200'
+  resp: '00'
+  count: '20'
+  label: ctlv2 Hc2Humidity
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020003002200'
+  resp: 08020322000000a841
+  count: '11'
+  label: ctlv0 Z1DayTemp
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020002002300'
+  resp: '00'
+  count: '23'
+  label: ctlv2 Hc1DewPointTemp
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020002012300'
+  resp: '00'
+  count: '15'
+  label: ctlv2 Hc2DewPointTemp
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020002002000'
+  resp: '00'
+  count: '20'
+  label: ctlv2 Hc1FlowTempCalc
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020002012000'
+  resp: '00'
+  count: '20'
+  label: ctlv2 Hc2FlowTempCalc
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020002002100'
+  resp: '00'
+  count: '19'
+  label: ctlv2 Hc1MixerPosition
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020002012100'
+  resp: '00'
+  count: '16'
+  label: ctlv2 Hc2MixerPosition
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020003002600'
+  resp: 080303260000004040
+  count: '10'
+  label: ctlv0 Z1QuickVetoDuration
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020000002700'
+  resp: 08020027000000a040
+  count: '12'
+  label: ctlv0 CylinderChargeHyst
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020002002400'
+  resp: '00'
+  count: '18'
+  label: ctlv2 Hc1PumpHours
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020002012400'
+  resp: '00'
+  count: '20'
+  label: ctlv2 Hc2PumpHours
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020003002400'
+  resp: 070303240008091a
+  count: '11'
+  label: ctlv0 Z1QuickVetoEndDate
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020002002500'
+  resp: '00'
+  count: '20'
+  label: ctlv2 Hc1PumpStarts
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020002012500'
+  resp: '00'
+  count: '19'
+  label: ctlv2 Hc2PumpStarts
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020003002800
+  resp: '00'
+  count: '20'
+  label: ctlv2 z1RoomHumidity
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020000002900
+  resp: 08020029000000c841
+  count: '10'
+  label: ctlv0 CylinderChargeOffset
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020000003600'
+  resp: '00'
+  count: '11'
+  label: ctlv0 HydraulicScheme
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020000003400'
+  resp: 070300340008091a
+  count: '12'
+  label: ctlv0 Date
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020000003900
+  resp: 08010039006666a63f
+  count: '1'
+  label: ctlv0 WaterPressure
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020000003e00
+  resp: '00'
+  count: '11'
+  label: ctlv0 YieldTotal
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020000004600'
+  resp: '00'
+  count: '11'
+  label: ctlv0 HwcMaxFlowTempDesired
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020000004b00
+  resp: 0800004b00ffffff7f
+  count: '10'
+  label: ctlv0 SystemFlowTemp
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020000004f00
+  resp: '00'
+  count: '11'
+  label: ctlv0 PrEnergySumHcThisMonth
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020000004d00
+  resp: '00'
+  count: '11'
+  label: ctlv0 MultiRelaySetting
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020000005300'
+  resp: '00'
+  count: '11'
+  label: ctlv0 PrEnergySumHcLastMonth
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020000005000'
+  resp: '00'
+  count: '12'
+  label: ctlv0 PrEnergySumHwcThisMonth
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020000005700'
+  resp: '00'
+  count: '10'
+  label: ctlv0 PrEnergySumHc
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020000005400'
+  resp: '00'
+  count: '12'
+  label: ctlv0 PrEnergySumHwcLastMonth
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020000005800
+  resp: '00'
+  count: '11'
+  label: ctlv0 PrEnergySumHwc
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020000005c00
+  resp: '00'
+  count: '11'
+  label: ctlv0 PrEnergySum
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: '06020000007300'
+  resp: 08010073000000f441
+  count: '11'
+  label: ctlv0 DisplayedOutsideTemp
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020000009500
+  resp: '00'
+  count: '11'
+  label: ctlv0 OutsideTempAvg
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020000009e00
+  resp: '00'
+  count: '11'
+  label: ctlv0 HwcStorageTempBottom
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 06020000009d00
+  resp: '00'
+  count: '12'
+  label: ctlv0 HwcStorageTempTop
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 0602000000da00
+  resp: '00'
+  count: '23'
+  label: ctlv2 ManualCoolingStartDate
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 0602000000db00
+  resp: '00'
+  count: '18'
+  label: ctlv2 ManualCoolingEndDate
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 080201030006000000
+  resp: '020003'
+  count: '2'
+  label: ctlv0 Z1OpMode
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 0a0201030008000000b041
+  resp: '020003'
+  count: '4'
+  label: ctlv0 Z1QuickVetoTemp
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 0a0201030022000000a841
+  resp: '020003'
+  count: '3'
+  label: ctlv0 Z1DayTemp
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 0a02010300260000004040
+  resp: '020003'
+  count: '1'
+  label: ctlv0 Z1QuickVetoDuration
+- msgid: b524
+  master: '31'
+  slave: '15'
+  sub: 0902010000db0001010f
+  resp: '00'
+  count: '1'
+  label: ctlv2 ManualCoolingEndDate
+unknown_telegrams:
+- msgid: b511
+  master: '10'
+  slave: 08
+  sub: '0100'
+  resp: 09ab010d001f10000000
+  count: '157'
+  label: null
+- msgid: b512
+  master: '10'
+  slave: 08
+  sub: 0204ff
+  resp: '0101'
+  count: '32'
+  label: null
+- msgid: b513
+  master: '10'
+  slave: 08
+  sub: 020508
+  resp: '0101'
+  count: '32'
+  label: null
+- msgid: b510
+  master: '10'
+  slave: 08
+  sub: 0305ff01
+  resp: '0101'
+  count: '32'
+  label: null
+after_registers:
+- circuit: Broadcast
+  name: Datetime
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: Broadcast
+  name: Error
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: Broadcast
+  name: FlowTemp
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: Broadcast
+  name: HwcStatus
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: Broadcast
+  name: Outsidetemp
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: Broadcast
+  name: Vdatetime
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: Broadcast
+  name: WaterPressure
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: AdaptHeatCurve
+  fields:
+  - value
+  values:
+  - null
+  writable: true
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: CcTimer_Config
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: CcTimer_Timeframes
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: ContinuousHeating
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: CylinderChargeHyst
+  fields:
+  - value
+  values:
+  - null
+  writable: true
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: CylinderChargeOffset
+  fields:
+  - value
+  values:
+  - null
+  writable: true
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: Date
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: DisplayedOutsideTemp
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: FrostOverRideTime
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: Hc1ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: Hc1AutoOffMode
+  fields:
+  - value
+  values:
+  - null
+  writable: true
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: Hc1CircuitType
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: Hc1CoolingEnabled
+  fields:
+  - value
+  values:
+  - null
+  writable: true
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: Hc1CoolingFlowTempMin
+  fields:
+  - value
+  values:
+  - null
+  writable: true
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: Hc1DewPointMonitoring
+  fields:
+  - value
+  values:
+  - null
+  writable: true
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: Hc1DewPointOffset
+  fields:
+  - value
+  values:
+  - null
+  writable: true
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: Hc1DewPointTemp
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: Hc1ExcessTemp
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: Hc1FlowTemp
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: Hc1FlowTempCalc
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: Hc1HeatCurve
+  fields:
+  - value
+  values:
+  - null
+  writable: true
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: Hc1HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: Hc1Humidity
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - null
+  writable: true
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - null
+  writable: true
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - null
+  writable: true
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MixerMovement
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: Hc1MixerPosition
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: Hc1PumpHours
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: Hc1PumpStarts
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: Hc1PumpStatus
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: Hc1RoomTempModulation
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: Hc1RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: Hc1Status
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: Hc1SummerTempLimit
+  fields:
+  - value
+  values:
+  - null
+  writable: true
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: Hc2ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - null
+  writable: true
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: Hc2AutoOffMode
+  fields:
+  - value
+  values:
+  - null
+  writable: true
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: Hc2CircuitType
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: Hc2DewPointTemp
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: Hc2ExcessTemp
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: Hc2FlowTemp
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: Hc2FlowTempCalc
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: Hc2HeatCurve
+  fields:
+  - value
+  values:
+  - null
+  writable: true
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: Hc2HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: Hc2Humidity
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - null
+  writable: true
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - null
+  writable: true
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - null
+  writable: true
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MixerMovement
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: Hc2MixerPosition
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: Hc2PumpHours
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: Hc2PumpStarts
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: Hc2PumpStatus
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: Hc2RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: Hc2Status
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: Hc2SummerTempLimit
+  fields:
+  - value
+  values:
+  - null
+  writable: true
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: Hc3ActualFlowTempDesired
+  fields:
+  - value
+  values:
+  - null
+  writable: true
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: Hc3AutoOffMode
+  fields:
+  - value
+  values:
+  - null
+  writable: true
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: Hc3CircuitType
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: Hc3ExcessTemp
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: Hc3FlowTemp
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: Hc3HeatCurve
+  fields:
+  - value
+  values:
+  - null
+  writable: true
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: Hc3HeatCurveAdaption
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - null
+  writable: true
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MinCoolingTempDesired
+  fields:
+  - value
+  values:
+  - null
+  writable: true
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MinFlowTempDesired
+  fields:
+  - value
+  values:
+  - null
+  writable: true
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: Hc3MixerMovement
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: Hc3PumpStatus
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: Hc3RoomTempSwitchOn
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: Hc3Status
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: Hc3SummerTempLimit
+  fields:
+  - value
+  values:
+  - null
+  writable: true
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: HcStorageTempBottom
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+  disabled: true
+- circuit: ctlv2
+  name: HcStorageTempTop
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+  disabled: true
+- circuit: ctlv2
+  name: HwcFlowTemp
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: HwcHolidayEndPeriod
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: HwcHolidayStartPeriod
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: HwcLockTime
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: HwcMaxFlowTempDesired
+  fields:
+  - value
+  values:
+  - null
+  writable: true
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: HwcOpMode
+  fields:
+  - value
+  values:
+  - null
+  writable: true
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: HwcParallelLoading
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: HwcSFMode
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: HwcSfMode
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: HwcStorageTemp
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: HwcStorageTempBottom
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: HwcStorageTempTop
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: HwcTempDesired
+  fields:
+  - value
+  values:
+  - null
+  writable: true
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: HydraulicScheme
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: ManualCoolingEndDate
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: ManualCoolingStartDate
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: MaxCylinderChargeTime
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: MaxRoomHumidity
+  fields:
+  - value
+  values:
+  - null
+  writable: true
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: MultiRelaySetting
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: OutsideTemp
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: OutsideTempAvg
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySum
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHc
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHcLastMonth
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHcThisMonth
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHwc
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHwcLastMonth
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: PrEnergySumHwcThisMonth
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: SystemFlowTemp
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: WaterPressure
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: Z1ActualRoomTempDesired
+  fields:
+  - value
+  values:
+  - null
+  writable: true
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingManualTemp
+  fields:
+  - value
+  values:
+  - null
+  writable: true
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingOpMode
+  fields:
+  - value
+  values:
+  - null
+  writable: true
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingSetbackTemp
+  fields:
+  - value
+  values:
+  - null
+  writable: true
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingTemp
+  fields:
+  - value
+  values:
+  - null
+  writable: true
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: Z1CoolingTempDesired
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: Z1DayTemp
+  fields:
+  - value
+  values:
+  - null
+  writable: true
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: Z1HolidayEndPeriod
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: Z1HolidayStartPeriod
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: Z1HolidayTemp
+  fields:
+  - value
+  values:
+  - null
+  writable: true
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: Z1NightTemp
+  fields:
+  - value
+  values:
+  - null
+  writable: true
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: Z1OpMode
+  fields:
+  - value
+  values:
+  - null
+  writable: true
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoDuration
+  fields:
+  - value
+  values:
+  - null
+  writable: true
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoEndDate
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoEndTime
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: Z1QuickVetoTemp
+  fields:
+  - value
+  values:
+  - null
+  writable: true
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: Z1RoomTemp
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: Z1SFMode
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: Z2RoomTemp
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: ctlv2
+  name: z1RoomHumidity
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: BuildingCircuitFlow
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: BuildingCircuitPumpSpeed
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: CompressorHc
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: CompressorHc.cycles
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: CompressorHc.runtime
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: CompressorHwc
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: CompressorHwc.cycles
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: CompressorHwc.runtime
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: ConsumptionTotal
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: CoolElecConsDay
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: CoolElecConsTotal
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: CoolEnvYieldDay
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: CoolEnvYieldMonth
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: CoolEnvYieldTotal
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: CopCooling
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: CopCoolingMonth
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: CopHc
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: CopHcMonth
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: CopHwc
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: CopHwcMonth
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: CurrentCompressorUtil
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: CurrentConsumedPower
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: CurrentYieldPower
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: DateTime
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: FlowTemp
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: FlowTemperature
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: HcElecConsDay
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: HcElecConsTotal
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: HoursCool
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: HwcElecConsDay
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: HwcElecConsTotal
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: LiveMonitorCurrentConsumedPower
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: PowerConsumptionHmu
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunDataAirInletTemp
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: RunDataBuildingCPumpPower
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: RunDataCompressorInletTemp
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: RunDataCompressorOutletTemp
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: RunDataCompressorSpeed
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: RunDataEEVOutletTemp
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: RunDataEEVPositionAbs
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: RunDataElectricPowerConsumption
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: RunDataFan1Speed
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: RunDataFan2Speed
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: RunDataHighPressure
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: RunDataLowPressure
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunDataReturnTemp
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: RunDataStatuscode
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: RunStats4PortValveHours
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: RunStats4PortValveSwitches
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: RunStatsBuildingCPumpStarts
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: RunStatsBuildingPumpHours
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHc
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunStatsCompressorHc.cycles
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHc.runtime
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHours
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHwc
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: RunStatsCompressorHwc.cycles
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorHwc.runtime
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: RunStatsCompressorStarts
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: RunStatsFan1Hours
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: RunStatsFan1Starts
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: RunStatsFan2Hours
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: RunStatsFan2Starts
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: RunStatsHMUHours
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: RunStatsHcHours
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: RunStatsHwcHours
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: SourceTempInput
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: SourceTempOutput
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: StatElectricEnergySum
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: StatElectricEnergySumCool
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: StatElectricEnergySumHc
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: StatElectricEnergySumHwc
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: StatEnvironmentEnergySum
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: StatEnvironmentEnergySumCool
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: StatEnvironmentEnergySumHc
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: StatEnvironmentEnergySumHwc
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: StatSolarEnergySum
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: StatSolarEnergySumHc
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: StatSolarEnergySumHwc
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: Status01
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: Status01.pumpstate
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: Status01.temp
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: Status01.temp_1
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: Status01.temp_2
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: Status01.temp_3
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: Status01.temp_4
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+  disabled: true
+- circuit: hmu
+  name: StatusCirPump
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: SupplyTempWeighted
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: TotalEnergyUsage
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: YieldCoolDay
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: YieldCooling
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: YieldCoolingMonth
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: YieldHc
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: YieldHcDay
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: YieldHcMonth
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: YieldHwc
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: YieldHwcDay
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: hmu
+  name: YieldHwcMonth
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: v32
+  name: BypassPosition
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: v32
+  name: ExhaustAirHumidity
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: v32
+  name: ExhaustAirTemp
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: v32
+  name: FanHours
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: v32
+  name: FlowTempDesired
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: v32
+  name: FlowTempMax
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: v32
+  name: HcHours
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: v32
+  name: HoursTillService
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: v32
+  name: HwcHours
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: v32
+  name: HwcTemp
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+  disabled: true
+- circuit: v32
+  name: Maintenancedata_HwcTempMax
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+  disabled: true
+- circuit: v32
+  name: MaxAirHumidity
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: v32
+  name: MinAirHumidity
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: v32
+  name: OutdoorstempSensor
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+  disabled: true
+- circuit: v32
+  name: OutsideAirTemp
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: v32
+  name: PumpHours
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: v32
+  name: PumpPower
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: v32
+  name: ReturnTemp
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: v32
+  name: ReturnTempMax
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: v32
+  name: Status02.hwcmode
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: v32
+  name: Status02.temp0
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: v32
+  name: Status02.temp0_1
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: v32
+  name: Status02.temp1
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: v32
+  name: Status02.temp1_1
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: v32
+  name: StorageLoadPumpHours
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: v32
+  name: StorageTemp
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: v32
+  name: StorageTempDesired
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: v32
+  name: SupplyAirTemp
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: v32
+  name: VentilationLevelDay
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: v32
+  name: VentilationLevelNight
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: v32
+  name: YieldMonth
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: v32
+  name: YieldToday
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: v32
+  name: YieldTotal
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: v32
+  name: YieldYear
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: vr_71
+  name: Clearerrorhistory
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: vr_71
+  name: Currenterror
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: vr_71
+  name: Errorhistory
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: vr_71
+  name: Mc1Operation
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: vr_71
+  name: Mc2Operation
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: vr_71
+  name: Mc3Operation
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: vr_71
+  name: SensorData1
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: vr_71
+  name: SensorData2
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: vr_71
+  name: SetActorState
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+- circuit: vwz
+  name: TestHwcTemp
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+  disabled: true
+- circuit: vwz
+  name: TestOutdoorTemp
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+  disabled: true
+- circuit: vwz
+  name: TestThreeWayValve
+  fields:
+  - value
+  values:
+  - null
+  writable: false
+  has_data: false
+  from_map: true
+  disabled: true
+raw_find_lines_after: []

--- a/tests/test_boost_switch.py
+++ b/tests/test_boost_switch.py
@@ -106,7 +106,7 @@ for _name in ("switch", "water_heater"):
     sys.modules[f"vaillant_ebus.{_name}"] = _mod
     _spec.loader.exec_module(_mod)
 
-from vaillant_ebus.switch import HwcBoostSwitch  # noqa: E402
+from vaillant_ebus.switch import HwcBoostSwitch, _is_holiday_active  # noqa: E402
 from vaillant_ebus.water_heater import EbusdWaterHeater  # noqa: E402
 
 
@@ -167,3 +167,8 @@ def test_water_heater_current_operation_boost_desired() -> None:
     assert wh.current_operation == "boost"
     wh2 = EbusdWaterHeater(_coordinator(dhw_boost_desired=False, sfmode="load"), _entry())
     assert wh2.current_operation == "auto"
+
+
+def test_holiday_reset_values_are_not_active() -> None:
+    assert _is_holiday_active("01.01.2015", "01.01.2015") is False
+    assert _is_holiday_active("01.01.2019", "01.01.2019") is False

--- a/tests/test_community_issue_fixtures.py
+++ b/tests/test_community_issue_fixtures.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from tests.fake_ebusd import load_find_lines
+import pytest
+
+from tests.fake_ebusd import load_discovery_dump, load_find_lines
 from tests.test_entity_factory import DiscoveryService, EntityFactoryService
 
 
@@ -48,3 +50,50 @@ def test_hmux0_latest_issue99_values_keep_entity_metadata() -> None:
     assert entities["hmux0.RunDataReturnTemp.value"].meta.device_class == "temperature"
     assert entities["hmux0.YieldHc.value"].meta.device_class == "energy"
     assert entities["hmux0.Status01.temp"].meta.device_class == "temperature"
+
+
+@pytest.mark.parametrize(
+    "fixture",
+    (
+        "community/arotherm_pro7_quiet_off_idle_discovery.yaml",
+        "community/arotherm_pro7_quiet_off_heating_discovery.yaml",
+        "community/arotherm_pro7_quiet_on_heating_discovery.yaml",
+    ),
+)
+def test_arotherm_pro7_quiet_captures_load_without_quiet_registers(fixture: str) -> None:
+    dump = load_discovery_dump(fixture)
+    graph = DiscoveryService.build_device_graph(load_find_lines(fixture))
+    names = {f"{node.circuit}.{register}" for node in graph.nodes.values() for register in node.registers}
+
+    assert dump["raw_find_lines"]
+    assert any("scan.08" in line for line in dump["raw_find_lines"])
+    assert graph.nodes["hmu"].device_type.name == "HEAT_PUMP"
+    assert not any("NoiseReduction" in name or "DeicingActive" in name for name in names)
+
+
+def test_hmux0_dhw_holiday_capture_keeps_controller_values_and_sentinels_unavailable() -> None:
+    dump = load_discovery_dump("community/arotherm_hmux0_dhw_holiday_discovery.yaml")
+    graph = DiscoveryService.build_device_graph(load_find_lines("community/arotherm_hmux0_dhw_holiday_discovery.yaml"))
+    entities = {entity.key: entity for entity in EntityFactoryService().generate(graph)}
+
+    assert dump["raw_find_lines"]
+    assert graph.raw_registers["ctlv3.HwcHolidayStartPeriod"] == "01.01.2015"
+    assert graph.raw_registers["ctlv3.HwcHolidayEndPeriod"] == "01.01.2015"
+    assert graph.raw_registers["ctlv3.PrEnergySumHwc"] == "327"
+    assert "ctlv3.PrEnergySumHwc.value" in entities
+
+
+@pytest.mark.parametrize(
+    "fixture",
+    (
+        "community/ecotec_vrt380_15700_discovery.yaml",
+        "community/ecotec_vrt380_ctlv2_discovery.yaml",
+    ),
+)
+def test_ecotec_vrt380_captures_expose_bai_and_controller_graph(fixture: str) -> None:
+    graph = DiscoveryService.build_device_graph(load_find_lines(fixture))
+    entities = {entity.key: entity for entity in EntityFactoryService().generate(graph)}
+
+    assert graph.nodes["bai"].device_type.name == "HEATING_CONTROLLER"
+    assert "bai.FlowTemp.value" in entities
+    assert "bai.StorageTemp.value" in entities

--- a/tests/test_fake_ebusd.py
+++ b/tests/test_fake_ebusd.py
@@ -51,6 +51,12 @@ async def test_arotherm_fixture_loads() -> None:
         ("community/arotherm_plus_ctlv2_cooling_discovery.yaml", 50),
         ("community/geniaset_bass3_discovery.yaml", 50),
         ("community/flexotherm_133_cooling_discovery.yaml", 50),
+        ("community/arotherm_pro7_quiet_off_idle_discovery.yaml", 50),
+        ("community/arotherm_pro7_quiet_off_heating_discovery.yaml", 50),
+        ("community/arotherm_pro7_quiet_on_heating_discovery.yaml", 50),
+        ("community/arotherm_hmux0_dhw_holiday_discovery.yaml", 50),
+        ("community/ecotec_vrt380_15700_discovery.yaml", 50),
+        ("community/ecotec_vrt380_ctlv2_discovery.yaml", 50),
     ],
 )
 async def test_all_fixtures_load(fixture: str, min_registers: int) -> None:

--- a/tests/test_hardening_fixes.py
+++ b/tests/test_hardening_fixes.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import importlib.machinery
 import importlib.util
+import inspect
 import sys
 import tempfile
 from pathlib import Path
@@ -311,3 +312,16 @@ async def test_async_setup_registers_all_services_with_entry_selector() -> None:
             "clear_mode_override",
         }
     assert set(registered) == expected
+
+
+async def test_registered_service_handlers_are_async_callbacks() -> None:
+    hass = MagicMock()
+    registered: dict[str, object] = {}
+
+    def _register(domain, name, handler, schema=None):  # noqa: ARG001
+        registered[name] = handler
+
+    hass.services.async_register.side_effect = _register
+    await INIT.async_setup(hass, {})
+
+    assert all(inspect.iscoroutinefunction(handler) for handler in registered.values())


### PR DESCRIPTION
## Summary

- Fix Home Assistant service callbacks so async integration services are awaited correctly.
- Treat controller-specific holiday reset values `01.01.2015` and `01.01.2019` as unset.
- Add community discovery fixtures and regression coverage for HMUX0, aroTHERM Pro, and ecoTEC/VRT380 captures.
- Exclude Python bytecode and `__pycache__` directories from release zip artifacts.

## Validation

- `412 passed`
- `.venv/bin/ruff check .`
- `python3 -m compileall -f custom_components/vaillant_ebus/`
- Release zip validated without `__pycache__` or `.pyc` files.
