### PR TITLE
hotfix: v1.7.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 1.7.4 - 2026-09-09
+
+### Fixed
+
+- **Discovered controller circuits.** Resolve legacy `ctlv2`/`hmu` metadata and
+  fallback reads to the actual controller and heat-pump circuits discovered on
+  the bus, including `ctlv1`, `ctlv3`, `basv`, and other variants.
+- **Discovery dump fallbacks.** Do not poll field-level mapping keys as raw
+  registers or emit generic `ctlv2`/`hmu` fallback entries when another circuit
+  is discovered.
+- **Dump metadata.** Read integration version from `manifest.json` and include
+  parsed ebusd `info` data. Addon options such as `seed_mqtt_cfg` and
+  `commandline_options` are explicitly marked unavailable because ebusd does
+  not expose them over TCP.
+
 ## 1.7.3 - 2026-09-09
 
 ### Added

--- a/custom_components/vaillant_ebus/climate.py
+++ b/custom_components/vaillant_ebus/climate.py
@@ -344,7 +344,7 @@ class EbusdClimate(CoordinatorEntity[VaillantCoordinator], ClimateEntity):
             today = datetime.now().date()
             end = today + timedelta(days=days)
             writes = [
-                ("ctlv2", "ManualCoolingEndDate", end.strftime(DATE_FMT)),
+                (self.coordinator.heating_circuit, "ManualCoolingEndDate", end.strftime(DATE_FMT)),
                 (self._circuit, f"{self._zn}OpMode", "auto"),
             ]
             return await self.coordinator.async_write_registers(writes)
@@ -357,7 +357,9 @@ class EbusdClimate(CoordinatorEntity[VaillantCoordinator], ClimateEntity):
     # The controller manages the start date itself.
     async def _cancel_manual_cooling(self) -> bool:
         try:
-            return await self.coordinator.async_write_register("ctlv2", "ManualCoolingEndDate", HOLIDAY_RESET)
+            return await self.coordinator.async_write_register(
+                self.coordinator.heating_circuit, "ManualCoolingEndDate", HOLIDAY_RESET
+            )
         except Exception as exc:
             _LOGGER.exception("cancel manual cooling failed: %s", exc)
             return False

--- a/custom_components/vaillant_ebus/const.py
+++ b/custom_components/vaillant_ebus/const.py
@@ -2,10 +2,24 @@
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
+
 from homeassistant.const import Platform
 
 DOMAIN = "vaillant_ebus"
-INTEGRATION_VERSION = "1.7.0"
+
+
+def _read_manifest_version() -> str:
+    """Read version from manifest so dump metadata cannot drift."""
+    try:
+        manifest = json.loads(Path(__file__).with_name("manifest.json").read_text())
+        return str(manifest["version"])
+    except (OSError, KeyError, TypeError, ValueError):
+        return "unknown"
+
+
+INTEGRATION_VERSION = _read_manifest_version()
 CONF_EBUSD_HOST = "ebusd_host"
 CONF_EBUSD_PORT = "ebusd_port"
 CONF_SCAN_INTERVAL = "scan_interval"

--- a/custom_components/vaillant_ebus/coordinator.py
+++ b/custom_components/vaillant_ebus/coordinator.py
@@ -218,6 +218,14 @@ class VaillantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     return node.circuit
         return "hmu"
 
+    def resolve_register_circuit(self, circuit: str) -> str:
+        """Resolve legacy map circuits to circuits discovered on this bus."""
+        if circuit == "ctlv2":
+            return self.heating_circuit
+        if circuit == "hmu":
+            return self.heat_pump_circuit
+        return circuit
+
     # Active heating zones (zone id -> hosting circuit) derived from the
     # discovery graph. A zone counts as active when it has a room-zone mapping
     # (ZNRoomZoneMapping with a value other than none/empty) or live data on a
@@ -923,8 +931,10 @@ class VaillantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             if not meta.enabled or key in graph_keys:
                 continue
             map_circuit, name = key.split(".", 1)
+            if "." in name:
+                continue
             circuit = self._fallback_candidate(name)
-            _add(circuit or map_circuit, name)
+            _add(circuit or self.resolve_register_circuit(map_circuit), name)
 
         # Placeholder reads: discovered no-data registers whose metadata
         # resolves via the circuit alias (15-minute interval).

--- a/custom_components/vaillant_ebus/dump_service.py
+++ b/custom_components/vaillant_ebus/dump_service.py
@@ -15,6 +15,7 @@ from homeassistant.exceptions import HomeAssistantError
 from .backend.dump_analysis import CURRENT_DUMP_VERSION, normalize_dump
 from .backend.grab_parser import parse_grab_lines, unknown_telegrams
 from .backend.mapping import REGISTER_MAP
+from .backend.models import is_no_data_value
 from .const import DOMAIN, INTEGRATION_VERSION, SENSITIVE_FIELDS
 from .coordinator import VaillantCoordinator
 
@@ -56,14 +57,18 @@ def _parse_find_lines(raw_lines: list[str]) -> list[dict]:
                 "fields": ["value"],
                 "values": [val],
                 "writable": False,
-                "has_data": val not in ("-", "") and not val.startswith(("(empty ", "(ERR", "no data stored")),
+                "has_data": not is_no_data_value(val),
             }
         )
     return result
 
 
 # Collect discovered + REGISTER_MAP registers into serializable dicts
-async def _dump_registers(ebus, seen_keys: set[str] | None = None) -> tuple[list[dict], set[str], list[str]]:
+async def _dump_registers(
+    ebus,
+    seen_keys: set[str] | None = None,
+    circuit_aliases: dict[str, str] | None = None,
+) -> tuple[list[dict], set[str], list[str]]:
     raw_lines = await ebus.find_registers()
     discovered = _parse_find_lines(raw_lines)
     if seen_keys is None:
@@ -83,15 +88,20 @@ async def _dump_registers(ebus, seen_keys: set[str] | None = None) -> tuple[list
         }
         register_list.append(entry)
 
+    aliases = circuit_aliases or {}
     for key, meta in REGISTER_MAP.items():
-        if key in seen_keys:
-            continue
         parts = key.split(".", 1)
         if len(parts) != 2:
             continue
         circuit, name = parts
+        if "." in name:
+            continue
+        target_circuit = aliases.get(circuit, circuit)
+        target_key = f"{target_circuit}.{name}"
+        if key in seen_keys or target_key in seen_keys:
+            continue
         map_entry: dict = {
-            "circuit": circuit,
+            "circuit": target_circuit,
             "name": name,
             "fields": ["value"],
             "values": [None],
@@ -102,10 +112,10 @@ async def _dump_registers(ebus, seen_keys: set[str] | None = None) -> tuple[list
         if not meta.enabled:
             map_entry["disabled"] = True
         try:
-            val = await ebus.read_register(circuit, name)
+            val = await ebus.read_register(target_circuit, name)
             if val:
                 map_entry["values"] = [_redact(val, name)]
-                map_entry["has_data"] = True
+                map_entry["has_data"] = not is_no_data_value(val)
         except Exception:
             pass
         register_list.append(map_entry)
@@ -174,7 +184,11 @@ async def async_export_discovery_dump(
         )
         raise HomeAssistantError(message)
 
-    before_registers, seen, raw_find_lines = await _dump_registers(ebus)
+    aliases = {
+        "ctlv2": coordinator.heating_circuit,
+        "hmu": coordinator.heat_pump_circuit,
+    }
+    before_registers, seen, raw_find_lines = await _dump_registers(ebus, circuit_aliases=aliases)
 
     grab_lines = []
     if grab_duration > 0:
@@ -188,13 +202,14 @@ async def async_export_discovery_dump(
     after_registers: list[dict] = []
     after_raw_lines: list[str] = []
     if grab_duration > 0:
-        after_registers, _, after_raw_lines = await _dump_registers(ebus)
+        after_registers, _, after_raw_lines = await _dump_registers(ebus, circuit_aliases=aliases)
 
     output_dir = hass.config.path(DOMAIN)
     # Directory creation and the YAML write are ordered inside _persist_dump;
     # a fire-and-forget mkdir here used to race the write.
     timestamp = datetime.now().strftime("%Y-%m-%d_%H%M%S")
     filepath = f"{output_dir}/discovery_dump_{timestamp}.yaml"
+    ebusd_info = await ebus.get_info()
 
     dump_data: dict = {
         "metadata": {
@@ -204,6 +219,12 @@ async def async_export_discovery_dump(
             "grab_duration": grab_duration,
             "dump_version": CURRENT_DUMP_VERSION,
             "integration_version": INTEGRATION_VERSION,
+            "ebusd_info": ebusd_info,
+            "ebusd_configuration": {
+                "available": False,
+                "reason": "ebusd info does not expose addon command-line options or seed_mqtt_cfg",
+                "requested_fields": ["seed_mqtt_cfg", "commandline_options"],
+            },
         },
         "raw_find_lines": raw_find_lines,
         "before_registers": before_registers,

--- a/custom_components/vaillant_ebus/manifest.json
+++ b/custom_components/vaillant_ebus/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/MarkBovee/vaillant-ebus/issues",
   "requirements": [],
-  "version": "1.7.3"
+  "version": "1.7.4"
 }


### PR DESCRIPTION
Fix discovered controller circuit resolution for ctlv variants, remove generic fallback noise from discovery dumps, and make dump version metadata manifest-driven. Includes parsed ebusd info metadata; addon-only options are explicitly marked unavailable.