### PR TITLE
release: v1.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
   normalized register categories, before/after changes, grouped telegrams,
   and backward-compatible legacy normalization.
 
-## 1.8.0 - 2026-09-09
+## 1.7.2 - 2026-09-09
 
 ### Added
 

--- a/custom_components/vaillant_ebus/manifest.json
+++ b/custom_components/vaillant_ebus/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/MarkBovee/vaillant-ebus/issues",
   "requirements": [],
-  "version": "1.8.0"
+  "version": "1.7.2"
 }


### PR DESCRIPTION
Version correction for the HMUX0 telemetry release.\n\nThis release uses the existing merged HMUX0 telemetry changes and publishes them as v1.7.2 instead of v1.8.0.