### PR TITLE
Added some BAI mappings

### DIFF
--- a/custom_components/vaillant_ebus/backend/mapping.py
+++ b/custom_components/vaillant_ebus/backend/mapping.py
@@ -468,6 +468,35 @@ REGISTER_MAP: dict[str, RegisterMeta] = {
         unit="kWh",
         state_class="total_increasing",
     ),
+    # ecoTEC Plus VMW 30 CS/1-5 / additional BAI endpoints.
+    "bai.HwcWaterflow": RegisterMeta(
+        friendly_name="Hot Water Flow",
+        unit="L/min",
+        device_class="volume_flow_rate" ,
+    ),
+    "bai.PrimaryCircuitFlowrate": RegisterMeta(
+        friendly_name="Primary Circuit Flow Rate",
+        unit="L/min",
+        device_class="volume_flow_rate",
+    ),    
+    "bai.StatFuelSum": RegisterMeta(
+        friendly_name="Fuel Energy",
+        device_class="energy",
+        unit="kWh",
+        state_class="total_increasing",
+    ),
+    "bai.StatFuelSumHc": RegisterMeta(
+        friendly_name="Fuel Energy (Heating)",
+        device_class="energy",
+        unit="kWh",
+        state_class="total_increasing",
+    ),
+    "bai.StatFuelSumHwc": RegisterMeta(
+        friendly_name="Fuel Energy (DHW)",
+        device_class="energy",
+        unit="kWh",
+        state_class="total_increasing",
+    ),
     # Runtime-defined b516 cooling-energy registers (issue #50). The bus
     # reports Wh; the unit stays Wh because ebusd returns the raw EXP value.
     "hmu.CoolEnvYieldTotal": RegisterMeta(

--- a/custom_components/vaillant_ebus/backend/mapping.py
+++ b/custom_components/vaillant_ebus/backend/mapping.py
@@ -472,13 +472,15 @@ REGISTER_MAP: dict[str, RegisterMeta] = {
     "bai.HwcWaterflow": RegisterMeta(
         friendly_name="Hot Water Flow",
         unit="L/min",
-        device_class="volume_flow_rate" ,
+        device_class="volume_flow_rate",
+        state_class="measurement",
     ),
     "bai.PrimaryCircuitFlowrate": RegisterMeta(
         friendly_name="Primary Circuit Flow Rate",
         unit="L/min",
         device_class="volume_flow_rate",
-    ),    
+        state_class="measurement",
+    ),
     "bai.StatFuelSum": RegisterMeta(
         friendly_name="Fuel Energy",
         device_class="energy",

--- a/tests/test_community_issue_fixtures.py
+++ b/tests/test_community_issue_fixtures.py
@@ -174,3 +174,34 @@ def test_ecotec_vrt380_captures_expose_bai_and_controller_graph(fixture: str) ->
     assert graph.nodes["bai"].device_type.name == "HEATING_CONTROLLER"
     assert "bai.FlowTemp.value" in entities
     assert "bai.StorageTemp.value" in entities
+
+
+# Intent: ecoTEC BAI flow and fuel registers expose Home Assistant metadata.
+# Why: these registers are present in the discovery graph even when the boiler
+# reports no data, so their metadata must remain covered independently of value availability.
+def test_ecotec_vrt380_bai_flow_and_fuel_metadata() -> None:
+    graph = DiscoveryService.build_device_graph(
+        load_find_lines("community/ecotec_vrt380_15700_discovery.yaml")
+    )
+    entities = {entity.key: entity for entity in EntityFactoryService().generate(graph)}
+
+    for register in (
+        "HwcWaterflow",
+        "PrimaryCircuitFlowrate",
+        "StatFuelSum",
+        "StatFuelSumHc",
+        "StatFuelSumHwc",
+    ):
+        assert f"bai.{register}.value" in entities
+
+    for register in ("HwcWaterflow", "PrimaryCircuitFlowrate"):
+        meta = entities[f"bai.{register}.value"].meta
+        assert meta.device_class == "volume_flow_rate"
+        assert meta.unit == "L/min"
+        assert meta.state_class == "measurement"
+
+    for register in ("StatFuelSum", "StatFuelSumHc", "StatFuelSumHwc"):
+        meta = entities[f"bai.{register}.value"].meta
+        assert meta.device_class == "energy"
+        assert meta.unit == "kWh"
+        assert meta.state_class == "total_increasing"


### PR DESCRIPTION
Added some BAI mappings for proper recognition of DHW flow rate, heating circuit flow rate, fuel usage stats.
This allows HA to make proper use of these entities, including fuel consumption.

Maybe `Heating Circuit Flow Rate` is a more fitting name instead of `Primary Circuit Flow Rate`?