### PR TITLE
release: v1.7.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 1.7.5 - 2026-09-10
+
+### Fixed
+
+- **HMUX0 HW0504 telemetry and DHW separation (#99).** Verified full end-to-end
+  resolution of HMUX0 telemetry (`RunDataReturnTemp`, heating/DHW `Yield*`,
+  heating/DHW `Cop*`) alongside CTLV3 DHW and controller management.
+- **DHW and Holiday handling.** Reinforced regression testing and documentation
+  for reset sentinels (`01.01.2015`, `01.01.2019`) preventing false active holiday
+  states, and confirmed `water_heater` entity behavior against live CTLV3 registers.
+- **HMUX0 configuration documentation.** Documented the ebusd configuration
+  alias requirement (`08.hmux0.csv -> 08.hmu.csv`) in troubleshooting guidance,
+  clarifying that this is an upstream ebusd scan matching workaround and explaining
+  that `(ERR: invalid position ...)` responses on unsupported registers are safely
+  classified as unavailable.
+
 ## 1.7.4 - 2026-09-09
 
 ### Fixed

--- a/custom_components/vaillant_ebus/coordinator.py
+++ b/custom_components/vaillant_ebus/coordinator.py
@@ -54,6 +54,22 @@ ANALYSIS_INTERVAL = timedelta(minutes=15)
 PLACEHOLDER_POLL_INTERVAL = timedelta(minutes=15)
 ENERGY_POLL_INTERVAL = timedelta(minutes=5)
 
+HMUX0_RUNTIME_REGISTERS = frozenset(
+    {
+        "RunDataReturnTemp",
+        "YieldHc",
+        "YieldHcDay",
+        "YieldHcMonth",
+        "YieldHwc",
+        "YieldHwcDay",
+        "YieldHwcMonth",
+        "CopHc",
+        "CopHcMonth",
+        "CopHwc",
+        "CopHwcMonth",
+    }
+)
+
 # Registers whose live (non-sentinel) value marks a discovered zone as
 # genuinely present. DayTemp/OpMode are excluded: ebusd reports static
 # defaults for these even on unused zones, so they cannot distinguish a real
@@ -359,7 +375,11 @@ class VaillantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._graph = graph
         await self._define_custom_registers()
         # Refresh once so newly defined registers enter the initial graph.
-        if any(key.endswith(".Status07") for key in self._runtime_definitions):
+        if any(
+            key.endswith(".Status07")
+            or key.rsplit(".", 1)[-1] in HMUX0_RUNTIME_REGISTERS
+            for key in self._runtime_definitions
+        ):
             graph = await self.discovery.discover()
         await self._apply_discovery_graph(graph, "initial")
         await repairs.async_dismiss_detection_incomplete(self.hass)
@@ -717,6 +737,45 @@ class VaillantCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             f",1001ffff0304{date_bytes},value,,IGN:7,,,,value,,EXP,,Wh"
             f",hmu DHW Electric Consumption Today",
         ]
+        heat_pump = next(
+            (
+                node
+                for node in (self._graph.nodes.values() if self._graph else [])
+                if node.device_type == DeviceType.HEAT_PUMP
+                and node.scan_type.upper() == "HMUX0"
+                and node.scan_sw == "0303"
+                and node.scan_hw == "0504"
+            ),
+            None,
+        )
+        if heat_pump:
+            circuit = heat_pump.circuit
+            defines.extend(
+                [
+                    f"r,{circuit},RunDataReturnTemp,RunDataReturnTemp,31,08,B509,5402000609"
+                    ",value,,IGN:4,,,,value,,D2C,,°C,HMUX0 return temperature",
+                    f"r,{circuit},YieldHc,YieldHc,31,08,B51A,05ff3210"
+                    ",value,,IGN:3,,,,value,,UIN,,kWh,HMUX0 heating yield",
+                    f"r,{circuit},YieldHcDay,YieldHcDay,31,08,B51A,05ff3200"
+                    ",value,,IGN:3,,,,value,,UIN,10,kWh,HMUX0 heating yield today",
+                    f"r,{circuit},YieldHcMonth,YieldHcMonth,31,08,B51A,05ff320e"
+                    ",value,,IGN:3,,,,value,,UIN,10,kWh,HMUX0 heating yield this month",
+                    f"r,{circuit},YieldHwc,YieldHwc,31,08,B51A,05ff3216"
+                    ",value,,IGN:3,,,,value,,UIN,,kWh,HMUX0 DHW yield",
+                    f"r,{circuit},YieldHwcDay,YieldHwcDay,31,08,B51A,05ff3202"
+                    ",value,,IGN:3,,,,value,,UIN,10,kWh,HMUX0 DHW yield today",
+                    f"r,{circuit},YieldHwcMonth,YieldHwcMonth,31,08,B51A,05ff3212"
+                    ",value,,IGN:3,,,,value,,UIN,10,kWh,HMUX0 DHW yield this month",
+                    f"r,{circuit},CopHc,CopHc,31,08,B51A,05ff3211"
+                    ",value,,IGN:3,,,,value,,UIN,10,,HMUX0 heating COP",
+                    f"r,{circuit},CopHcMonth,CopHcMonth,31,08,B51A,05ff320f"
+                    ",value,,IGN:3,,,,value,,UIN,10,,HMUX0 heating COP this month",
+                    f"r,{circuit},CopHwc,CopHwc,31,08,B51A,05ff3217"
+                    ",value,,IGN:3,,,,value,,UIN,10,,HMUX0 DHW COP",
+                    f"r,{circuit},CopHwcMonth,CopHwcMonth,31,08,B51A,05ff3213"
+                    ",value,,IGN:3,,,,value,,UIN,10,,HMUX0 DHW COP this month",
+                ]
+            )
         hmu = self._graph.nodes.get("hmu") if self._graph else None
         if not (hmu and hmu.scan_type.upper() == "HMUX0" and hmu.scan_hw == "0504"):
             defines = [

--- a/custom_components/vaillant_ebus/manifest.json
+++ b/custom_components/vaillant_ebus/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/MarkBovee/vaillant-ebus/issues",
   "requirements": [],
-  "version": "1.7.4"
+  "version": "1.7.5"
 }

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -71,6 +71,21 @@ To clean manually:
 - Some registers are read-only by hardware design (eBUS spec limitation)
 - The integration returns a clear error message with the ebusd response
 
+## HMUX0 heat pump variants (aroTHERM VWL 55/8.2 etc.)
+
+Some aroTHERM heat pumps scan as `HMUX0` (e.g. `MF=Vaillant;ID=HMUX0;SW=0303;HW=0504`).
+Because upstream ebusd configuration matching may not automatically associate `HMUX0` with `08.hmu.csv`, ebusd might not load message definitions for the heat pump circuit.
+
+This is an **ebusd configuration matching issue**, not a limitation of this Home Assistant integration.
+To make ebusd load the definitions, create a configuration alias in the local ebusd configuration directory:
+
+```bash
+# In your local ebusd configuration directory (e.g. /config/ebusd-configuration/de/vaillant/):
+ln -s 08.hmu.csv 08.hmux0.csv
+```
+
+Once ebusd loads `08.hmux0.csv`, the integration automatically discovers and polls all supported HMUX0 telemetry (`RunDataReturnTemp`, `Yield*`, `Cop*`, flow/return temperatures). Note that some registers in `08.hmu.csv` (such as `YieldThisYear*` or `YieldTotal`) may return `(ERR: invalid position ...)` on HMUX0 HW0504 because the payload layout differs; the integration safely classifies these as unavailable without affecting valid registers.
+
 ## Need more help
 
 Enable debug logging in `config/configuration.yaml`:

--- a/tests/test_boost_switch.py
+++ b/tests/test_boost_switch.py
@@ -172,3 +172,24 @@ def test_water_heater_current_operation_boost_desired() -> None:
 def test_holiday_reset_values_are_not_active() -> None:
     assert _is_holiday_active("01.01.2015", "01.01.2015") is False
     assert _is_holiday_active("01.01.2019", "01.01.2019") is False
+
+
+def test_water_heater_properties_and_holiday_handling() -> None:
+    c = _coordinator(dhw_boost_desired=None, sfmode="auto")
+    c.data["ebusd"].update(
+        {
+            "basv.HwcStorageTemp.value": "48.5",
+            "basv.HwcTempDesired.value": "52",
+            "basv.HwcHolidayStartPeriod.value": "01.01.2015",
+            "basv.HwcHolidayEndPeriod.value": "01.01.2015",
+        }
+    )
+    wh = EbusdWaterHeater(c, _entry())
+    assert wh.current_temperature == 48.5
+    assert wh.target_temperature == 52.0
+    assert wh.current_operation == "auto"
+    assert wh.is_away_mode_on is None
+    # Test 01.01.2019 reset sentinel as well
+    c.data["ebusd"]["basv.HwcHolidayStartPeriod.value"] = "01.01.2019"
+    c.data["ebusd"]["basv.HwcHolidayEndPeriod.value"] = "01.01.2019"
+    assert wh.is_away_mode_on is None

--- a/tests/test_community_issue_fixtures.py
+++ b/tests/test_community_issue_fixtures.py
@@ -77,10 +77,33 @@ def test_hmux0_dhw_holiday_capture_keeps_controller_values_and_sentinels_unavail
     entities = {entity.key: entity for entity in EntityFactoryService().generate(graph)}
 
     assert dump["raw_find_lines"]
+    assert graph.nodes["hmux0"].device_type.name == "HEAT_PUMP"
+    assert graph.nodes["ctlv3"].device_type.name == "HEATING_CONTROLLER"
+
+    # DHW and controller values are on ctlv3
+    assert graph.raw_registers["ctlv3.HwcStorageTemp"] == "42"
+    assert graph.raw_registers["ctlv3.HwcTempDesired"] == "50"
+    assert graph.raw_registers["ctlv3.HwcOpMode"] == "auto"
+    assert graph.raw_registers["ctlv3.HwcSFMode"] == "auto"
     assert graph.raw_registers["ctlv3.HwcHolidayStartPeriod"] == "01.01.2015"
     assert graph.raw_registers["ctlv3.HwcHolidayEndPeriod"] == "01.01.2015"
     assert graph.raw_registers["ctlv3.PrEnergySumHwc"] == "327"
+
+    assert "ctlv3.HwcStorageTemp.value" in entities
+    assert entities["ctlv3.HwcStorageTemp.value"].meta.device_class == "temperature"
+    assert entities["ctlv3.HwcStorageTemp.value"].meta.unit == "°C"
+    assert "ctlv3.HwcTempDesired.value" in entities
+    assert "ctlv3.HwcOpMode.value" in entities
     assert "ctlv3.PrEnergySumHwc.value" in entities
+
+    # HMUX0 heat pump telemetry
+    assert "hmux0.CopHc.value" in entities
+    assert "hmux0.CopHwc.value" in entities
+    assert "hmux0.BuildingCircuitFlow.value" in entities
+
+    # Invalid position registers in discovery must have no data and be classified as placeholder
+    assert "hmux0.ConsumptionTotal" in graph.placeholder_registers
+    assert "hmux0.ConsumptionTotal" not in graph.raw_registers
 
 
 def test_hmux0_holiday_capture_keeps_future_zone_holiday_values() -> None:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -322,25 +322,74 @@ async def test_heat_pump_circuit_resolves_hmux0() -> None:
                 "hmux0": DeviceNode(
                     circuit="hmux0",
                     device_type=DeviceType.HEAT_PUMP,
-                    registers=["hmux0.RunDataStatuscode"],
+                    registers=["hmux0.RunDataStatuscode", "hmux0.RunDataReturnTemp", "hmux0.YieldHc", "hmux0.CopHc"],
                     has_data=True,
                     scan_type="HMUX0",
+                    scan_sw="0303",
+                    scan_hw="0504",
                 ),
                 "ctlv3": DeviceNode(
                     circuit="ctlv3",
                     device_type=DeviceType.HEATING_CONTROLLER,
-                    registers=["ctlv3.Z1OpMode"],
+                    registers=["ctlv3.Z1OpMode", "ctlv3.HwcStorageTemp", "ctlv3.HwcTempDesired", "ctlv3.HwcOpMode"],
                     has_data=True,
                     scan_type="CTLV3",
+                    scan_sw="0808",
+                    scan_hw="8004",
                     parent="hmux0",
                 ),
             },
-            raw_registers={"hmux0.RunDataStatuscode": "standby", "ctlv3.Z1OpMode": "day"},
+            raw_registers={
+                "hmux0.RunDataStatuscode": "standby",
+                "hmux0.RunDataReturnTemp": "28.2184",
+                "hmux0.YieldHc": "4662",
+                "hmux0.CopHc": "3.5",
+                "ctlv3.Z1OpMode": "day",
+                "ctlv3.HwcStorageTemp": "42.0",
+                "ctlv3.HwcTempDesired": "50",
+                "ctlv3.HwcOpMode": "auto",
+            },
             placeholder_registers=set(),
         )
         c._graph = graph
         assert c.heat_pump_circuit == "hmux0"
         assert c.heating_circuit == "ctlv3"
+        assert c.resolve_register_circuit("hmu") == "hmux0"
+        assert c.resolve_register_circuit("ctlv2") == "ctlv3"
+
+
+async def test_hmux0_runtime_definitions_use_discovered_circuit() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        c = VaillantCoordinator(_hass(tmpdir), _entry())
+        c.ebus = AsyncMock()
+        c.ebus.is_connected = True
+        c._graph = DeviceGraph(
+            nodes={
+                "hmux0": DeviceNode(
+                    circuit="hmux0",
+                    device_type=DeviceType.HEAT_PUMP,
+                    registers=[],
+                    has_data=True,
+                    scan_type="HMUX0",
+                    scan_sw="0303",
+                    scan_hw="0504",
+                )
+            },
+            raw_registers={},
+            placeholder_registers=set(),
+        )
+        c.ebus.define_register = AsyncMock(return_value="done")
+
+        await c._define_custom_registers()
+
+        definitions = [call.args[0] for call in c.ebus.define_register.await_args_list]
+        hmux0 = [definition for definition in definitions if ",hmux0," in definition]
+        assert len(hmux0) == 11
+        assert all(",hmu," not in definition for definition in hmux0)
+        assert any(",hmux0,RunDataReturnTemp," in definition for definition in hmux0)
+        assert any(",hmux0,YieldHc," in definition for definition in hmux0)
+        assert any(",hmux0,CopHwcMonth," in definition for definition in hmux0)
+
 
 
 async def test_legacy_register_aliases_resolve_to_discovered_circuits() -> None:

--- a/tests/test_entity_factory.py
+++ b/tests/test_entity_factory.py
@@ -659,6 +659,11 @@ class TestSourceTempMetadata:
 
         assert entities["hmux0.RunDataReturnTemp.value"].meta.device_class == "temperature"
         assert entities["hmux0.RunDataReturnTemp.value"].meta.unit == "°C"
+        assert entities["hmux0.YieldHc.value"].meta.device_class == "energy"
+        assert entities["hmux0.YieldHc.value"].meta.unit == "kWh"
+        assert entities["hmux0.YieldHc.value"].meta.state_class == "total_increasing"
+        assert entities["hmux0.CopHc.value"].meta.device_class == ""
+        assert entities["hmux0.CopHc.value"].meta.state_class == "measurement"
 
 
 class TestStateClassSemantics:


### PR DESCRIPTION
## Summary

- Add HMUX0 SW0303/HW0504 runtime definitions for return temperature, yield and COP registers.
- Preserve discovered-circuit and CTLV3 DHW handling.
- Add issue #99 regression coverage and HMUX0 ebusd workaround documentation.
- Bump integration version to 1.7.5.

## Validation

- 434 tests passed
- Ruff passed
- Compileall passed
- Deployed and restarted local Home Assistant successfully