### PR TITLE
fix: restore DHW controller circuit selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 1.7.1 - 2026-09-09
+
+### Fixed
+
+- **Controller circuit selection.** Prefer the controller carrying climate and
+  DHW registers, and prefer `ctlv`/`basv`/`bass` controllers over `bai` when
+  multiple controller circuits are discovered. This restores DHW entities and
+  writes on installations where `bai` is discovered before `ctlv2`.
+
 ## 1.7.0 - 2026-09-09
 
 ### Added

--- a/custom_components/vaillant_ebus/coordinator.py
+++ b/custom_components/vaillant_ebus/coordinator.py
@@ -187,9 +187,27 @@ class VaillantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     @property
     def heating_circuit(self) -> str:
         if self._graph:
-            for node in self._graph.nodes.values():
-                if node.device_type == DeviceType.HEATING_CONTROLLER:
+            controllers = [
+                node for node in self._graph.nodes.values() if node.device_type == DeviceType.HEATING_CONTROLLER
+            ]
+            # Prefer controller carrying climate/DHW registers. Some boilers
+            # expose a BAI controller before the CTLV controller in discovery.
+            control_registers = {
+                "HwcTempDesired",
+                "HwcStorageTemp",
+                "HwcOpMode",
+                "Z1DayTemp",
+                "Z1OpMode",
+            }
+            for node in controllers:
+                if any(register.rsplit(".", 1)[-1] in control_registers for register in node.registers):
                     return node.circuit
+            for prefix in ("ctlv", "basv", "bass"):
+                for node in controllers:
+                    if node.circuit.lower().startswith(prefix):
+                        return node.circuit
+            if controllers:
+                return controllers[0].circuit
         return self._heating_circuit
 
     @property

--- a/custom_components/vaillant_ebus/manifest.json
+++ b/custom_components/vaillant_ebus/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/MarkBovee/vaillant-ebus/issues",
   "requirements": [],
-  "version": "1.7.0"
+  "version": "1.7.1"
 }

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1039,6 +1039,28 @@ async def test_heating_circuit_from_graph() -> None:
         assert c.heating_circuit == "ctlv2"
 
 
+async def test_heating_circuit_prefers_controller_with_control_registers() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        c = VaillantCoordinator(_hass(tmpdir), _entry())
+        graph = _make_graph()
+        graph.nodes = {
+            "bai": DeviceNode(
+                circuit="bai",
+                device_type=DeviceType.HEATING_CONTROLLER,
+                registers=["bai.FlowTemp", "bai.StorageTemp"],
+                has_data=True,
+            ),
+            "ctlv0": DeviceNode(
+                circuit="ctlv0",
+                device_type=DeviceType.HEATING_CONTROLLER,
+                registers=["ctlv0.HwcTempDesired", "ctlv0.HwcOpMode"],
+                has_data=True,
+            ),
+        }
+        c._graph = graph
+        assert c.heating_circuit == "ctlv0"
+
+
 async def test_heating_circuit_fallback_no_graph() -> None:
     with tempfile.TemporaryDirectory() as tmpdir:
         c = VaillantCoordinator(_hass(tmpdir), _entry())


### PR DESCRIPTION
## Summary
- Prefer the controller carrying climate and DHW registers.
- Prefer ctlv/basv/bass controllers over bai when multiple controllers are discovered.
- Bump integration to v1.7.1 with changelog coverage.

## Validation
- 423 tests passed.
- Ruff passed.
- Compileall passed.
- Live Home Assistant verification: water heater restored to manual with current temperature 31.5 C and target 35.0 C; no vaillant_ebus errors after restart.