### PR TITLE
fix: enforce discovered circuit resolution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,23 @@
 - `CIRCUIT_NAMES` is the only place for hardcoded circuit-to-label descriptions used by the Home Assistant UI.
 - Values such as `-`, `no data stored`, and `empty` represent unavailable ebusd data. They must not be exposed as normal sensor values.
 - Keep filtering for unsupported circuits, secondary zones, broadcast registers, and no-data devices consistent with the existing discovery and entity-factory logic. Do not create virtual entities for unsupported hardware.
+- **Discovered-circuit resolution is mandatory.** Runtime fallback reads, runtime
+  definitions, dump `REGISTER_MAP` probes, writes, and entity data lookup must
+  target the circuit actually discovered on the bus. Resolve logical metadata
+  aliases through the `DeviceGraph` and scan identity (for example `ctlv1`,
+  `ctlv3`, `basv3`, or another controller), never by assuming `ctlv2`, `hmu`,
+  `bai`, or a numeric circuit. This must work for every supported controller and
+  heat-pump variant.
+- **Field entries are not ebusd registers.** Mapping keys such as
+  `Status01.temp`, `Status01.pumpstate`, or `Status07.displaypressure` are
+  parsed fields of a parent register, not independent registers to poll or
+  include in discovery dumps. Strip field suffixes before fallback reads and
+  dump probes; resolve and read only parent register names.
+- **No hardcoded hardware workaround for circuit aliases.** A new device or
+  firmware variant must be supported by scan metadata and graph-driven alias
+  resolution, with fixture coverage for the discovered circuit and absent-path
+  coverage. Do not add another literal `ctlvN`, `hmu`, or `bai` fallback for one
+  user's hardware.
 
 ## Runtime-Defined Registers
 

--- a/custom_components/vaillant_ebus/backend/entity_factory.py
+++ b/custom_components/vaillant_ebus/backend/entity_factory.py
@@ -271,6 +271,10 @@ class EntityFactoryService:
 
                 circuit, name = rk.split(".", 1)
                 raw = graph.raw_registers.get(rk)
+                # Keys containing a second dot are parsed fields of a parent
+                # register, not standalone ebusd registers.
+                if "." in name:
+                    continue
                 base_meta = get_meta(circuit, name)
 
                 # Date-like empty sentinel is not a supported entity value;

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -343,6 +343,21 @@ async def test_heat_pump_circuit_resolves_hmux0() -> None:
         assert c.heating_circuit == "ctlv3"
 
 
+async def test_legacy_register_aliases_resolve_to_discovered_circuits() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        c = VaillantCoordinator(_hass(tmpdir), _entry())
+        c._graph = _make_graph()
+        assert c.resolve_register_circuit("ctlv2") == "ctlv2"
+        assert c.resolve_register_circuit("hmu") == "hmu"
+
+        controller = c._graph.nodes.pop("ctlv2")
+        controller.circuit = "ctlv3"
+        controller.registers = ["ctlv3.Z1OpMode"]
+        controller.scan_type = "CTLV3"
+        c._graph.nodes["ctlv3"] = controller
+        assert c.resolve_register_circuit("ctlv2") == "ctlv3"
+
+
 # Intent: re-run discovery once after ebusd has had time to populate live values.
 async def test_connect_schedules_one_delayed_rediscovery() -> None:
     with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/test_entity_factory.py
+++ b/tests/test_entity_factory.py
@@ -365,6 +365,22 @@ class TestRegisterMapFallback:
         result = svc.generate(graph)
         assert len(result) == 0, "Empty graph → no entities"
 
+    def test_field_entry_is_not_treated_as_register(self) -> None:
+        graph = DeviceGraph(
+            nodes={
+                "ctlv3": DeviceNode(
+                    circuit="ctlv3",
+                    device_type=DeviceType.HEATING_CONTROLLER,
+                    registers=["ctlv3.Status01.temp"],
+                    has_data=True,
+                )
+            },
+            raw_registers={"ctlv3.Status01.temp": "21.5"},
+            placeholder_registers=set(),
+        )
+
+        assert EntityFactoryService().generate(graph) == []
+
     def test_unmapped_composite_register_is_not_exposed_as_raw_sensor(self) -> None:
         graph = DeviceGraph(
             nodes={


### PR DESCRIPTION
Complete v1.7.4 follow-up.\n\n- Record discovered-circuit resolution and field-entry rules in AGENTS.md.\n- Add regression coverage for legacy alias resolution and field entries.\n- Keep runtime fallback, dump probes, writes, and entity lookup graph-driven.