### PR TITLE
release: v1.8.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,33 @@ telegrams; capture them with `grab` and mine the unknown ones for new registers.
   unsupported. Search by register name, message ID, sub-address, and distinctive payload
   fragments where useful. Use `tools/search_upstream.sh`, including `--comments` and
   `--all` when appropriate; do not limit the search to the repository's CSV/TSP files.
+- **Unknown-telegram investigation is mandatory, not optional.** For every unknown
+  telegram that is relevant to the user request, create a candidate row before drawing
+  a conclusion. At minimum record: local dump(s), master, slave, message ID, sub-address,
+  request bytes, response length, response bytes, observed state(s), and occurrence
+  count. Deduplicate identical `(slave, message ID, sub-address)` candidates, but retain
+  state-specific payloads and counts.
+- Search each candidate systematically, not only by a guessed register name. Run
+  `tools/search_upstream.sh --comments --all` for: the complete message ID (`b511`),
+  message ID plus sub-address (`b511 0101`), request/payload fragments with and without
+  spaces, slave/device identifiers (`HMUX0`, `HW0504`), and any candidate name found in
+  search results. Also search relevant hardware terms and feature terms separately (for
+  example `Quiet mode`, `NoiseReduction`, `DeicingActive`). A zero-result search is
+  evidence only for that query, never proof that no mapping exists.
+- Search result handling must survive GitHub search rate limits. Cache command output,
+  reduce parallel requests, wait and retry when GitHub returns HTTP 403, and use direct
+  `gh issue view <number> --comments` / `gh pr view <number> --comments` for promising
+  threads. If search remains blocked, report the blocked queries and do not classify the
+  candidate as unsupported solely because of the failure.
+- Inspect every promising issue and PR in full, including comments. Extract exact CSV,
+  TSP, `define -r`, message/sub-address, field layout, hardware, firmware, and live-test
+  evidence. Then compare those fields with the local candidate byte-for-byte: master/slave,
+  message ID, sub-address, response length, field offsets, encoding, and plausible values.
+- Before concluding that no mapping exists, explicitly report the candidate inventory,
+  all upstream query variants attempted, matching threads (or confirmed no matches), and
+  why each candidate is `confirmed`, `strong assumption`, `speculative`, or remains
+  `discovery-only`. Never summarize this as merely “no unknown registers found” when the
+  dump contains unknown telegrams.
 - Treat upstream matches as evidence, not local live verification. Upstream/community
   evidence may be sufficient for production when classified `confirmed` or `strong
   assumption`, hardware scope is explicit, and absent-register behavior is safe. Open

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,17 @@
   normalized register categories, before/after changes, grouped telegrams,
   and backward-compatible legacy normalization.
 
+## 1.8.0 - 2026-09-09
+
+### Added
+
+- **HMUX0 HW0504 telemetry.** Adds fixture- and upstream-backed runtime
+  definitions for `Status00` and `RunDataElPowerConsumption`, gated strictly
+  to HMUX0 HW0504 hardware so other HMU variants are unaffected.
+- **Unknown-telegram investigation workflow.** Documents systematic candidate
+  inventory, upstream issue/PR searches, byte-level correlation, rate-limit
+  handling, and evidence classification for community captures.
+
 ## Unreleased
 
 ### Added

--- a/custom_components/vaillant_ebus/backend/mapping.py
+++ b/custom_components/vaillant_ebus/backend/mapping.py
@@ -43,6 +43,10 @@ ELOBLOCK_GAS_REGISTERS: frozenset[str] = frozenset(
 # Source: ebusd vaillant CSV (08.hmu.csv) + community dumps.
 MULTI_FIELD_FIELDS: dict[str, list[str]] = {
     "hmu.Status01": ["temp", "temp_1", "temp_2", "temp_3", "temp_4", "pumpstate"],
+    "hmu.Status00": [
+        "supplytemp", "waterpressure", "compressormodulation", "compressorstate",
+        "heatingstate", "field6", "defrost", "compressorpower",
+    ],
     "hmu.Status07": [
         "power", "dailyenvyield", "display_b0_heaterenabled", "display_b1",
         "display_b2_backupheater", "display_b3", "display_b4", "display_b5_noisereduction",
@@ -59,6 +63,7 @@ MULTI_FIELD_FIELDS: dict[str, list[str]] = {
     "hmu.CompressorHwc": ["runtime", "cycles"],
     "hmu.RunStatsCompressorHc": ["runtime", "cycles"],
     "hmu.RunStatsCompressorHwc": ["runtime", "cycles"],
+    "hmu.RunDataElPowerConsumption": ["value"],
     # v32 gas boiler (ecoTEC plus via VR32, bai.308523.inc + hcmode.inc).
     # Status01/Status02 share the hmu Status01 layout (hcmode.inc B511).
     # Single-field sensor registers expose only the first field; the trailing
@@ -98,6 +103,31 @@ REGISTER_MAP: dict[str, RegisterMeta] = {
         friendly_name="Status",
         icon="mdi:information",
         entity_category="diagnostic",
+    ),
+    "hmu.Status00": RegisterMeta(
+        friendly_name="Compressor Status",
+        icon="mdi:information",
+        entity_category="diagnostic",
+    ),
+    "hmu.Status00.supplytemp": RegisterMeta(
+        friendly_name="Status Flow Temperature", device_class="temperature", unit="°C"
+    ),
+    "hmu.Status00.waterpressure": RegisterMeta(
+        friendly_name="Status Water Pressure", device_class="pressure", unit="bar"
+    ),
+    "hmu.Status00.compressormodulation": RegisterMeta(
+        friendly_name="Status Compressor Modulation", unit="%"
+    ),
+    "hmu.Status00.compressorstate": RegisterMeta(friendly_name="Status Compressor State"),
+    "hmu.Status00.heatingstate": RegisterMeta(friendly_name="Status Heating State"),
+    "hmu.Status00.defrost": RegisterMeta(
+        friendly_name="Defrost Active", entity_type="binary_sensor"
+    ),
+    "hmu.Status00.compressorpower": RegisterMeta(
+        friendly_name="Status Compressor Power", unit="%"
+    ),
+    "hmu.RunDataElPowerConsumption": RegisterMeta(
+        friendly_name="Electrical Power Consumption", device_class="power", unit="W"
     ),
     "hmu.Status01.temp": RegisterMeta(
         friendly_name="Flow Temperature",

--- a/custom_components/vaillant_ebus/coordinator.py
+++ b/custom_components/vaillant_ebus/coordinator.py
@@ -647,6 +647,22 @@ class VaillantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             # out of entity values.
             "r,hmu,SourceTempInput,SourceTempInput,31,8,B51A,05ff3222"
             ",value,,IGN:3,,,,value,,D2C,,°C,Source temp input",
+            # HMUX0 HW0504 community capture: upstream issue #249 / PR #330
+            # identifies B511/00 as the multi-field compressor status block.
+            # Unsupported variants return an empty response and remain filtered.
+            "r,hmu,Status00,Status00,31,8,B511,00"
+            ",supplytemp,,D2C,,°C,,waterpressure,,UCH,10,bar,,"
+            "compressormodulation,,UCH,,%,,compressorstate,,UCH,"
+            "0=off;1=heating_prerun;4=heating;5=heating_overrun;24=hot_water;"
+            "110=defrosting,,heatingstate,,UCH,8=off;9=heating,,"
+            "field6,,UCH,,,defrost,,UCH,0=inactive;32=active,,"
+            "compressorpower,,percent1,,%,,HMUX0 Status00",
+            # HMUX0 HW0504 community capture: upstream issue #522 identifies
+            # B509/540200/5b0d as diagnostic electrical power in watts.
+            # This is additive; absent hardware returns no data.
+            "r,hmu,RunDataElPowerConsumption,RunDataElPowerConsumption,31,8,B509"
+            ",055402005b0d,value,,IGN:4,,,,value,,EXP,,W,"
+            "HMUX0 electrical power consumption",
             "r5,ctlv2,ManualCoolingStartDate,ManualCoolingStartDate,31,15,B524"
             ",02000000da00,value,,IGN:4,,,,value,,HDA:3",
             "r5,ctlv2,ManualCoolingEndDate,ManualCoolingEndDate,31,15,B524"
@@ -694,6 +710,13 @@ class VaillantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             f",hmu DHW Electric Consumption Today",
         ]
         hmu = self._graph.nodes.get("hmu") if self._graph else None
+        if not (hmu and hmu.scan_type.upper() == "HMUX0" and hmu.scan_hw == "0504"):
+            defines = [
+                definition
+                for definition in defines
+                if ",Status00," not in definition
+                and ",RunDataElPowerConsumption," not in definition
+            ]
         if hmu and hmu.scan_type.upper() == "HMU00" and hmu.scan_hw == "5103":
             # Upstream ebusd-configuration PR #614, confirmed for HW5103.
             # Status07 is active-read because this HW5103 variant polls b511/07;

--- a/custom_components/vaillant_ebus/manifest.json
+++ b/custom_components/vaillant_ebus/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/MarkBovee/vaillant-ebus/issues",
   "requirements": [],
-  "version": "1.7.1"
+  "version": "1.8.0"
 }

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -508,6 +508,7 @@ async def test_status07_definition_is_gated_to_hm5103() -> None:
         c.ebus.is_connected = True
         c.ebus.define_register = AsyncMock(return_value="done")
         c._graph = _make_graph()
+        c._graph.nodes["hmu"].scan_type = "HMU00"
         c._graph.nodes["hmu"].scan_hw = "5103"
 
         await c._define_custom_registers()
@@ -516,6 +517,44 @@ async def test_status07_definition_is_gated_to_hm5103() -> None:
         status07 = next(definition for definition in definitions if ",Status07," in definition)
         assert ",B511,07," in status07
         assert "display_b5_noisereduction" in status07
+
+
+async def test_hmux0_strong_assumption_definitions_are_additive() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        c = VaillantCoordinator(_hass(tmpdir), _entry())
+        c.ebus = MagicMock(spec=EbusService)
+        c.ebus.is_connected = True
+        c.ebus.define_register = AsyncMock(return_value="done")
+        c._graph = _make_graph()
+        c._graph.nodes["hmu"].scan_type = "HMUX0"
+        c._graph.nodes["hmu"].scan_hw = "0504"
+
+        await c._define_custom_registers()
+
+        definitions = [call.args[0] for call in c.ebus.define_register.await_args_list]
+        status00 = next(definition for definition in definitions if ",Status00," in definition)
+        power = next(
+            definition for definition in definitions if ",RunDataElPowerConsumption," in definition
+        )
+        assert ",B511,00," in status00
+        assert "defrost,,UCH,0=inactive;32=active" in status00
+        assert ",B509,055402005b0d," in power
+        assert ",value,,EXP,,W," in power
+
+
+async def test_hmux0_strong_assumption_definitions_skip_other_hardware() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        c = VaillantCoordinator(_hass(tmpdir), _entry())
+        c.ebus = MagicMock(spec=EbusService)
+        c.ebus.is_connected = True
+        c.ebus.define_register = AsyncMock(return_value="done")
+        c._graph = _make_graph()
+
+        await c._define_custom_registers()
+
+        definitions = [call.args[0] for call in c.ebus.define_register.await_args_list]
+        assert not any(",Status00," in definition for definition in definitions)
+        assert not any(",RunDataElPowerConsumption," in definition for definition in definitions)
 
 
 async def test_status07_definition_skips_other_hmu_hardware() -> None:


### PR DESCRIPTION
## Summary

- Add upstream- and fixture-backed HMUX0 HW0504 Status00 telemetry.
- Add HMUX0 electrical power telemetry from B509.
- Gate runtime definitions to HMUX0 HW0504 to avoid affecting other HMU variants.
- Document systematic unknown-telegram investigation workflow.

## Verification

- `ruff check` passes.
- `pytest -q`: 425 passed.
- `compileall` passes.
- Deployed to live Home Assistant and restarted successfully.
- Live hardware is HMU00 SW0522 HW5103; new HMUX0 definitions correctly remain absent, while existing Status01 remains functional.
- No new `vaillant_ebus` warnings or errors after restart.
