### PR TITLE
release: v1.7.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,12 +79,46 @@ telegrams; capture them with `grab` and mine the unknown ones for new registers.
 - Dumps capture them as `unknown_telegrams` (and `labeled_telegrams`) next to the
   raw `grab` lines. When a dump exists, prefer mining its `unknown_telegrams` over
   a fresh grab.
-- Register candidates found this way must be verified against ebusd (message format,
-  read-back value) before adding a `define -r` to `_define_custom_registers()`.
+- Register candidates found this way must have message format and layout evidence
+  before adding a `define -r` to `_define_custom_registers()`; owner hardware live
+  verification is preferred but not mandatory when upstream/community evidence is
+  strong and the hardware scope is explicit.
+- A register with a strong upstream/community layout match may be added through
+  `_define_custom_registers()` even when the installed ebusd CSV does not expose it.
+  This is the preferred path for community-supported opt-in registers; never modify
+  or upload addon CSV files. The definition must hardcode the verified circuit/address
+  and message layout, be additive, and tolerate an absent or `ERR` response without
+  creating a normal entity.
+- Before adding a runtime definition, confirm all of the following: the evidence
+  telegram master/slave and message/sub-address match the candidate; the response
+  byte length and field offsets match; the value has plausible units/range; hardware
+  and firmware scope is explicit; and the definition does not introduce active polling
+  that can alter bus behaviour unless active reads are explicitly required and safe.
+  Prefer passive `u` definitions for passively observed telegrams. Add the definition
+  only after a fixture-backed test covers both the decoded value and absent-register
+  path.
 - **Live-verificatie geldt alleen voor de eigen hardware.** Eén grabbage op de eigen
   bus is live testbaar. Data afkomstig van anderen (dumps, gists, issue snippets,
   upstream threads) is **nooit** live testbaar — behandel die als community-data (zie
   "Community Data" hieronder), niet als eigen-live-verificatie.
+- During dump analysis, search every useful unknown telegram and unmapped live register
+  in `john30/ebusd-configuration` issues and pull requests before classifying it as
+  unsupported. Search by register name, message ID, sub-address, and distinctive payload
+  fragments where useful. Use `tools/search_upstream.sh`, including `--comments` and
+  `--all` when appropriate; do not limit the search to the repository's CSV/TSP files.
+- Treat upstream matches as evidence, not local live verification. Upstream/community
+  evidence may be sufficient for production when classified `confirmed` or `strong
+  assumption`, hardware scope is explicit, and absent-register behavior is safe. Open
+  promising issues or PRs
+  with `gh issue view <number> --comments` and read the complete conversation before using
+  a snippet. Record the upstream URL, hardware context, and whether the mapping is
+  `confirmed`, `strong assumption`, or `speculative`.
+- For a local live dump, correlate upstream candidates against the local telegram's master,
+  slave, message ID, sub-address, response layout, and observed value. A name match alone
+  is insufficient for production code.
+- Add the relevant upstream evidence and local capture as fixture-backed analysis notes when
+  a candidate moves toward production. Keep candidates without a matching layout or safe
+  absent-register behavior discovery-only until evidence improves.
 
 ## Upstream Issues/PRs as a Register Source
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## 1.7.0 - 2026-09-09
+
+### Added
+
+- **HW5103 Status07 support.** Adds upstream-evidenced `b511 07` runtime
+  decoding for HMU00 HW5103 systems, including Quiet mode
+  (`display_b5_noisereduction`), heating, cooling, DHW, pressure-loss, and
+  backup-heater status bit entities.
+- **Improved discovery dump analysis.** Adds dump schema v4 metadata,
+  normalized register categories, before/after changes, grouped telegrams,
+  and backward-compatible legacy normalization.
+
+## Unreleased
+
+### Added
+
+- **Live dump evidence analysis.** Added fixture-backed notes for the VWZIO
+  `b511 01`/`Status01` strong-assumption match against upstream PR #598,
+  while keeping the address-only mapping discovery-only until a stable VWZIO
+  circuit path is available.
+- **Structured discovery dump analysis.** New dumps include integration metadata,
+  normalized register categories, before/after register changes, and grouped
+  known/unknown telegram traffic while preserving the existing raw YAML fields.
+- **Backward-compatible dump normalization.** Legacy dumps, including files
+  without `dump_version`, can be normalized through one analysis pipeline;
+  unknown future versions are preserved and reported as unsupported.
+
 ## 1.6.3 - 2026-09-09
 
 ### Fixed

--- a/custom_components/vaillant_ebus/backend/dump_analysis.py
+++ b/custom_components/vaillant_ebus/backend/dump_analysis.py
@@ -1,0 +1,145 @@
+"""Backward-compatible discovery dump normalization and analysis."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .grab_parser import parse_grab_lines
+
+CURRENT_DUMP_VERSION = 4
+_SENTINELS = ("", "-", "empty", "unknown", "unavailable", "no data stored")
+
+
+def _meaningful(value: Any) -> bool:
+    """Return whether a register value carries usable data."""
+    if value is None:
+        return False
+    text = str(value).strip().lower()
+    return not any(text == sentinel or text.startswith(f"{sentinel} ") for sentinel in _SENTINELS)
+
+
+def _registers_by_key(registers: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    """Index serialized register entries by stable circuit/name key."""
+    return {
+        f"{entry.get('circuit', '')}.{entry.get('name', '')}": entry
+        for entry in registers
+        if entry.get("circuit") and entry.get("name")
+    }
+
+
+def _register_categories(registers: list[dict[str, Any]]) -> dict[str, list[str]]:
+    """Classify discovered, mapped, unavailable, and disabled registers."""
+    categories: dict[str, list[str]] = {
+        "discovered": [],
+        "mapped": [],
+        "unavailable": [],
+        "disabled": [],
+    }
+    for entry in registers:
+        key = f"{entry.get('circuit', '')}.{entry.get('name', '')}"
+        if not key.startswith("."):
+            if entry.get("from_map"):
+                categories["mapped"].append(key)
+            else:
+                categories["discovered"].append(key)
+            if not entry.get("has_data", False):
+                categories["unavailable"].append(key)
+            if entry.get("disabled", False):
+                categories["disabled"].append(key)
+    for values in categories.values():
+        values.sort()
+    return categories
+
+
+def _register_changes(before: list[dict[str, Any]], after: list[dict[str, Any]]) -> dict[str, list[Any]]:
+    """Compare register snapshots while ignoring sentinel-only transitions."""
+    old = _registers_by_key(before)
+    new = _registers_by_key(after)
+    changes: dict[str, list[Any]] = {
+        "new_registers": sorted(set(new) - set(old)),
+        "changed_registers": [],
+        "disappeared_registers": sorted(set(old) - set(new)),
+    }
+    for key in sorted(set(old) & set(new)):
+        old_values = old[key].get("values", [])
+        new_values = new[key].get("values", [])
+        if old_values == new_values:
+            continue
+        if not any(_meaningful(value) for value in old_values + new_values):
+            continue
+        changes["changed_registers"].append({"key": key, "before": old_values, "after": new_values})
+    return changes
+
+
+def group_telegrams(telegrams: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Aggregate telegrams by bus identity, preserving changing responses."""
+    groups: dict[tuple[Any, ...], dict[str, Any]] = {}
+    for telegram in telegrams:
+        key = tuple(telegram.get(field) for field in ("master", "slave", "msgid", "sub", "label"))
+        group = groups.setdefault(
+            key,
+            {
+                "master": telegram.get("master"),
+                "slave": telegram.get("slave"),
+                "msgid": telegram.get("msgid"),
+                "sub": telegram.get("sub"),
+                "label": telegram.get("label"),
+                "known": bool(telegram.get("label")),
+                "occurrence_count": 0,
+                "unique_requests": [],
+                "unique_responses": [],
+            },
+        )
+        group["occurrence_count"] += int(telegram.get("count") or 1)
+        request = telegram.get("request") or telegram.get("req")
+        response = telegram.get("resp")
+        if request and request not in group["unique_requests"]:
+            group["unique_requests"].append(request)
+        if response and response not in group["unique_responses"]:
+            group["unique_responses"].append(response)
+    return sorted(
+        groups.values(),
+        key=lambda item: (
+            item["msgid"] or "",
+            item["master"] or "",
+            item["slave"] or "",
+            item["sub"] or "",
+        ),
+    )
+
+
+def normalize_dump(dump: dict[str, Any]) -> dict[str, Any]:
+    """Normalize legacy/current/future dump data without mutating input."""
+    metadata = dict(dump.get("metadata") or {})
+    version = metadata.get("dump_version", 1)
+    known_version = isinstance(version, int) and version <= CURRENT_DUMP_VERSION
+    before = list(dump.get("before_registers") or [])
+    after = list(dump.get("after_registers") or [])
+    current = after or before
+    raw_grab = list(dump.get("grab") or [])
+    parsed = parse_grab_lines(raw_grab) if raw_grab else list(dump.get("labeled_telegrams") or [])
+    unknown = [telegram for telegram in parsed if not telegram.get("label")]
+    return {
+        "dump_version": version,
+        "version_supported": known_version,
+        "metadata": metadata,
+        "registers": {
+            **_register_categories(current),
+            "entries": current,
+        },
+        "changes": (
+            _register_changes(before, after)
+            if after
+            else {"new_registers": [], "changed_registers": [], "disappeared_registers": []}
+        ),
+        "traffic": {
+            "summary": group_telegrams(parsed),
+            "unknown": group_telegrams(unknown),
+        },
+        "raw": {
+            "raw_find_lines": list(dump.get("raw_find_lines") or []),
+            "before_registers": before,
+            "after_registers": after,
+            "grab": raw_grab,
+        },
+    }

--- a/custom_components/vaillant_ebus/backend/grab_parser.py
+++ b/custom_components/vaillant_ebus/backend/grab_parser.py
@@ -33,6 +33,7 @@ def parse_grab_lines(grab_lines: list[str]) -> list[dict]:
                 "msgid": req[4:8],
                 "master": req[0:2],
                 "slave": req[2:4],
+                "request": req,
                 "sub": req[8:],
                 "resp": resp_value,
                 "count": count,

--- a/custom_components/vaillant_ebus/backend/mapping.py
+++ b/custom_components/vaillant_ebus/backend/mapping.py
@@ -43,6 +43,16 @@ ELOBLOCK_GAS_REGISTERS: frozenset[str] = frozenset(
 # Source: ebusd vaillant CSV (08.hmu.csv) + community dumps.
 MULTI_FIELD_FIELDS: dict[str, list[str]] = {
     "hmu.Status01": ["temp", "temp_1", "temp_2", "temp_3", "temp_4", "pumpstate"],
+    "hmu.Status07": [
+        "power", "dailyenvyield", "display_b0_heaterenabled", "display_b1",
+        "display_b2_backupheater", "display_b3", "display_b4", "display_b5_noisereduction",
+        "display_b6_dhwecomode", "display_b7", "heatermain_b0", "heatermain_b1_error",
+        "heatermain_b2", "heatermain_b3_heating", "heatermain_b4_cooling",
+        "heatermain_b5_pressureloss", "heatermain_b6", "heatermain_b7_warmwater",
+        "displaypressure", "heaterbackup_b0", "heaterbackup_b1_error", "heaterbackup_b2",
+        "heaterbackup_b3_heating", "heaterbackup_b4_cooling", "heaterbackup_b5_pressureloss",
+        "heaterbackup_b6", "heaterbackup_b7_warmwater",
+    ],
     "hmux0.Status01": ["temp", "temp_1", "temp_2", "temp_3", "temp_4", "pumpstate"],
     "bai.Status01": ["temp", "temp_1", "temp_2", "temp_3", "temp_4", "pumpstate"],
     "hmu.CompressorHc": ["runtime", "cycles"],
@@ -1928,6 +1938,47 @@ REGISTER_MAP: dict[str, RegisterMeta] = {
         friendly_name="Clear Error History",
         icon="mdi:delete",
         entity_category="diagnostic",
+    ),
+    "hmu.Status07": RegisterMeta(
+        friendly_name="Display Status",
+        icon="mdi:information",
+        entity_category="diagnostic",
+    ),
+    "hmu.Status07.power": RegisterMeta(
+        friendly_name="Display Compressor Power", device_class="power", unit="%"
+    ),
+    "hmu.Status07.dailyenvyield": RegisterMeta(
+        friendly_name="Display Environmental Yield Today", device_class="energy", unit="kWh"
+    ),
+    "hmu.Status07.display_b5_noisereduction": RegisterMeta(
+        friendly_name="Quiet Mode", entity_type="binary_sensor", icon="mdi:volume-off"
+    ),
+    "hmu.Status07.display_b0_heaterenabled": RegisterMeta(
+        friendly_name="Main Heater Enabled", entity_type="binary_sensor"
+    ),
+    "hmu.Status07.display_b2_backupheater": RegisterMeta(
+        friendly_name="Backup Heater Active", entity_type="binary_sensor"
+    ),
+    "hmu.Status07.display_b6_dhwecomode": RegisterMeta(
+        friendly_name="DHW Eco Mode", entity_type="binary_sensor"
+    ),
+    "hmu.Status07.heatermain_b1_error": RegisterMeta(
+        friendly_name="Comfort Protection Error", entity_type="binary_sensor", entity_category="diagnostic"
+    ),
+    "hmu.Status07.heatermain_b3_heating": RegisterMeta(
+        friendly_name="Heating Active", entity_type="binary_sensor"
+    ),
+    "hmu.Status07.heatermain_b4_cooling": RegisterMeta(
+        friendly_name="Cooling Active", entity_type="binary_sensor"
+    ),
+    "hmu.Status07.heatermain_b5_pressureloss": RegisterMeta(
+        friendly_name="Pressure Loss", entity_type="binary_sensor", entity_category="diagnostic"
+    ),
+    "hmu.Status07.heatermain_b7_warmwater": RegisterMeta(
+        friendly_name="DHW Active", entity_type="binary_sensor"
+    ),
+    "hmu.Status07.displaypressure": RegisterMeta(
+        friendly_name="Display System Pressure", device_class="pressure", unit="bar"
     ),
 }
 

--- a/custom_components/vaillant_ebus/const.py
+++ b/custom_components/vaillant_ebus/const.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from homeassistant.const import Platform
 
 DOMAIN = "vaillant_ebus"
+INTEGRATION_VERSION = "1.7.0"
 CONF_EBUSD_HOST = "ebusd_host"
 CONF_EBUSD_PORT = "ebusd_port"
 CONF_SCAN_INTERVAL = "scan_interval"

--- a/custom_components/vaillant_ebus/coordinator.py
+++ b/custom_components/vaillant_ebus/coordinator.py
@@ -319,7 +319,6 @@ class VaillantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             _LOGGER.info("ebusd version: %s", version)
 
         await self._define_custom_registers()
-
         try:
             graph = await self.discovery.discover()
         except Exception as exc:
@@ -329,6 +328,13 @@ class VaillantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             _LOGGER.warning("ebusd discovery failed: %s", exc)
             return
 
+        # HW5103 Status07 is gated in _define_custom_registers by scan identity.
+        # The first discovery supplies scan identity for hardware-specific additions.
+        self._graph = graph
+        await self._define_custom_registers()
+        # Refresh once so newly defined registers enter the initial graph.
+        if any(key.endswith(".Status07") for key in self._runtime_definitions):
+            graph = await self.discovery.discover()
         await self._apply_discovery_graph(graph, "initial")
         await repairs.async_dismiss_detection_incomplete(self.hass)
         self._schedule_delayed_rediscovery()
@@ -669,6 +675,40 @@ class VaillantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             f",1001ffff0304{date_bytes},value,,IGN:7,,,,value,,EXP,,Wh"
             f",hmu DHW Electric Consumption Today",
         ]
+        hmu = self._graph.nodes.get("hmu") if self._graph else None
+        if hmu and hmu.scan_type.upper() == "HMU00" and hmu.scan_hw == "5103":
+            # Upstream ebusd-configuration PR #614, confirmed for HW5103.
+            # Status07 is active-read because this HW5103 variant polls b511/07;
+            # unsupported hardware returns ERR and remains absent from entities.
+            defines.append(
+                "r,hmu,Status07,Status07,31,08,B511,07"
+                ",power,,UCH,,%,,dailyenvyield,,UIN,10,kWh,"
+                ",display_b0_heaterenabled,,BI0,0=off;1=on,,"
+                ",display_b1,,BI1,0=off;1=on,,"
+                ",display_b2_backupheater,,BI2,0=off;1=on,,"
+                ",display_b3,,BI3,0=off;1=on,,"
+                ",display_b4,,BI4,0=off;1=on,,"
+                ",display_b5_noisereduction,,BI5,0=off;1=on,,"
+                ",display_b6_dhwecomode,,BI6,0=off;1=on,,"
+                ",display_b7,,BI7,0=off;1=on,,"
+                ",heatermain_b0,,BI0,0=off;1=on,,"
+                ",heatermain_b1_error,,BI1,0=off;1=on,,"
+                ",heatermain_b2,,BI2,0=off;1=on,,"
+                ",heatermain_b3_heating,,BI3,0=off;1=on,,"
+                ",heatermain_b4_cooling,,BI4,0=off;1=on,,"
+                ",heatermain_b5_pressureloss,,BI5,0=off;1=on,,"
+                ",heatermain_b6,,BI6,0=off;1=on,,"
+                ",heatermain_b7_warmwater,,BI7,0=off;1=on,,"
+                ",displaypressure,,UCH,30,bar,,"
+                ",heaterbackup_b0,,BI0,0=off;1=on,,"
+                ",heaterbackup_b1_error,,BI1,0=off;1=on,,"
+                ",heaterbackup_b2,,BI2,0=off;1=on,,"
+                ",heaterbackup_b3_heating,,BI3,0=off;1=on,,"
+                ",heaterbackup_b4_cooling,,BI4,0=off;1=on,,"
+                ",heaterbackup_b5_pressureloss,,BI5,0=off;1=on,,"
+                ",heaterbackup_b6,,BI6,0=off;1=on,,"
+                ",heaterbackup_b7_warmwater,,BI7,0=off;1=on,,"
+            )
         defined = 0
         unavailable = 0
         for definition in defines:

--- a/custom_components/vaillant_ebus/dump_service.py
+++ b/custom_components/vaillant_ebus/dump_service.py
@@ -12,9 +12,10 @@ from homeassistant.components import persistent_notification
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 
+from .backend.dump_analysis import CURRENT_DUMP_VERSION, normalize_dump
 from .backend.grab_parser import parse_grab_lines, unknown_telegrams
 from .backend.mapping import REGISTER_MAP
-from .const import DOMAIN, SENSITIVE_FIELDS
+from .const import DOMAIN, INTEGRATION_VERSION, SENSITIVE_FIELDS
 from .coordinator import VaillantCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -201,7 +202,8 @@ async def async_export_discovery_dump(
             "ebusd_version": ebus.version,
             "register_count": len(after_registers or before_registers),
             "grab_duration": grab_duration,
-            "dump_version": 3,
+            "dump_version": CURRENT_DUMP_VERSION,
+            "integration_version": INTEGRATION_VERSION,
         },
         "raw_find_lines": raw_find_lines,
         "before_registers": before_registers,
@@ -212,11 +214,16 @@ async def async_export_discovery_dump(
             telegrams = parse_grab_lines(grab_lines)
             dump_data["labeled_telegrams"] = [t for t in telegrams if t["label"]]
             dump_data["unknown_telegrams"] = unknown_telegrams(grab_lines)
+            dump_data["traffic"] = normalize_dump(dump_data)["traffic"]
         except Exception as exc:  # pragma: no cover - defensive
             _LOGGER.warning("Failed to parse grab telegrams: %s", exc)
     if after_registers:
         dump_data["after_registers"] = after_registers
         dump_data["raw_find_lines_after"] = after_raw_lines
+
+    dump_data["registers"] = normalize_dump(dump_data)["registers"]
+    if after_registers:
+        dump_data["changes"] = normalize_dump(dump_data)["changes"]
 
     await _persist_dump(hass, filepath, dump_data)
     _LOGGER.info("Discovery dump written to %s", filepath)

--- a/custom_components/vaillant_ebus/manifest.json
+++ b/custom_components/vaillant_ebus/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/MarkBovee/vaillant-ebus/issues",
   "requirements": [],
-  "version": "1.6.3"
+  "version": "1.7.0"
 }

--- a/docs/discovery-dump-schema.md
+++ b/docs/discovery-dump-schema.md
@@ -1,0 +1,48 @@
+# Discovery Dump Schema
+
+Discovery dumps are YAML files intended for user support, device comparison, and automated analysis.
+
+## Compatibility
+
+Existing fields remain unchanged:
+
+- `metadata`
+- `raw_find_lines`
+- `before_registers`
+- `after_registers`
+- `raw_find_lines_after`
+- `grab`
+- `labeled_telegrams`
+- `unknown_telegrams`
+
+Current dumps use `metadata.dump_version: 4`. Dumps with no version are treated as legacy version 1. Future versions are preserved and reported as unsupported by the normalizer instead of being interpreted as a different schema.
+
+## Structured fields
+
+Current exports add these fields alongside the raw representation:
+
+- `registers.discovered`: register keys found by ebusd.
+- `registers.mapped`: register keys supplied by `REGISTER_MAP`.
+- `registers.unavailable`: discovered or mapped registers without usable data.
+- `registers.disabled`: mapped registers disabled by default.
+- `changes.new_registers`: registers appearing only in the after snapshot.
+- `changes.changed_registers`: meaningful value changes with before/after values.
+- `changes.disappeared_registers`: registers absent from the after snapshot.
+- `traffic.summary`: grouped known and unknown telegrams with counts, requests, and responses.
+- `traffic.unknown`: grouped telegrams without an ebusd register label.
+
+Sentinel-only changes such as `no data stored`, `empty`, `-`, and `unknown` are not treated as meaningful value changes.
+
+## Analysis API
+
+Use `normalize_dump(dump)` from `custom_components/vaillant_ebus/backend/dump_analysis.py` for both old and new dumps:
+
+```python
+from custom_components.vaillant_ebus.backend.dump_analysis import normalize_dump
+
+normalized = normalize_dump(yaml.safe_load(path.read_text()))
+```
+
+The function does not modify or migrate files on disk. It preserves raw data under `normalized["raw"]` and exposes one stable analysis representation for legacy and current dumps.
+
+Review the generated file for sensitive information before sharing it. The exporter continues to redact sensitive register names and writes this warning into every file.

--- a/docs/live-dump-analysis-2026-09-09.md
+++ b/docs/live-dump-analysis-2026-09-09.md
@@ -1,0 +1,74 @@
+# Live Dump Analysis: 2026-09-09
+
+Source: local Home Assistant export `discovery_dump_2026-09-09_102624.yaml`, captured from the owner's bus with a five-second grab. The source dump is retained outside the repository because it contains live installation data; the relevant capture remains available in the deployment workspace for analysis.
+
+## Strong Assumption: VWZIO Status01
+
+Local unknown telegram:
+
+```text
+request: 1076b5110101
+response: 092e2dfb0fff4c0000ff
+master: 10
+slave: 76
+message: b511
+sub-address: 0101
+```
+
+Upstream evidence:
+
+- `john30/ebusd-configuration#598`, PR: https://github.com/john30/ebusd-configuration/pull/598
+- The PR documents `b511 01` as `Status01` for VWZIO and gives the layout:
+  flow temperature, unavailable return field, outside temperature, unavailable DHW field, storage temperature, pump state, and trailing padding.
+
+Correlation:
+
+- Local response has the same slave (`0x76`), message (`b511`), sub-address (`0101`), and nine-byte response shape.
+- `0x2e` decodes as 46 °C flow using D1C.
+- `0xfb0f` decodes as approximately 15.98 °C outside using D2B/256, matching local `Broadcast.Outsidetemp`.
+- `0x4c` decodes as 76 °C storage using D1C.
+- `0x00` matches pump off and final `0xff` matches the documented trailing padding.
+
+Classification: `strong assumption`.
+
+This is not yet a production entity mapping because the local ebusd configuration exposes the device under numeric circuit `76`, and the integration intentionally suppresses raw address circuits. The mapping should become production-ready only when the VWZIO circuit is exposed with a stable configured circuit name or when a safe scan-type-to-logical-circuit path is added and fixture-covered.
+
+## Upstream Lead: VWZIO DHW Status
+
+Upstream PR #598 also documents passive `b512 0f` as a unified VWZIO DHW status message (`StatusDhw`) with DHW temperature, supply temperature, pressure, and status fields. The local five-second dump contains unknown `b512` traffic, but not the exact `b512 0f` payload required to validate that layout on this bus. Keep discovery-only until a matching local response is captured.
+
+## Discovery-only Candidates
+
+- `76.VWZ_Status01b = 46`: likely an address-specific duplicate/status helper, but no upstream match for this exact name. Do not map from name alone.
+- `ctlv2.YieldTotal = 29577`: plausible aggregate yield, but no local field/layout evidence tying it to the desired energy semantics. Search upstream issue #269 before mapping.
+- `hmu.HcEnvYieldDay` and `hmu.HcEnvYieldTotal`: upstream energy-statistics discussions exist, but local names do not match a confirmed existing metadata entry. Do not alias until layout/unit semantics are correlated.
+- Unknown `b504`, `b507`, `b511`, `b512`, and `b513` telegrams: no matching upstream issue/PR with a local layout correlation was found in this pass. Keep grouped in dump traffic for future captures.
+
+## Quiet Mode Follow-up
+
+Upstream PR #614 documents a useful Quiet-mode signal: `display_b5_noisereduction`
+inside HMU `Status07` (`b511 07`) for `08.hmu.HW5103`:
+
+- PR: https://github.com/john30/ebusd-configuration/pull/614
+- Consolidation PR: https://github.com/john30/ebusd-configuration/pull/660
+- The same `Status07` bit is described as `display_b5_noisereduction` and is
+  correlated with Quiet mode in the upstream HW5103 work.
+
+The three local Quiet captures do not contain a `b511 07` telegram. Their scan
+identity is `HMUX0;SW=0406;HW=0504`, not `HMU00;...;HW=5103`, so the upstream
+layout cannot be applied to this installation. The changing `b511 01` values
+between Quiet on/off captures are general flow/outside/status data and do not
+isolate Quiet mode.
+
+Classification: upstream `confirmed` for HW5103, local hardware `speculative`.
+Keep Quiet mode discovery-only for HMUX0 HW0504 until a local `b511 07` capture
+or a matching upstream layout for that hardware is available. Do not actively
+poll or define `Status07` on this bus without first confirming that the slave
+supports the message and that the read is safe.
+
+## Method Notes
+
+- Unknown telegrams were searched by register/message name, message ID, sub-address, and payload fragments with `tools/search_upstream.sh --comments --all`.
+- Promising upstream PRs were read in full with `gh pr view <number> --comments`.
+- Upstream evidence is not treated as live verification; only the local capture establishes the local response correlation.
+- No CSV, `--configpath`, or runtime register definition was changed from this analysis.

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -501,6 +501,37 @@ async def test_runtime_energy_refreshes_without_reload(monkeypatch) -> None:
         assert values["ebusd"]["hmu.CoolElecConsDay.value"] == "300"
 
 
+async def test_status07_definition_is_gated_to_hm5103() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        c = VaillantCoordinator(_hass(tmpdir), _entry())
+        c.ebus = MagicMock(spec=EbusService)
+        c.ebus.is_connected = True
+        c.ebus.define_register = AsyncMock(return_value="done")
+        c._graph = _make_graph()
+        c._graph.nodes["hmu"].scan_hw = "5103"
+
+        await c._define_custom_registers()
+
+        definitions = [call.args[0] for call in c.ebus.define_register.await_args_list]
+        status07 = next(definition for definition in definitions if ",Status07," in definition)
+        assert ",B511,07," in status07
+        assert "display_b5_noisereduction" in status07
+
+
+async def test_status07_definition_skips_other_hmu_hardware() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        c = VaillantCoordinator(_hass(tmpdir), _entry())
+        c.ebus = MagicMock(spec=EbusService)
+        c.ebus.is_connected = True
+        c.ebus.define_register = AsyncMock(return_value="done")
+        c._graph = _make_graph()
+
+        await c._define_custom_registers()
+
+        definitions = [call.args[0] for call in c.ebus.define_register.await_args_list]
+        assert not any(",Status07," in definition for definition in definitions)
+
+
 async def test_runtime_definitions_roll_over_and_retry_failures(monkeypatch) -> None:
     with tempfile.TemporaryDirectory() as tmpdir:
         c = VaillantCoordinator(_hass(tmpdir), _entry())

--- a/tests/test_dump_analysis.py
+++ b/tests/test_dump_analysis.py
@@ -1,0 +1,125 @@
+"""Tests for backward-compatible discovery dump analysis."""
+
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import sys
+from pathlib import Path
+
+import yaml
+
+BACKEND_PATH = Path(__file__).parents[1] / "custom_components/vaillant_ebus/backend"
+COMPONENT_PATH = BACKEND_PATH.parent
+for name, path in (("vaillant_ebus", COMPONENT_PATH), ("vaillant_ebus.backend", BACKEND_PATH)):
+    package = importlib.util.module_from_spec(importlib.machinery.ModuleSpec(name, None))
+    package.__path__ = [str(path)]
+    sys.modules[name] = package
+
+parser_spec = importlib.util.spec_from_file_location(
+    "vaillant_ebus.backend.grab_parser", BACKEND_PATH / "grab_parser.py"
+)
+assert parser_spec and parser_spec.loader
+parser_module = importlib.util.module_from_spec(parser_spec)
+sys.modules["vaillant_ebus.backend.grab_parser"] = parser_module
+parser_spec.loader.exec_module(parser_module)
+
+spec = importlib.util.spec_from_file_location(
+    "vaillant_ebus.backend.dump_analysis", BACKEND_PATH / "dump_analysis.py"
+)
+assert spec and spec.loader
+module = importlib.util.module_from_spec(spec)
+sys.modules["vaillant_ebus.backend.dump_analysis"] = module
+spec.loader.exec_module(module)
+
+normalize_dump = module.normalize_dump
+group_telegrams = module.group_telegrams
+
+
+def test_legacy_fixture_normalizes_without_migration() -> None:
+    path = Path(__file__).parent / "fixtures/community/arotherm_plus_ctlv2_cooling_discovery.yaml"
+    dump = yaml.safe_load(path.read_text())
+    normalized = normalize_dump(dump)
+
+    assert normalized["dump_version"] == 3
+    assert normalized["version_supported"] is True
+    assert normalized["registers"]["discovered"]
+    assert normalized["raw"]["grab"] == dump["grab"]
+
+
+def test_unversioned_dump_is_treated_as_legacy() -> None:
+    normalized = normalize_dump(
+        {"before_registers": [{"circuit": "hmu", "name": "State", "values": ["on"], "has_data": True}]}
+    )
+
+    assert normalized["dump_version"] == 1
+    assert normalized["version_supported"] is True
+    assert normalized["registers"]["discovered"] == ["hmu.State"]
+
+
+def test_future_version_is_preserved_but_not_assumed_supported() -> None:
+    normalized = normalize_dump({"metadata": {"dump_version": 99}, "before_registers": []})
+
+    assert normalized["dump_version"] == 99
+    assert normalized["version_supported"] is False
+
+
+def test_register_categories_and_sentinel_diff() -> None:
+    before = [{"circuit": "hmu", "name": "State", "values": ["no data stored"], "has_data": False}]
+    after = [
+        {"circuit": "hmu", "name": "State", "values": ["on"], "has_data": True},
+        {"circuit": "hmu", "name": "New", "values": ["1"], "has_data": True, "from_map": True},
+    ]
+    normalized = normalize_dump({"before_registers": before, "after_registers": after})
+
+    assert normalized["registers"]["mapped"] == ["hmu.New"]
+    assert normalized["registers"]["unavailable"] == []
+    assert normalized["changes"]["new_registers"] == ["hmu.New"]
+    assert normalized["changes"]["changed_registers"][0]["key"] == "hmu.State"
+
+
+def test_telegram_grouping_aggregates_counts_and_responses() -> None:
+    grouped = group_telegrams(
+        [
+            {
+                "master": "10", "slave": "08", "msgid": "b510", "sub": "01",
+                "label": None, "request": "10...", "resp": "aa", "count": "2",
+            },
+            {
+                "master": "10", "slave": "08", "msgid": "b510", "sub": "01",
+                "label": None, "request": "10...", "resp": "bb", "count": "3",
+            },
+        ]
+    )
+
+    assert len(grouped) == 1
+    assert grouped[0]["known"] is False
+    assert grouped[0]["occurrence_count"] == 5
+    assert grouped[0]["unique_responses"] == ["aa", "bb"]
+
+
+def test_empty_grab_normalizes_to_empty_traffic() -> None:
+    normalized = normalize_dump({"metadata": {"dump_version": 4}, "before_registers": []})
+
+    assert normalized["traffic"] == {"summary": [], "unknown": []}
+
+
+def test_live_vwzio_status01_candidate_preserves_correlated_telegram() -> None:
+    dump = {
+        "traffic": {
+            "unknown": [
+                {
+                    "msgid": "b511",
+                    "slave": "76",
+                    "sub": "0101",
+                    "unique_requests": ["1076b5110101"],
+                    "unique_responses": ["092e2dfb0fff4c0000ff"],
+                }
+            ]
+        }
+    }
+    status = next(item for item in dump["traffic"]["unknown"] if item["msgid"] == "b511" and item["slave"] == "76")
+
+    assert status["sub"] == "0101"
+    assert status["unique_requests"] == ["1076b5110101"]
+    assert status["unique_responses"] == ["092e2dfb0fff4c0000ff"]

--- a/tests/test_hardening_fixes.py
+++ b/tests/test_hardening_fixes.py
@@ -44,6 +44,8 @@ if not hasattr(_const, "PLATFORMS"):
     _const.PLATFORMS = ("climate", "sensor", "select", "switch", "binary_sensor", "number", "button")
 if not hasattr(_const, "SENSITIVE_FIELDS"):
     _const.SENSITIVE_FIELDS = frozenset()
+if not hasattr(_const, "INTEGRATION_VERSION"):
+    _const.INTEGRATION_VERSION = "1.7.0"
 
 # __init__.py imports voluptuous at module scope and builds the entry
 # selector with vol.Optional; CI does not install it, so stub the parts
@@ -233,6 +235,12 @@ async def test_export_dump_reports_disconnected_ebusd(tmp_path: Path) -> None:
 
     with pytest.raises(HomeAssistantError, match="ebusd is not connected"):
         await DUMP.async_export_discovery_dump(hass, coordinator)
+
+
+def test_dump_redacts_sensitive_register_names() -> None:
+    DUMP.SENSITIVE_FIELDS = {"serial"}
+    assert DUMP._redact("secret-value", "SerialNumber") == "<redacted>"
+    assert DUMP._redact("normal-value", "Status") == "normal-value"
 
 
 # --- multi-entry service dispatch ---


### PR DESCRIPTION
## Summary

- Add backward-compatible discovery dump schema v4 with normalization, register categories, before/after diffs, and grouped known/unknown telegram traffic.
- Add upstream-evidenced HW5103 `Status07` runtime definition, including Quiet mode (`display_b5_noisereduction`) and operating-mode bit sensors.
- Gate `Status07` to `HMU00` / `HW=5103`; unsupported hardware remains unchanged and absent definitions are safe.
- Document live dump analysis and upstream issue/PR evidence workflow.

## Evidence

- `john30/ebusd-configuration#614` documents `Status07` and Quiet-mode bit `display_b5_noisereduction`.
- Local/live dump analysis and community evidence are recorded in `docs/live-dump-analysis-2026-09-09.md`.

## Validation

- `420 passed`
- `.venv/bin/ruff check .`
- `python3 -m compileall -f custom_components/vaillant_ebus/`
- Release zip built and validated without Python bytecode artifacts.
