### PR TITLE
release: v1.7.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 1.7.6 - 2026-09-10
+
+### Fixed
+
+- **Deterministic scan-metadata matching.** Scan `TYPE`/`SW`/`HW` entries are
+  now bound to circuits through an explicit evidence priority: exact normalized
+  name, then digit-stripped family match, then a stable family-prefix fallback.
+  A scan entry is consumed by at most one circuit, and ambiguous associations
+  (several sibling circuits of one family, or several scan variants of one
+  family) are intentionally left unmatched instead of guessed. This prevents
+  placeholder circuits (for example a generic `ctlv2` probe circuit on an
+  HMUX0/CTLV3 bus) from silently receiving another circuit's scan metadata,
+  which affected device naming and classification on mixed installs.
+
 ## 1.7.5 - 2026-09-10
 
 ### Fixed

--- a/custom_components/vaillant_ebus/backend/discovery_service.py
+++ b/custom_components/vaillant_ebus/backend/discovery_service.py
@@ -387,41 +387,115 @@ def _name_belongs_to_sub(name: str, sub_name: str) -> bool:
     return False
 
 
+# Normalize a circuit name or scan TYPE for comparison: case-insensitive and
+# underscore-insensitive (VR_71 ↔ VR71). Deliberately conservative — no other
+# characters or digits are stripped, so HMU, HMUX0 and HMU00 remain
+# distinguishable from each other.
+def _normalize_name(name: str) -> str:
+    return name.replace("_", "").lower()
+
+
+# Stable family of a circuit name or scan TYPE: trailing variant digits
+# removed (HMU00 → hmu, HMUX0 → hmux, BASV3 → basv). Digits inside the name
+# are kept so related families (hmu vs hmux) never collapse into one.
+def _name_family(name: str) -> str:
+    return _normalize_name(name).rstrip("0123456789")
+
+
 # Associate ebusd scan metadata with the discovered circuits it describes.
+#
+# Matching runs from strongest to weakest evidence and a circuit is bound at
+# most once:
+#   1. NETX2 → Broadcast (fixed relationship in the ebusd configuration).
+#   2. Exact normalized TYPE ↔ circuit match (HMUX0 ↔ hmux0, CTLV3 ↔ ctlv3).
+#   3. Family match after stripping variant digits (HMU00 ↔ hmu, BASV3 ↔ basv).
+#   4. Stable family-prefix fallback (circuit starts with the scan family).
+# A scan entry is consumed by at most one circuit. Ambiguous associations are
+# intentionally left unmatched instead of guessed: scan metadata drives device
+# naming, classification and hardware-gated runtime definitions (HMUX0 SW/HW),
+# so a wrong assignment poisons the graph. Identical repeated scan lines (find
+# output may repeat them) collapse to the first occurrence, keeping the result
+# deterministic regardless of duplication.
 def _match_scan_to_circuits(
     scan_entries: list[tuple[str, str, str, str]],
     regs_by_circuit: dict[str, list[str]],
 ) -> dict[str, tuple[str, str, str]]:
-    result: dict[str, tuple[str, str, str]] = {}
     circuit_names = [c for c in regs_by_circuit if not c.lower().startswith("scan")]
 
-    def _norm(name: str) -> str:
-        return name.replace("_", "").lower()
+    scans: list[tuple[str, str, str]] = []
+    seen: set[str] = set()
+    for _addr, scan_type, scan_sw, scan_hw in scan_entries:
+        if scan_type.lower() in seen:
+            continue
+        seen.add(scan_type.lower())
+        scans.append((scan_type, scan_sw, scan_hw))
 
-    # Prefer the most specific match. Exact scan-type ↔ circuit first.
-    for scan_addr, scan_type, scan_sw, scan_hw in scan_entries:
-        # Direct mapping for NETX2 → Broadcast
+    result: dict[str, tuple[str, str, str]] = {}
+
+    # Priority 1: NETX2 always describes the Broadcast pseudo-circuit.
+    for scan_type, scan_sw, scan_hw in scans:
         if scan_type.lower() == "netx2":
             result["Broadcast"] = (scan_type, scan_sw, scan_hw)
+
+    # Priority 2: exact normalized match. Skipped when several circuits share
+    # the normalized name — assigning one of them would be a coin flip.
+    for scan_type, scan_sw, scan_hw in scans:
+        if scan_type.lower() == "netx2":
             continue
-        for ckt in circuit_names:
-            if _norm(ckt) == _norm(scan_type):
-                result[ckt] = (scan_type, scan_sw, scan_hw)
-                break
-    # Fall back to prefix matching for circuits with no exact match, giving
-    # each circuit the longest matching scan prefix.
-    for ckt in circuit_names:
-        if ckt in result:
+        candidates = [c for c in circuit_names if _normalize_name(c) == _normalize_name(scan_type)]
+        if len(candidates) == 1 and candidates[0] not in result:
+            result[candidates[0]] = (scan_type, scan_sw, scan_hw)
+
+    claimed = {info[0].lower() for info in result.values()}
+
+    # Priority 3: family match on digit-stripped names (HMU00 ↔ hmu, BASV3 ↔
+    # basv). Only when exactly one circuit carries the family and exactly one
+    # unclaimed scan shares it; a family shared by several circuits (or a
+    # family with several scan variants) stays unmatched.
+    unmatched = [c for c in circuit_names if c not in result]
+    family_counts: dict[str, int] = {}
+    for ckt in unmatched:
+        fam = _name_family(ckt)
+        if fam:
+            family_counts[fam] = family_counts.get(fam, 0) + 1
+    for ckt in unmatched:
+        fam = _name_family(ckt)
+        if not fam or family_counts.get(fam, 0) != 1:
             continue
-        best = None
-        for scan_addr, scan_type, scan_sw, scan_hw in scan_entries:
-            if scan_type.lower() == "netx2":
-                continue
-            prefix = _norm(scan_type).rstrip("0123456789")
-            if _norm(ckt).startswith(prefix) and (best is None or len(prefix) > len(best[0])):
-                best = (prefix, scan_type, scan_sw, scan_hw)
-        if best is not None:
-            result[ckt] = (best[1], best[2], best[3])
+        candidates = [
+            (t, sw, hw)
+            for t, sw, hw in scans
+            if t.lower() != "netx2" and t.lower() not in claimed and _name_family(t) == fam
+        ]
+        if len(candidates) == 1:
+            result[ckt] = candidates[0]
+            claimed.add(candidates[0][0].lower())
+
+    # Priority 4: prefix fallback for circuits whose name only shares the scan
+    # family as a prefix. Used only when exactly one unclaimed scan and one
+    # unmatched circuit claim each other; anything broader stays unmatched.
+    for scan_type, scan_sw, scan_hw in scans:
+        if scan_type.lower() == "netx2" or scan_type.lower() in claimed:
+            continue
+        fam = _name_family(scan_type)
+        if not fam:
+            continue
+        # Multiple unclaimed variants of the same family (e.g. CTLV2 and
+        # CTLV3) cannot be told apart by a bare prefix — skip the family.
+        same_family = [
+            t for t, _sw, _hw in scans if t.lower() != "netx2" and t.lower() not in claimed and _name_family(t) == fam
+        ]
+        if len(same_family) != 1:
+            continue
+        claimants = [
+            c
+            for c in circuit_names
+            if c not in result and _normalize_name(c).startswith(fam)
+        ]
+        if len(claimants) == 1:
+            result[claimants[0]] = (scan_type, scan_sw, scan_hw)
+            claimed.add(scan_type.lower())
+
     return result
 
 

--- a/custom_components/vaillant_ebus/manifest.json
+++ b/custom_components/vaillant_ebus/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/MarkBovee/vaillant-ebus/issues",
   "requirements": [],
-  "version": "1.7.5"
+  "version": "1.7.6"
 }

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -642,6 +642,71 @@ async def test_status07_definition_skips_other_hmu_hardware() -> None:
         assert not any(",Status07," in definition for definition in definitions)
 
 
+# End-to-end: issue #99 find output → DeviceGraph scan metadata → runtime
+# hardware detection. The HMUX0 yield/COP definitions must activate from the
+# discovered scan identity (HMUX0;0303;0504) without any circuit-name hack.
+async def test_hmux0_runtime_definitions_use_issue99_fixture_metadata() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        graph = DISCOVERY.DiscoveryService.build_device_graph(
+            load_find_lines("community/arotherm_hmux0_dhw_holiday_discovery.yaml")
+        )
+        hmux0 = graph.nodes.get("hmux0")
+        assert hmux0 is not None
+        assert hmux0.device_type == DeviceType.HEAT_PUMP
+        assert hmux0.scan_type == "HMUX0"
+        assert hmux0.scan_sw == "0303"
+        assert hmux0.scan_hw == "0504"
+        ctlv3 = graph.nodes["ctlv3"]
+        assert ctlv3.device_type == DeviceType.HEATING_CONTROLLER
+        assert ctlv3.scan_type == "CTLV3"
+        assert ctlv3.scan_sw == "0808"
+        assert ctlv3.scan_hw == "8004"
+
+        c = VaillantCoordinator(_hass(tmpdir), _entry())
+        c.ebus = MagicMock(spec=EbusService)
+        c.ebus.is_connected = True
+        c.ebus.define_register = AsyncMock(return_value="done")
+        c._graph = graph
+
+        await c._define_custom_registers()
+
+        definitions = [call.args[0] for call in c.ebus.define_register.await_args_list]
+        hmux0_defs = [definition for definition in definitions if ",hmux0," in definition]
+        assert len(hmux0_defs) == 11
+        assert all(",hmu," not in definition for definition in hmux0_defs)
+        assert any(",hmux0,RunDataReturnTemp," in definition for definition in hmux0_defs)
+        assert any(",hmux0,YieldHc," in definition for definition in hmux0_defs)
+        assert any(",hmux0,CopHwcMonth," in definition for definition in hmux0_defs)
+
+
+# A future HMUX0 firmware (pro7 capture: SW0406/HW0504 on an `hmu` circuit)
+# receives no cross-family scan binding (HMUX0 ≠ hmu), and neither the SW0303-
+# gated yield/COP definitions nor the HMUX0 Status00/power definitions may
+# activate from that combination.
+async def test_hmux0_other_firmware_gets_scan_metadata_without_yield_definitions() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        graph = DISCOVERY.DiscoveryService.build_device_graph(
+            load_find_lines("community/arotherm_pro7_quiet_off_idle_discovery.yaml")
+        )
+        hmu = graph.nodes.get("hmu")
+        assert hmu is not None
+        assert hmu.device_type == DeviceType.HEAT_PUMP
+        assert hmu.scan_type == ""
+
+        c = VaillantCoordinator(_hass(tmpdir), _entry())
+        c.ebus = MagicMock(spec=EbusService)
+        c.ebus.is_connected = True
+        c.ebus.define_register = AsyncMock(return_value="done")
+        c._graph = graph
+
+        await c._define_custom_registers()
+
+        definitions = [call.args[0] for call in c.ebus.define_register.await_args_list]
+        assert not any(",hmux0," in definition for definition in definitions)
+        assert not any(",Status00," in definition for definition in definitions)
+        assert not any(",RunDataElPowerConsumption," in definition for definition in definitions)
+
+
 async def test_runtime_definitions_roll_over_and_retry_failures(monkeypatch) -> None:
     with tempfile.TemporaryDirectory() as tmpdir:
         c = VaillantCoordinator(_hass(tmpdir), _entry())

--- a/tests/test_discovery_service.py
+++ b/tests/test_discovery_service.py
@@ -68,6 +68,184 @@ def test_scan_matching_normalizes_prefix_underscores() -> None:
     assert result["vr_71"] == ("VR71", "0100", "5904")
 
 
+# =============================================================================
+# A2. Scan metadata ↔ circuit matching (unit tests)
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    ("circuit", "scan_type"),
+    [
+        ("hmux0", "HMUX0"),
+        ("ctlv3", "CTLV3"),
+        ("hmu", "HMU"),
+        ("basv", "BASV"),
+        ("ctlv2", "CTLV2"),
+        ("basv2", "BASV2"),
+        ("bass3", "BASS3"),
+    ],
+)
+def test_scan_matching_exact_normalized_names(circuit: str, scan_type: str) -> None:
+    result = match_scan_to_circuits(
+        [("08", scan_type, "0102", "0304")],
+        {circuit: [f"{circuit}.SomeRegister"]},
+    )
+    assert result[circuit] == (scan_type, "0102", "0304")
+
+
+def test_scan_matching_underscore_normalization() -> None:
+    result = match_scan_to_circuits(
+        [("15", "CTLV3", "0808", "8004")],
+        {"ctl_v3": ["ctl_v3.Z1OpMode"]},
+    )
+    assert result["ctl_v3"] == ("CTLV3", "0808", "8004")
+
+
+@pytest.mark.parametrize(
+    ("circuit", "scan_type"),
+    [
+        ("hmu", "HMU00"),
+        ("basv", "BASV2"),
+        ("vwz", "VWZ00"),
+        ("bai", "BAI00"),
+        ("sol00", "SOL00"),
+    ],
+)
+def test_scan_matching_family_variant_number_on_scan_only(circuit: str, scan_type: str) -> None:
+    result = match_scan_to_circuits(
+        [("08", scan_type, "0101", "0202")],
+        {circuit: [f"{circuit}.SomeRegister"]},
+    )
+    assert result[circuit] == (scan_type, "0101", "0202")
+
+
+def test_scan_matching_family_variant_number_on_circuit_only() -> None:
+    result = match_scan_to_circuits(
+        [("15", "BASV", "0507", "1704")],
+        {"basv2": ["basv2.HwcTempDesired"]},
+    )
+    assert result["basv2"] == ("BASV", "0507", "1704")
+
+
+def test_scan_matching_rejects_ambiguous_family_circuits() -> None:
+    """Two sibling circuits of one scan family must not receive guessed metadata."""
+    result = match_scan_to_circuits(
+        [("15", "BASV3", "0708", "4304")],
+        {
+            "basv": ["basv.HwcTempDesired"],
+            "basv2": ["basv2.HwcTempDesired"],
+        },
+    )
+    assert "basv" not in result
+    assert "basv2" not in result
+
+
+def test_scan_matching_rejects_ambiguous_family_scans() -> None:
+    """One circuit with two same-family scan variants stays unmatched."""
+    result = match_scan_to_circuits(
+        [("15", "CTLV2", "0514", "1104"), ("16", "CTLV3", "0808", "8004")],
+        {"ctlv": ["ctlv.Z1OpMode"]},
+    )
+    assert "ctlv" not in result
+
+
+def test_scan_matching_does_not_reuse_claimed_scan_for_sibling_circuit() -> None:
+    """A scan exactly/family-bound to one circuit must not leak to a sibling."""
+    result = match_scan_to_circuits(
+        [("08", "HMU00", "0901", "5103")],
+        {
+            "hmu": ["hmu.FlowTemp"],
+            "hmux0": ["hmux0.RunDataReturnTemp"],
+        },
+    )
+    assert result["hmu"] == ("HMU00", "0901", "5103")
+    assert "hmux0" not in result
+
+
+def test_scan_matching_does_not_cross_hmu_hmux_families() -> None:
+    """HMUX0 scan metadata must not bind to the differently-named hmu circuit."""
+    result = match_scan_to_circuits(
+        [("08", "HMUX0", "0303", "0504")],
+        {"hmu": ["hmu.FlowTemp"]},
+    )
+    assert "hmu" not in result
+
+
+def test_scan_matching_sibling_circuits_each_get_own_scan() -> None:
+    result = match_scan_to_circuits(
+        [("08", "HMU00", "0901", "5103"), ("08", "HMUX0", "0303", "0504")],
+        {
+            "hmu": ["hmu.FlowTemp"],
+            "hmux0": ["hmux0.RunDataReturnTemp"],
+        },
+    )
+    assert result["hmu"] == ("HMU00", "0901", "5103")
+    assert result["hmux0"] == ("HMUX0", "0303", "0504")
+
+
+def test_scan_matching_unknown_scan_type_does_not_leak() -> None:
+    result = match_scan_to_circuits(
+        [("01", "XYZ01", "1234", "5678")],
+        {
+            "hmu": ["hmu.FlowTemp"],
+            "ctlv2": ["ctlv2.Z1OpMode"],
+        },
+    )
+    assert result == {}
+
+
+def test_scan_matching_unknown_scan_type_matches_own_circuit() -> None:
+    result = match_scan_to_circuits(
+        [("01", "XYZ01", "1234", "5678")],
+        {"xyz": ["xyz.Status"]},
+    )
+    assert result["xyz"] == ("XYZ01", "1234", "5678")
+
+
+def test_scan_matching_duplicate_identical_entries_are_deterministic() -> None:
+    entries = [
+        ("15", "CTLV3", "0808", "8004"),
+        ("15", "CTLV3", "0808", "8004"),
+        ("08", "HMUX0", "0303", "0504"),
+        ("08", "HMUX0", "0303", "0504"),
+    ]
+    circuits = {"hmux0": ["hmux0.Status01"], "ctlv3": ["ctlv3.Z1OpMode"]}
+    result = match_scan_to_circuits(entries, circuits)
+    assert result == match_scan_to_circuits(entries[:2] + entries[2:], circuits)
+    assert result["ctlv3"] == ("CTLV3", "0808", "8004")
+    assert result["hmux0"] == ("HMUX0", "0303", "0504")
+
+
+def test_scan_matching_multiple_unrelated_scans_stay_isolated() -> None:
+    result = match_scan_to_circuits(
+        [
+            ("08", "HMUX0", "0303", "0504"),
+            ("15", "CTLV3", "0808", "8004"),
+            ("15", "CTLV3", "0808", "8004"),
+            ("76", "VWZIO", "0303", "0504"),
+            ("f6", "NETX2", "4039", "5703"),
+        ],
+        {
+            "hmux0": ["hmux0.Status01"],
+            "ctlv3": ["ctlv3.Z1OpMode"],
+            "vwzio": ["vwzio.TestHwcTemp"],
+            "Broadcast": ["Broadcast.Outsidetemp"],
+        },
+    )
+    assert result["hmux0"] == ("HMUX0", "0303", "0504")
+    assert result["ctlv3"] == ("CTLV3", "0808", "8004")
+    assert result["vwzio"] == ("VWZIO", "0303", "0504")
+    assert result["Broadcast"] == ("NETX2", "4039", "5703")
+
+
+def test_scan_matching_netx2_broadcast_and_netx3_ignored() -> None:
+    result = match_scan_to_circuits(
+        [("f6", "NETX3", "0129", "0404")],
+        {"Broadcast": ["Broadcast.Outsidetemp"]},
+    )
+    assert result == {}
+
+
 def _arotherm_graph() -> DeviceGraph:
     return DiscoveryService.build_device_graph(AROTHERM_LINES)
 


### PR DESCRIPTION
## Summary

- Harden scan metadata to circuit matching with deterministic exact, family, and conservative prefix priorities.
- Reject ambiguous scan/circuit associations instead of copying metadata between sibling circuits.
- Preserve HMUX0 SW0303/HW0504 runtime-definition gating and CTLV3 topology handling.
- Add focused matching tests and issue #99 end-to-end graph/runtime coverage.
- Bump integration version and changelog to 1.7.6.

## Validation

- 460 tests passed
- Ruff passed
- Compileall passed
- Git diff check passed