### PR TITLE
release: v1.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
   normalized register categories, before/after changes, grouped telegrams,
   and backward-compatible legacy normalization.
 
-## 1.7.2 - 2026-09-09
+## 1.7.3 - 2026-09-09
 
 ### Added
 
@@ -31,6 +31,16 @@
 - **Unknown-telegram investigation workflow.** Documents systematic candidate
   inventory, upstream issue/PR searches, byte-level correlation, rate-limit
   handling, and evidence classification for community captures.
+
+### Fixed
+
+- **Composite register filtering.** Do not expose opaque multi-field values as
+  raw sensors when no field mapping exists, and ignore empty date sentinels such
+  as `-.-.-` so they do not create entities or devices.
+- **Device naming.** Give BAI and solar-controller circuits descriptive device
+  names instead of exposing raw circuit identifiers.
+- **Holiday regression coverage.** Verify future and active holiday periods and
+  controller-side values from HMUX0/CTLV fixtures.
 
 ## Unreleased
 

--- a/custom_components/vaillant_ebus/backend/entity_factory.py
+++ b/custom_components/vaillant_ebus/backend/entity_factory.py
@@ -273,6 +273,18 @@ class EntityFactoryService:
                 raw = graph.raw_registers.get(rk)
                 base_meta = get_meta(circuit, name)
 
+                # Date-like empty sentinel is not a supported entity value;
+                # unlike normal no-data placeholders it cannot become useful
+                # through later polling and should not create a device.
+                if raw and raw.strip() == "-.-.-":
+                    continue
+
+                # Do not expose opaque multi-field ebusd values as a raw sensor.
+                # Registers with an explicit MULTI_FIELD_FIELDS mapping still
+                # generate their parsed field entities below.
+                if raw and ";" in raw and not multi_field_fields(rk) and not base_meta.friendly_name:
+                    continue
+
                 override = overrides.get(rk) or {}
                 meta = _merge_overrides(base_meta, override)
 

--- a/custom_components/vaillant_ebus/backend/models.py
+++ b/custom_components/vaillant_ebus/backend/models.py
@@ -9,7 +9,9 @@ from enum import Enum
 # ebusd values that mean "no usable data" rather than a measured value.
 # Exact-match set; prefix/substring forms are handled by is_no_data_value().
 # "none" is deliberately excluded: RoomZoneMapping legitimately reports it.
-EBUSD_NO_DATA_VALUES: frozenset[str] = frozenset({"", "-", "empty", "unknown", "unavailable"})
+EBUSD_NO_DATA_VALUES: frozenset[str] = frozenset(
+    {"", "-", "empty", "unknown", "unavailable", "-.-.-"}
+)
 
 # Sensor fault statuses from the Vaillant sensor enum (Values_sensor in the
 # upstream ebusd configuration: ok=0, circuit=85, cutoff=170). Registers whose
@@ -201,6 +203,8 @@ def zero_idle_registers(registers: Mapping[str, EbusdRegister], hp_circuit: str 
 CIRCUIT_NAMES: dict[str, str] = {
     "hmu": "Vaillant aroTHERM heat pump",
     "basv": "Vaillant BASV2 Heating Control",
+    "bai": "Vaillant boiler controller",
+    "sc": "Vaillant solar controller",
     "z1": "Zone 1",
     "dhw": "Boiler (DHW)",
     "hc1": "Heating Circuit 1",

--- a/custom_components/vaillant_ebus/manifest.json
+++ b/custom_components/vaillant_ebus/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/MarkBovee/vaillant-ebus/issues",
   "requirements": [],
-  "version": "1.7.2"
+  "version": "1.7.3"
 }

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -383,6 +383,32 @@ async def test_past_sentinel_end_date_reports_no_boost() -> None:
         assert ("ctlv2", "Z2QuickVetoDuration", "3") in calls
 
 
+def test_future_holiday_period_is_not_away_and_active_period_is_away() -> None:
+    from datetime import date, timedelta
+
+    today = date.today()
+    future = {
+        "ctlv2.Z1OpMode.value": "auto",
+        "ctlv2.Z1HolidayStartPeriod.value": (today + timedelta(days=1)).strftime("%d.%m.%Y"),
+        "ctlv2.Z1HolidayEndPeriod.value": (today + timedelta(days=7)).strftime("%d.%m.%Y"),
+    }
+    active = {
+        "ctlv2.Z1OpMode.value": "auto",
+        "ctlv2.Z1HolidayStartPeriod.value": (today - timedelta(days=1)).strftime("%d.%m.%Y"),
+        "ctlv2.Z1HolidayEndPeriod.value": (today + timedelta(days=1)).strftime("%d.%m.%Y"),
+    }
+    with tempfile.TemporaryDirectory() as tmpdir:
+        future_zone = EbusdClimate(
+            _coordinator(tmpdir, _graph_two_zone(), {"ebusd": future}), _entry(), "z1", "ctlv2"
+        )
+        active_zone = EbusdClimate(
+            _coordinator(tmpdir, _graph_two_zone(), {"ebusd": active}), _entry(), "z1", "ctlv2"
+        )
+
+        assert future_zone.preset_mode == "none"
+        assert active_zone.preset_mode == "away"
+
+
 # Intent: boost on a zone with quick-veto support writes the zone's veto registers.
 async def test_zone2_boost_writes_quick_veto() -> None:
     with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/test_community_issue_fixtures.py
+++ b/tests/test_community_issue_fixtures.py
@@ -83,6 +83,18 @@ def test_hmux0_dhw_holiday_capture_keeps_controller_values_and_sentinels_unavail
     assert "ctlv3.PrEnergySumHwc.value" in entities
 
 
+def test_hmux0_holiday_capture_keeps_future_zone_holiday_values() -> None:
+    """Controller holiday dates must survive discovery as ctlv3 values."""
+    dump = load_discovery_dump("community/arotherm_hmux0_dhw_holiday_discovery.yaml")
+    graph = DiscoveryService.build_device_graph(
+        load_find_lines("community/arotherm_hmux0_dhw_holiday_discovery.yaml")
+    )
+
+    assert dump["metadata"]["dump_version"] == 3
+    assert graph.raw_registers["ctlv3.Z1HolidayStartPeriod"] == "26.09.2026"
+    assert graph.raw_registers["ctlv3.Z1HolidayEndPeriod"] == "09.10.2027"
+
+
 @pytest.mark.parametrize(
     "fixture",
     (

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -206,6 +206,13 @@ async def test_coordinator_creates_entity_factory() -> None:
         assert isinstance(c.entity_factory, EntityFactoryService)
 
 
+async def test_device_names_for_bai_and_sc_are_descriptive() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        c = VaillantCoordinator(_hass(tmpdir), _entry())
+        assert c.get_device_info("bai")["name"] == "Vaillant boiler controller"
+        assert c.get_device_info("sc")["name"] == "Vaillant solar controller"
+
+
 async def test_coordinator_seeds_from_cache() -> None:
     with tempfile.TemporaryDirectory() as tmpdir:
         c = VaillantCoordinator(_hass(tmpdir), _entry())

--- a/tests/test_entity_factory.py
+++ b/tests/test_entity_factory.py
@@ -365,6 +365,38 @@ class TestRegisterMapFallback:
         result = svc.generate(graph)
         assert len(result) == 0, "Empty graph → no entities"
 
+    def test_unmapped_composite_register_is_not_exposed_as_raw_sensor(self) -> None:
+        graph = DeviceGraph(
+            nodes={
+                "bai": DeviceNode(
+                    circuit="bai",
+                    device_type=DeviceType.HEATING_CONTROLLER,
+                    registers=["bai.SetModeOverride"],
+                    has_data=True,
+                )
+            },
+            raw_registers={"bai.SetModeOverride": "0;55.0;45.0;-;-;0;0;0;-;0;0;0"},
+            placeholder_registers=set(),
+        )
+
+        assert EntityFactoryService().generate(graph) == []
+
+    def test_empty_date_value_is_not_exposed_as_sensor(self) -> None:
+        graph = DeviceGraph(
+            nodes={
+                "sc": DeviceNode(
+                    circuit="sc",
+                    device_type=DeviceType.SOLAR,
+                    registers=["sc.Date"],
+                    has_data=True,
+                )
+            },
+            raw_registers={"sc.Date": "-.-.-"},
+            placeholder_registers=set(),
+        )
+
+        assert EntityFactoryService().generate(graph) == []
+
 
 class TestBackwardCompatibility:
     """EntityDescription structure compatibility."""

--- a/tests/test_no_data_values.py
+++ b/tests/test_no_data_values.py
@@ -18,7 +18,7 @@ is_no_data_value = MODELS.is_no_data_value
 
 # Exact sentinel values carry no usable data
 def test_exact_sentinels() -> None:
-    for raw in ("", "-", "empty", "unknown", "unavailable"):
+    for raw in ("", "-", "empty", "unknown", "unavailable", "-.-.-"):
         assert is_no_data_value(raw), f"{raw!r} should be no-data"
 
 


### PR DESCRIPTION
## Fixed

- Filter opaque composite register values when no field mapping exists.
- Ignore empty date sentinel `-.-.-` so it cannot create entities or devices.
- Use descriptive names for BAI and solar-controller devices.
- Add holiday-period regression coverage for controller values and away-state calculation.

## Verification

- `pytest -q`: 430 passed.
- `ruff check .` passed.
- `compileall` passed.
- Deployed to live Home Assistant and restarted successfully.
- Live entity writes for Zone 1 and DHW holiday dates were verified by read-back.
