### PR TITLE
docs: order changelog releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## 1.7.3 - 2026-09-09
+
+### Added
+
+- **HMUX0 HW0504 telemetry.** Adds fixture- and upstream-backed runtime
+  definitions for `Status00` and `RunDataElPowerConsumption`, gated strictly
+  to HMUX0 HW0504 hardware so other HMU variants are unaffected.
+- **Unknown-telegram investigation workflow.** Documents systematic candidate
+  inventory, upstream issue/PR searches, byte-level correlation, rate-limit
+  handling, and evidence classification for community captures.
+
+### Fixed
+
+- **Composite register filtering.** Do not expose opaque multi-field values as
+  raw sensors when no field mapping exists, and ignore empty date sentinels such
+  as `-.-.-` so they do not create entities or devices.
+- **Device naming.** Give BAI and solar-controller circuits descriptive device
+  names instead of exposing raw circuit identifiers.
+- **Holiday regression coverage.** Verify future and active holiday periods and
+  controller-side values from HMUX0/CTLV fixtures.
+
+## 1.7.2 - 2026-09-09
+
+### Added
+
+- **HMUX0 HW0504 telemetry.** Adds fixture- and upstream-backed runtime
+  definitions for `Status00` and `RunDataElPowerConsumption`, gated strictly
+  to HMUX0 HW0504 hardware so other HMU variants are unaffected.
+- **Unknown-telegram investigation workflow.** Documents systematic candidate
+  inventory, upstream issue/PR searches, byte-level correlation, rate-limit
+  handling, and evidence classification for community captures.
+
 ## 1.7.1 - 2026-09-09
 
 ### Fixed


### PR DESCRIPTION
Keep newest release sections at top of CHANGELOG so CI extracts correct GitHub release notes. This corrects the ordering for v1.7.2 and v1.7.3.