### PR TITLE
Release v1.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,9 +41,9 @@
   `F303`) for a discovered BAI controller, matching the upstream
   product-specific includes and the community eloBLOCK guide.
 - **VWZIO/VWZ Status01 (upstream PR #598).** The Hydraulikstation
-  flow/return/outside/storage/pump telemetry is observed passively on address
-  `0x76` and exposed when a `vwz`/`vwzio` circuit is discovered; no active bus
-  traffic is added.
+  flow/return/outside/storage/pump telemetry is read on address `0x76` and
+  exposed when a `vwz`/`vwzio` circuit is discovered, reusing the HMU Status01
+  field layout with concrete ebusd types.
 
 ### Validation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,66 @@
 # Changelog
 
+## 1.8.1 - 2026-09-12
+
+### Fixed
+
+- **Malformed HMUX0 `Status00` definition.** The field list contained short
+  rows that shifted every later field, so ebusd would have decoded the wrong
+  bytes. It is now a complete six-column definition and the field layout is
+  regression-tested.
+- **ecoTEC/VRT380 write path (#109).** On a bus that exposes both a BAI burner
+  interface and a CTLV0 controller, `bai.HwcTempDesired` made controller
+  resolution ambiguous. The bare runtime `ctlv2` probe alias was then treated
+  as the discovered heating controller, so logical `ctlv2` writes targeted a
+  circuit that does not exist and HA changes had no effect. Controller
+  resolution now prefers a unique `ctlv*`/`basv*`/`bass*` control-register
+  owner over the BAI burner interface, so writes resolve to the discovered
+  `ctlv0` controller instead of the probe alias.
+- **Phantom heat pump on boiler-only buses (#109).** A boiler bus with no
+  heat-pump scan can still report a bare `hmu` circuit made only of runtime
+  b516 energy probes. That alias is no longer classified as an aroTHERM heat
+  pump when a BAI scan is present and no heat-pump scan exists, so no phantom
+  heat-pump device is created. Genuine HMU/HMUX buses and scan-less legacy
+  captures are unaffected.
+
+### Added
+
+- **Energy Manager State sensor (#102).** A derived sensor exposes `Heating`,
+  `DHW`, `Cooling`, `Standby`, or `Defrost`. It is created for a discovered
+  heat pump and maps the compressor status the controller already reports
+  (`RunDataStatuscode`, `Status00`, `Status07` heater bits). It reports
+  unavailable until a status field carries data, so no state is invented.
+- **HMUX0 HW0504 compressor telemetry.** `Status00` and
+  `RunDataElPowerConsumption` are defined for the confirmed `0303/0504`
+  variant (upstream issues #249 / #522). A double filter had disabled these
+  definitions on every bus; the shared b516 energy family and the
+  0303/0504-gated yield/COP registers are unchanged, and `SourceTempInput`
+  stays off for every HMUX0.
+- **eloBLOCK/BAI boiler switches (#111).** `HeatingSwitch` and `HwcSwitch` are
+  exposed as switch entities and redefined writable on `B509` (ID `F203` /
+  `F303`) for a discovered BAI controller, matching the upstream
+  product-specific includes and the community eloBLOCK guide.
+- **VWZIO/VWZ Status01 (upstream PR #598).** The Hydraulikstation
+  flow/return/outside/storage/pump telemetry is observed passively on address
+  `0x76` and exposed when a `vwz`/`vwzio` circuit is discovered; no active bus
+  traffic is added.
+
+### Validation
+
+- 549 pytest tests passing, including fixture-backed regressions for the
+  ecoTEC/VRT380 controller resolution, phantom heat-pump suppression, the
+  derived operating state, the BAI switch/Status00 wire definitions, and the
+  VWZ Status01 field parsing.
+- Ruff, scoped format, strict mypy, YAML, compileall, version consistency, and
+  whitespace checks passing.
+- Live Home Assistant deployment tested.
+
+### Compatibility
+
+- Entity IDs, names, device identities, register names, runtime definitions,
+  dump schema, and service behavior remain unchanged except for the additive
+  entities above (Energy Manager State, BAI switches, VWZ Status01).
+
 ## 1.8.0 - 2026-09-11
 
 ### Changed

--- a/custom_components/vaillant_ebus/backend/discovery_service.py
+++ b/custom_components/vaillant_ebus/backend/discovery_service.py
@@ -174,7 +174,7 @@ class DiscoveryService:
         raw_registers: dict[str, str] = {}
         placeholder_registers: set[str] = set()
         scan_entries = [scan for line in find_lines if (scan := DiscoveryService._parse_scan(line)) is not None]
-        suppress_hmu_alias = _is_hmux0_0303_0504_without_hmu(scan_entries)
+        suppress_hmu_alias = _is_hmux0_0303_0504_without_hmu(scan_entries) or _is_boiler_without_heat_pump(scan_entries)
         regs_by_circuit: dict[str, list[str]] = {}
 
         for line in find_lines:
@@ -603,6 +603,18 @@ def _is_hmux0_0303_0504_without_hmu(scan_entries: Sequence[ScanEntry]) -> bool:
     if not hmux0 or any(entry.scan_sw != "0303" or entry.scan_hw != "0504" for entry in hmux0):
         return False
     return not any(_name_family(entry.scan_type) == "hmu" for entry in scan_entries)
+
+
+# A boiler bus (BAI burner interface) with no heat-pump scan can still report a
+# bare `hmu` circuit made only of runtime-defined b516 energy probes. That alias
+# must not be exposed as a real aroTHERM heat pump. Suppress it only when a BAI
+# scan is present and no heat-pump scan exists, so genuine HMU/HMUX buses and
+# scan-less legacy captures keep their heat-pump node.
+def _is_boiler_without_heat_pump(scan_entries: Sequence[ScanEntry]) -> bool:
+    """Identify a BAI boiler bus with no scanned heat pump."""
+    has_bai = any(_name_family(entry.scan_type) == "bai" for entry in scan_entries)
+    has_heat_pump = any(_name_family(entry.scan_type) in ("hmu", "hmux") for entry in scan_entries)
+    return has_bai and not has_heat_pump
 
 
 # Link discovered logical devices to their source circuit and heat-pump parents.

--- a/custom_components/vaillant_ebus/backend/mapping.py
+++ b/custom_components/vaillant_ebus/backend/mapping.py
@@ -2078,6 +2078,37 @@ REGISTER_MAP: dict[str, RegisterMeta] = {
     ),
 }
 
+# VWZIO/VWZ Hydraulikstation Status01 (upstream PR #598) reuses the HMU layout.
+# Give it explicit metadata so the outside/storage fields are enabled here: the
+# shared HMU entries disable those because a heat pump exposes them elsewhere.
+for _vwz_circuit in ("vwz", "vwzio"):
+    REGISTER_MAP.update(
+        {
+            f"{_vwz_circuit}.Status01": RegisterMeta(
+                friendly_name="Status", icon="mdi:information", entity_category="diagnostic"
+            ),
+            f"{_vwz_circuit}.Status01.temp": RegisterMeta(
+                friendly_name="Flow Temperature", device_class="temperature", unit="°C"
+            ),
+            f"{_vwz_circuit}.Status01.temp_1": RegisterMeta(
+                friendly_name="Return Temperature", device_class="temperature", unit="°C"
+            ),
+            f"{_vwz_circuit}.Status01.temp_2": RegisterMeta(
+                friendly_name="Outside Temperature", device_class="temperature", unit="°C"
+            ),
+            f"{_vwz_circuit}.Status01.temp_3": RegisterMeta(
+                friendly_name="Hot Water Temperature", device_class="temperature", unit="°C"
+            ),
+            f"{_vwz_circuit}.Status01.temp_4": RegisterMeta(
+                friendly_name="Storage Temperature", device_class="temperature", unit="°C"
+            ),
+            f"{_vwz_circuit}.Status01.pumpstate": RegisterMeta(
+                friendly_name="Pump State", entity_type="binary_sensor", entity_category="diagnostic"
+            ),
+        }
+    )
+del _vwz_circuit
+
 
 # Encode the W/V/QQ date bytes of the b516 energy-statistics API (upstream
 # john30/ebusd-configuration issue #490). W is a month nibble that restarts at

--- a/custom_components/vaillant_ebus/backend/mapping.py
+++ b/custom_components/vaillant_ebus/backend/mapping.py
@@ -43,6 +43,10 @@ ELOBLOCK_GAS_REGISTERS: frozenset[str] = frozenset(
 # Source: ebusd vaillant CSV (08.hmu.csv) + community dumps.
 MULTI_FIELD_FIELDS: dict[str, list[str]] = {
     "hmu.Status01": ["temp", "temp_1", "temp_2", "temp_3", "temp_4", "pumpstate"],
+    # VWZIO/VWZ Hydraulikstation Status01 (upstream PR #598) reuses the HMU
+    # layout on address 0x76; the fields are parsed the same way.
+    "vwz.Status01": ["temp", "temp_1", "temp_2", "temp_3", "temp_4", "pumpstate"],
+    "vwzio.Status01": ["temp", "temp_1", "temp_2", "temp_3", "temp_4", "pumpstate"],
     "hmu.Status00": [
         "supplytemp",
         "waterpressure",
@@ -498,6 +502,20 @@ REGISTER_MAP: dict[str, RegisterMeta] = {
         device_class="energy",
         unit="kWh",
         state_class="total_increasing",
+    ),
+    # eloBLOCK/BAI boiler on/off control (issue #111). Exposed as switches; the
+    # integration redefines them writable on B509 for BAI hardware.
+    "bai.HeatingSwitch": RegisterMeta(
+        friendly_name="Heating Switch",
+        entity_type="switch",
+        writable=True,
+        icon="mdi:radiator",
+    ),
+    "bai.HwcSwitch": RegisterMeta(
+        friendly_name="DHW Switch",
+        entity_type="switch",
+        writable=True,
+        icon="mdi:water-boiler",
     ),
     # Runtime-defined b516 cooling-energy registers (issue #50). The bus
     # reports Wh; the unit stays Wh because ebusd returns the raw EXP value.

--- a/custom_components/vaillant_ebus/backend/models.py
+++ b/custom_components/vaillant_ebus/backend/models.py
@@ -202,6 +202,66 @@ def zero_idle_registers(registers: Mapping[str, EbusdRegister], hp_circuit: str 
             reg.has_data = True
 
 
+# Operating states exposed by the derived Energy Manager State sensor.
+OPERATING_STATE_HEATING = "Heating"
+OPERATING_STATE_DHW = "DHW"
+OPERATING_STATE_COOLING = "Cooling"
+OPERATING_STATE_STANDBY = "Standby"
+OPERATING_STATE_DEFROST = "Defrost"
+
+_ON_BITS = frozenset({"on", "1", "true", "yes"})
+
+
+def _value_is_on(value: str | None) -> bool:
+    return not is_no_data_value(value) and (value or "").strip().lower() in _ON_BITS
+
+
+def _clean(value: str | None) -> str:
+    """Normalize a status string, treating ebusd no-data sentinels as empty."""
+    return "" if is_no_data_value(value) else (value or "").strip().lower()
+
+
+# Derive one Energy Manager State from the protocol data the integration
+# already polls. This is a direct mapping of the compressor status and heater
+# bits the controller reports, not an invented state machine:
+#   - RunDataStatuscode (translated label or raw string): standby, defrost,
+#     hwc_compressor_active, heat_compressor_active/*_prerun/*_overrun,
+#     cool_compressor_active/*_prerun.
+#   - HMUX0/HMU Status00 compressorstate/defrost: off, heating*, hot_water,
+#     defrosting.
+#   - HMU00 HW5103 Status07 heatermain bits: heating/cooling/warmwater.
+# Returns None when no status field carries data, so the entity stays unknown
+# rather than guessing a state.
+def derive_operating_state(values: Mapping[str, str | None], hp_circuit: str | None) -> str | None:
+    if not hp_circuit:
+        return None
+    status = _clean(values.get(f"{hp_circuit}.RunDataStatuscode.value"))
+    compressor = _clean(values.get(f"{hp_circuit}.Status00.compressorstate"))
+    heating_state = _clean(values.get(f"{hp_circuit}.Status00.heatingstate"))
+    defrost_bit = values.get(f"{hp_circuit}.Status00.defrost")
+    heating_bit = values.get(f"{hp_circuit}.Status07.heatermain_b3_heating")
+    cooling_bit = values.get(f"{hp_circuit}.Status07.heatermain_b4_cooling")
+    warmwater_bit = values.get(f"{hp_circuit}.Status07.heatermain_b7_warmwater")
+
+    blob = " ".join(part for part in (status, compressor, heating_state) if part)
+    if not blob and not any(_value_is_on(bit) for bit in (heating_bit, cooling_bit, warmwater_bit, defrost_bit)):
+        return None
+
+    if "defrost" in blob or _value_is_on(defrost_bit):
+        return OPERATING_STATE_DEFROST
+    # A shutdown/standby status means no active demand; it never counts as
+    # heating/cooling activity even though the string contains those words.
+    if "shutdown" in blob or "standby" in blob or status in ("off", "0") or compressor in ("off", "0"):
+        return OPERATING_STATE_STANDBY
+    if "hwc" in blob or "hot_water" in blob or "dhw" in blob or _value_is_on(warmwater_bit):
+        return OPERATING_STATE_DHW
+    if "cool" in blob or _value_is_on(cooling_bit):
+        return OPERATING_STATE_COOLING
+    if "heat" in blob or _value_is_on(heating_bit):
+        return OPERATING_STATE_HEATING
+    return OPERATING_STATE_STANDBY
+
+
 CIRCUIT_NAMES: dict[str, str] = {
     "hmu": "Vaillant aroTHERM heat pump",
     "basv": "Vaillant BASV2 Heating Control",
@@ -327,6 +387,22 @@ class DeviceGraph:
             if node.circuit.casefold() in control_owners
             or any(register.rsplit(".", 1)[-1] in self._CONTROL_REGISTERS for register in node.registers)
         ]
+        # A BAI boiler interface also exposes DHW control registers
+        # (HwcTempDesired), but it is a burner, not the heating controller.
+        # When a real controller circuit (ctlv*/basv*/bass*) also owns control
+        # registers, it is authoritative; a bare runtime-probed ctlv2 alias must
+        # never outrank it. This is what makes ecoTEC/VRT380 (bai + ctlv0)
+        # resolve deterministically instead of staying AMBIGUOUS.
+        prefix_control = [
+            node for node in control_candidates if node.circuit.casefold().startswith(("ctlv", "basv", "bass"))
+        ]
+        if len(prefix_control) == 1:
+            node = prefix_control[0]
+            return ResolutionResult(
+                ResolutionStatus.UNIQUE, node.circuit, node, "control registers (controller prefix)"
+            )
+        if len(prefix_control) > 1:
+            return ResolutionResult(ResolutionStatus.AMBIGUOUS, reason="multiple controllers own control registers")
         if len(control_candidates) == 1:
             node = control_candidates[0]
             return ResolutionResult(ResolutionStatus.UNIQUE, node.circuit, node, "control registers")

--- a/custom_components/vaillant_ebus/coordinator.py
+++ b/custom_components/vaillant_ebus/coordinator.py
@@ -56,6 +56,11 @@ ANALYSIS_INTERVAL = timedelta(minutes=15)
 PLACEHOLDER_POLL_INTERVAL = timedelta(minutes=15)
 ENERGY_POLL_INTERVAL = timedelta(minutes=5)
 
+# VWZIO/VWZ Status01 field layout (upstream PR #598); reuses the HMU layout.
+VWZ_STATUS01_FIELDS = (
+    "temp,,temp1,,,,temp_1,,temp1,,,,temp_2,,temp2,,,,temp_3,,temp1,,,,temp_4,,temp1,,,,pumpstate,,pumpstate,,,"
+)
+
 HMUX0_RUNTIME_REGISTERS = frozenset(
     {
         "RunDataReturnTemp",
@@ -628,6 +633,20 @@ class VaillantCoordinator(DataUpdateCoordinator[CoordinatorState]):
             ",,,,hwcflowtempdesired,,UCH,,,,setmode1,,UCH,,,,disablehc,,BI0"
             ",,,,disablehwctapping,,BI1,,,,disablehwcload,,BI2,,,,setmode2,,UCH"
             ",,,,remoteControlHcPump,,BI0,,,,releaseBackup,,BI1,,,,releaseCooling,,BI2",
+            # eloBLOCK/BAI boiler control: the generic BAI configuration exposes
+            # HeatingSwitch/HwcSwitch read-only. Redefine them writable on B509
+            # (ID F203/F303) as the upstream product-specific includes do and as
+            # the community eloBLOCK guide uses. Only emitted when a BAI
+            # controller is discovered; absent hardware is filtered by resolution.
+            "wi,bai,HeatingSwitch,Heating Switch,,08,B509,f203,value,,onoff,,,",
+            "wi,bai,HwcSwitch,DHW Switch,,08,B509,f303,value,,onoff,,,",
+            # VWZIO/VWZ Hydraulikstation process telemetry (upstream PR #598).
+            # Status01 (b511 01, 9 bytes) is passively observed (*u) on address
+            # 0x76 and reuses the HMU layout: flow, return, outside, DHW,
+            # storage, pump. Emitted for whichever of vwz/vwzio the bus exposes;
+            # circuit resolution drops the variant that is not discovered.
+            "u,vwz,Status01,Status01,31,76,B511,01," + VWZ_STATUS01_FIELDS,
+            "u,vwzio,Status01,Status01,31,76,B511,01," + VWZ_STATUS01_FIELDS,
             # B524 heating-circuit state registers (OP=0x02 GG=0x02, RR=0x20..0x25)
             # absent from the shipped CSVs (verified against the installed find
             # output and upstream 15.ctlv2.tsp). Layout documented in the
@@ -666,11 +685,10 @@ class VaillantCoordinator(DataUpdateCoordinator[CoordinatorState]):
             # Unsupported variants return an empty response and remain filtered.
             "r,hmu,Status00,Status00,31,8,B511,00"
             ",supplytemp,,D2C,,°C,,waterpressure,,UCH,10,bar,,"
-            "compressormodulation,,UCH,,%,,compressorstate,,UCH,"
-            "0=off;1=heating_prerun;4=heating;5=heating_overrun;24=hot_water;"
-            "110=defrosting,,heatingstate,,UCH,8=off;9=heating,,"
-            "field6,,UCH,,,defrost,,UCH,0=inactive;32=active,,"
-            "compressorpower,,percent1,,%,,HMUX0 Status00",
+            "compressormodulation,,UCH,,%,,compressorstate,,UCH,0=off;1=heating_prerun;"
+            "4=heating;5=heating_overrun;24=hot_water;110=defrosting,,,"
+            "heatingstate,,UCH,8=off;9=heating,,,field6,,UCH,,,,"
+            "defrost,,UCH,0=inactive;32=active,,,compressorpower,,percent1,,%,HMUX0 Status00",
             # HMUX0 HW0504 community capture: upstream issue #522 identifies
             # B509/540200/5b0d as diagnostic electrical power in watts.
             # This is additive; absent hardware returns no data.
@@ -728,13 +746,16 @@ class VaillantCoordinator(DataUpdateCoordinator[CoordinatorState]):
             and heat_pump.scan_sw == "0303"
             and heat_pump.scan_hw == "0504"
         )
-        # HMU layouts that are proven incompatible with this HMUX0 variant:
-        # the brine source-temperature probe, the generic compressor status
-        # block, and the electrical-power decode. The shared b516 energy
-        # statistics family is kept; the without-symlink capture shows it
-        # returning valid heating/DHW/cooling consumption on this hardware.
+        # HMU-only layouts on HMUX0: the brine source-temperature probe is
+        # always incompatible with the air/water HMUX0. The compressor status
+        # block and electrical-power decode are kept only on the confirmed
+        # 0303/0504 variant (upstream issue #249 / #522, community fixtures);
+        # other HMUX0 variants drop them. The shared b516 energy statistics
+        # family is kept for every HMUX0.
         if heat_pump and heat_pump.scan_type.upper() == "HMUX0":
-            hmu_only_layouts = {"SourceTempInput", "Status00", "RunDataElPowerConsumption"}
+            hmu_only_layouts = {"SourceTempInput"}
+            if not is_hmux0_0303_0504:
+                hmu_only_layouts |= {"Status00", "RunDataElPowerConsumption"}
             defines = [
                 definition
                 for definition in defines

--- a/custom_components/vaillant_ebus/coordinator.py
+++ b/custom_components/vaillant_ebus/coordinator.py
@@ -57,8 +57,11 @@ PLACEHOLDER_POLL_INTERVAL = timedelta(minutes=15)
 ENERGY_POLL_INTERVAL = timedelta(minutes=5)
 
 # VWZIO/VWZ Status01 field layout (upstream PR #598); reuses the HMU layout.
+# Explicit types are required: the hcmode_inc template aliases (temp1/temp2/
+# pumpstate) are not resolvable in a runtime `define`.
 VWZ_STATUS01_FIELDS = (
-    "temp,,temp1,,,,temp_1,,temp1,,,,temp_2,,temp2,,,,temp_3,,temp1,,,,temp_4,,temp1,,,,pumpstate,,pumpstate,,,"
+    "temp,,D1C,,,,temp_1,,D1C,,,,temp_2,,D2B,,,,temp_3,,D1C,,,,temp_4,,D1C,,,,"
+    "pumpstate,,UCH,0=off;1=on;2=overrun;4=hwc,,"
 )
 
 HMUX0_RUNTIME_REGISTERS = frozenset(
@@ -641,12 +644,12 @@ class VaillantCoordinator(DataUpdateCoordinator[CoordinatorState]):
             "wi,bai,HeatingSwitch,Heating Switch,,08,B509,f203,value,,onoff,,,",
             "wi,bai,HwcSwitch,DHW Switch,,08,B509,f303,value,,onoff,,,",
             # VWZIO/VWZ Hydraulikstation process telemetry (upstream PR #598).
-            # Status01 (b511 01, 9 bytes) is passively observed (*u) on address
-            # 0x76 and reuses the HMU layout: flow, return, outside, DHW,
-            # storage, pump. Emitted for whichever of vwz/vwzio the bus exposes;
-            # circuit resolution drops the variant that is not discovered.
-            "u,vwz,Status01,Status01,31,76,B511,01," + VWZ_STATUS01_FIELDS,
-            "u,vwzio,Status01,Status01,31,76,B511,01," + VWZ_STATUS01_FIELDS,
+            # Status01 (b511 01, 9 bytes) reuses the HMU layout: flow, return,
+            # outside, DHW, storage, pump. Read actively like hmu.Status01 so it
+            # populates immediately; emitted for whichever of vwz/vwzio the bus
+            # exposes, and resolution drops the variant that is not discovered.
+            "r,vwz,Status01,Status01,31,76,B511,01," + VWZ_STATUS01_FIELDS,
+            "r,vwzio,Status01,Status01,31,76,B511,01," + VWZ_STATUS01_FIELDS,
             # B524 heating-circuit state registers (OP=0x02 GG=0x02, RR=0x20..0x25)
             # absent from the shipped CSVs (verified against the installed find
             # output and upstream 15.ctlv2.tsp). Layout documented in the

--- a/custom_components/vaillant_ebus/manifest.json
+++ b/custom_components/vaillant_ebus/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/MarkBovee/vaillant-ebus/issues",
   "requirements": [],
-  "version": "1.8.0"
+  "version": "1.8.1"
 }

--- a/custom_components/vaillant_ebus/sensor.py
+++ b/custom_components/vaillant_ebus/sensor.py
@@ -11,6 +11,7 @@ from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .backend.entity_factory import EntityDescription
+from .backend.models import derive_operating_state
 from .const import DOMAIN
 from .coordinator import VaillantCoordinator
 
@@ -36,9 +37,48 @@ async def async_setup_entry(
         return entities
 
     async_add_entities(_build(coordinator.entities))
-    coordinator.register_entity_adder(
-        "sensor", lambda descriptions: async_add_entities(_build(descriptions))
-    )
+    coordinator.register_entity_adder("sensor", lambda descriptions: async_add_entities(_build(descriptions)))
+
+    # The Energy Manager State is derived, not a register read. Create it for a
+    # discovered heat pump only, so boiler-only buses never grow a phantom
+    # entity. It reports `unavailable` until a status field carries data.
+    heat_pump_circuit = coordinator.heat_pump_circuit
+    if heat_pump_circuit is not None:
+        async_add_entities([EbusdEnergyManagerState(coordinator, entry, heat_pump_circuit)])
+
+
+class EbusdEnergyManagerState(CoordinatorEntity[VaillantCoordinator], SensorEntity):
+    """Derived operating state: Heating / DHW / Cooling / Standby / Defrost."""
+
+    _attr_has_entity_name = True
+    _attr_name = "Energy Manager State"
+    _attr_icon = "mdi:heat-pump-outline"
+
+    def __init__(
+        self,
+        coordinator: VaillantCoordinator,
+        entry: ConfigEntry,
+        heat_pump_circuit: str,
+    ) -> None:
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{entry.entry_id}_energy_manager_state"
+        self._attr_device_info = coordinator.get_device_info(heat_pump_circuit)
+        self._fallback_circuit = heat_pump_circuit
+
+    def _state(self) -> str | None:
+        # Re-resolve the heat-pump circuit so late discovery or a circuit rename
+        # keeps the state sensor on the device that actually reports the status.
+        circuit = self.coordinator.heat_pump_circuit or self._fallback_circuit
+        data = (self.coordinator.data or {}).get("ebusd", {})
+        return derive_operating_state(data, circuit)
+
+    @property
+    def native_value(self) -> str | None:
+        return self._state()
+
+    @property
+    def available(self) -> bool:
+        return self.coordinator.last_update_success and self._state() is not None
 
 
 class EbusdSensor(CoordinatorEntity[VaillantCoordinator], SensorEntity, RestoreEntity):
@@ -87,7 +127,7 @@ class EbusdSensor(CoordinatorEntity[VaillantCoordinator], SensorEntity, RestoreE
         val: float | str | None
         try:
             val = float(raw)
-        except (ValueError, TypeError):
+        except ValueError, TypeError:
             if getattr(self, "_attr_native_unit_of_measurement", None):
                 val = None
             else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vaillant-ebus"
-version = "1.8.0"
+version = "1.8.1"
 description = "Home Assistant integration for Vaillant heat pumps via ebusd TCP"
 requires-python = ">=3.14"
 license = { text = "Apache-2.0" }

--- a/tests/test_community_issue_fixtures.py
+++ b/tests/test_community_issue_fixtures.py
@@ -74,6 +74,10 @@ def test_vwz_status01_fields_are_parsed() -> None:
         assert entities[key].raw_value == expected
 
     assert entities["vwz.Status01.temp"].meta.device_class == "temperature"
+    # Outside and storage are enabled for the Hydraulikstation, unlike the
+    # shared HMU mapping where they are disabled (exposed elsewhere).
+    assert entities["vwz.Status01.temp_2"].enabled_by_default is True
+    assert entities["vwz.Status01.temp_4"].enabled_by_default is True
 
 
 # Intent: BAI HeatingSwitch/HwcSwitch become writable switch entities.

--- a/tests/test_community_issue_fixtures.py
+++ b/tests/test_community_issue_fixtures.py
@@ -8,6 +8,31 @@ from tests.fake_ebusd import load_discovery_dump, load_find_lines
 from tests.test_entity_factory import DiscoveryService, EntityFactoryService
 
 
+# Intent: the derived Energy Manager State honours a real cooling capture.
+# Why: issue #102 - the state must be derived from the actual compressor status,
+# not assumed from the register presence.
+def test_cooling_capture_derives_cooling_operating_state() -> None:
+    from tests.test_compressor_power import derive_operating_state
+
+    graph = DiscoveryService.build_device_graph(load_find_lines("community/arotherm_plus_cooling_run_discovery.yaml"))
+    values = {f"{key}.value": value for key, value in graph.raw_registers.items()}
+
+    assert graph.raw_registers["hmu.RunDataStatuscode"] == "cool_compressor_active"
+    assert derive_operating_state(values, "hmu") == "Cooling"
+
+
+# Intent: the derived Energy Manager State honours a real DHW-active capture.
+# Why: issue #102 - DHW demand must map to the DHW state from live compressor data.
+def test_dhw_capture_derives_dhw_operating_state() -> None:
+    from tests.test_compressor_power import derive_operating_state
+
+    graph = DiscoveryService.build_device_graph(load_find_lines("community/arotherm_basv_boost_on_discovery.yaml"))
+    values = {f"{key}.value": value for key, value in graph.raw_registers.items()}
+
+    assert graph.raw_registers["hmu.RunDataStatuscode"] == "hwc_compressor_active"
+    assert derive_operating_state(values, "hmu") == "DHW"
+
+
 # Intent: the eloblock VE28 fixture exposes observed bai registers with metadata.
 # Why: community boiler captures must produce typed, correctly-labeled entities.
 def test_eloblock_ve28_exposes_observed_bai_registers() -> None:
@@ -27,6 +52,41 @@ def test_eloblock_ve28_exposes_observed_bai_registers() -> None:
     assert entities["bai.Gasvalve.value"].enabled_by_default is False
     assert entities["bai.FanSpeed.value"].enabled_by_default is False
     assert entities["bai.Flame.value"].enabled_by_default is False
+
+
+# Intent: VWZIO/VWZ Status01 is parsed into the six shared status fields.
+# Why: upstream PR #598 - the Hydraulikstation reuses the HMU Status01 layout,
+# so its flow/storage/outside/pump values must reach HA as typed sensors.
+def test_vwz_status01_fields_are_parsed() -> None:
+    graph = DiscoveryService.build_device_graph(["vwz Status01 = 23.0;22.5;15.98;-;38.0;off"])
+    entities = {entity.key: entity for entity in EntityFactoryService().generate(graph)}
+
+    for field, expected in (
+        ("temp", "23.0"),
+        ("temp_1", "22.5"),
+        ("temp_2", "15.98"),
+        ("temp_3", "-"),
+        ("temp_4", "38.0"),
+        ("pumpstate", "off"),
+    ):
+        key = f"vwz.Status01.{field}"
+        assert key in entities
+        assert entities[key].raw_value == expected
+
+    assert entities["vwz.Status01.temp"].meta.device_class == "temperature"
+
+
+# Intent: BAI HeatingSwitch/HwcSwitch become writable switch entities.
+# Why: issue #111 - the eloBLOCK VE 28 exposes these registers and they are the
+# reliable on/off control, unlike the absent SetModeOverride.
+def test_bai_heating_and_hwc_switches_are_switch_entities() -> None:
+    graph = DiscoveryService.build_device_graph(["bai HeatingSwitch = on", "bai HwcSwitch = off"])
+    entities = {entity.key: entity for entity in EntityFactoryService().generate(graph)}
+
+    assert entities["bai.HeatingSwitch.value"].meta.entity_type == "switch"
+    assert entities["bai.HwcSwitch.value"].meta.entity_type == "switch"
+    assert entities["bai.HeatingSwitch.value"].meta.friendly_name == "Heating Switch"
+    assert entities["bai.HeatingSwitch.value"].enabled_by_default is True
 
 
 # Intent: the latest issue #99 HMUX0 values keep entity metadata and raw values.
@@ -176,13 +236,57 @@ def test_ecotec_vrt380_captures_expose_bai_and_controller_graph(fixture: str) ->
     assert "bai.StorageTemp.value" in entities
 
 
+# Issue #109: the boiler bus exposes both a BAI burner interface and a CTLV0
+# controller. Both list a DHW setpoint register, which previously left the
+# controller AMBIGUOUS and let the bare runtime `ctlv2` probe alias become the
+# resolved heating circuit, so HA writes targeted a circuit that does not exist.
+# Intent: the real ctlv0 controller wins over bai and the bare ctlv2 alias.
+# Why: issue #109 - HA writes must target the discovered controller circuit.
+@pytest.mark.parametrize(
+    "fixture",
+    (
+        "community/ecotec_vrt380_15700_discovery.yaml",
+        "community/ecotec_vrt380_ctlv2_discovery.yaml",
+    ),
+)
+def test_ecotec_vrt380_resolves_real_controller_not_bare_probe(fixture: str) -> None:
+    graph = DiscoveryService.build_device_graph(load_find_lines(fixture))
+
+    result = graph.heating_controller_result()
+    assert result.status.name == "UNIQUE"
+    assert result.circuit == "ctlv0"
+    # The logical ctlv2 metadata alias must route to the discovered ctlv0.
+    assert graph.resolve_circuit_result("ctlv2").circuit == "ctlv0"
+
+
+# Issue #109: a boiler-only bus reports only runtime-defined b516 `hmu` energy
+# probes (created by the integration's generic define pass), which used to
+# surface as a phantom aroTHERM heat-pump device.
+# Intent: a BAI bus with no heat-pump scan exposes no hmu heat-pump node.
+# Why: issue #109 - no phantom heat-pump device on boiler-only hardware.
+def test_ecotec_vrt380_boiler_bus_has_no_phantom_heat_pump() -> None:
+    graph = DiscoveryService.build_device_graph(load_find_lines("community/ecotec_vrt380_15700_discovery.yaml"))
+
+    assert "hmu" not in graph.nodes
+    assert graph.heat_pump_result().status.name == "MISSING"
+    entities = EntityFactoryService().generate(graph)
+    assert not any(entity.device_circuit == "hmu" for entity in entities)
+
+
+# Intent: a real HMU00 heat pump scan keeps its hmu node and is not suppressed.
+# Why: the boiler-only suppression must not affect genuine heat-pump buses.
+def test_ecotec_heat_pump_bus_keeps_hmu_node() -> None:
+    graph = DiscoveryService.build_device_graph(load_find_lines("community/arotherm_ecotec_discovery.yaml"))
+
+    assert graph.nodes["hmu"].device_type.name == "HEAT_PUMP"
+    assert graph.heat_pump_result().circuit == "hmu"
+
+
 # Intent: ecoTEC BAI flow and fuel registers expose Home Assistant metadata.
 # Why: these registers are present in the discovery graph even when the boiler
 # reports no data, so their metadata must remain covered independently of value availability.
 def test_ecotec_vrt380_bai_flow_and_fuel_metadata() -> None:
-    graph = DiscoveryService.build_device_graph(
-        load_find_lines("community/ecotec_vrt380_15700_discovery.yaml")
-    )
+    graph = DiscoveryService.build_device_graph(load_find_lines("community/ecotec_vrt380_15700_discovery.yaml"))
     entities = {entity.key: entity for entity in EntityFactoryService().generate(graph)}
 
     for register in (

--- a/tests/test_compressor_power.py
+++ b/tests/test_compressor_power.py
@@ -17,6 +17,7 @@ EbusdRegister = MODELS.EbusdRegister
 compressor_is_idle = MODELS.compressor_is_idle
 zero_idle_registers = MODELS.zero_idle_registers
 COMPRESSOR_ZERO_REGISTER_NAMES = MODELS.COMPRESSOR_ZERO_REGISTER_NAMES
+derive_operating_state = MODELS.derive_operating_state
 
 
 # Build a register dict entry with given key and string value
@@ -165,3 +166,51 @@ def test_default_call_ignores_other_circuits() -> None:
     )
     zero_idle_registers(regs)
     assert regs["um.CurrentConsumedPower"].value["value"] == "3.2"
+
+
+# Intent: derive_operating_state maps RunDataStatuscode strings to the five
+# Energy Manager states, with defrost and shutdown handled before heat/cool.
+# Why: issue #102 - the derived state must be correct for every documented
+# compressor status without inventing a state machine.
+def test_derive_operating_state_from_run_data_statuscode() -> None:
+    cases = {
+        "hwc_compressor_active": "DHW",
+        "heat_compressor_active": "Heating",
+        "heat_prerun": "Heating",
+        "heat_overrun": "Heating",
+        "cool_compressor_active": "Cooling",
+        "cool_compressor_active;ok": "Cooling",
+        "cool_prerun": "Cooling",
+        "defrost": "Defrost",
+        "standby": "Standby",
+        "heat_compressor_shutdown": "Standby",
+        "cool_compressor_shutdown": "Standby",
+    }
+    for raw, expected in cases.items():
+        values = {"hmu.RunDataStatuscode.value": raw}
+        assert derive_operating_state(values, "hmu") == expected, raw
+
+
+# Intent: derive_operating_state falls back to HMU Status07 heater bits.
+# Why: issue #102 - HW5103 can rely on Status07 when RunDataStatuscode is absent.
+def test_derive_operating_state_from_status07_bits() -> None:
+    assert derive_operating_state({"hmu.Status07.heatermain_b3_heating": "on"}, "hmu") == "Heating"
+    assert derive_operating_state({"hmu.Status07.heatermain_b4_cooling": "on"}, "hmu") == "Cooling"
+    assert derive_operating_state({"hmu.Status07.heatermain_b7_warmwater": "on"}, "hmu") == "DHW"
+
+
+# Intent: derive_operating_state maps HMUX0 Status00 compressor states.
+# Why: issue #102 - HMUX0 reports operating state through Status00, not Statuscode.
+def test_derive_operating_state_from_status00() -> None:
+    assert derive_operating_state({"hmu.Status00.compressorstate": "hot_water"}, "hmu") == "DHW"
+    assert derive_operating_state({"hmu.Status00.compressorstate": "heating_prerun"}, "hmu") == "Heating"
+    assert derive_operating_state({"hmu.Status00.compressorstate": "defrosting"}, "hmu") == "Defrost"
+    assert derive_operating_state({"hmu.Status00.compressorstate": "off"}, "hmu") == "Standby"
+
+
+# Intent: derive_operating_state is unknown when nothing reports a state.
+# Why: a missing status must not be coerced into Standby or another default.
+def test_derive_operating_state_unknown_without_data() -> None:
+    assert derive_operating_state({}, "hmu") is None
+    assert derive_operating_state({"hmu.RunDataStatuscode.value": "no data stored"}, "hmu") is None
+    assert derive_operating_state({"hmu.RunDataStatuscode.value": "standby"}, None) is None

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -806,10 +806,10 @@ async def test_bai_switch_definitions_use_b509_write_message() -> None:
         assert all(",hmu," not in item for item in definitions)
 
 
-# Intent: the VWZIO/VWZ Status01 definition is emitted passively on address 0x76.
-# Why: upstream PR #598 - the Hydraulikstation flow/storage telemetry must be
-# observed without adding active bus traffic.
-async def test_vwz_status01_definition_is_passive_on_0x76() -> None:
+# Intent: the VWZIO/VWZ Status01 definition targets address 0x76 with explicit types.
+# Why: upstream PR #598 - the hcmode_inc template aliases do not resolve in a
+# runtime define, so the Hydraulikstation telemetry needs concrete types.
+async def test_vwz_status01_definition_uses_explicit_types_on_0x76() -> None:
     with tempfile.TemporaryDirectory() as tmpdir:
         c = VaillantCoordinator(_hass(tmpdir), _entry())
         c.ebus = MagicMock(spec=EbusService)
@@ -823,12 +823,15 @@ async def test_vwz_status01_definition_is_passive_on_0x76() -> None:
 
         definitions = [call.args[0] for call in c.ebus.define_register.await_args_list]
         status01 = next(item for item in definitions if ",vwz,Status01," in item)
-        assert status01.startswith("u,vwz,Status01,")
+        assert status01.startswith("r,vwz,Status01,")
         assert ",31,76,B511,01," in status01
         tokens = status01.split(",B511,01,", 1)[1].split(",")
         assert len(tokens) == 36
         assert tokens[0] == "temp"
+        assert tokens[2] == "D1C"
+        assert tokens[14] == "D2B"
         assert tokens[30] == "pumpstate"
+        assert tokens[32] == "UCH"
 
 
 # Intent: unproven HMUX0-specific definitions stay disabled for a plain HMU graph.

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -439,15 +439,42 @@ async def test_hmux0_runtime_definitions_use_discovered_circuit() -> None:
 
         definitions = [call.args[0] for call in c.ebus.define_register.await_args_list]
         hmux0 = [definition for definition in definitions if ",hmux0," in definition]
-        assert len(hmux0) == 20
+        assert len(hmux0) == 22
         assert all(",hmu," not in definition for definition in hmux0)
         assert any(",hmux0,RunDataReturnTemp," in definition for definition in hmux0)
         assert any(",hmux0,YieldHc," in definition for definition in hmux0)
         assert any(",hmux0,CopHwcMonth," in definition for definition in hmux0)
         assert any(",hmux0,HcElecConsDay," in definition for definition in hmux0)
         assert any(",hmux0,HwcElecConsTotal," in definition for definition in hmux0)
-        assert not any(",Status00," in definition for definition in definitions)
-        assert not any(",RunDataElPowerConsumption," in definition for definition in definitions)
+        # Confirmed 0303/0504 telemetry (upstream #249 / #522).
+        assert any(",hmux0,Status00," in definition for definition in definitions)
+        assert any(",hmux0,RunDataElPowerConsumption," in definition for definition in definitions)
+
+
+# Intent: the bespoke HMUX0 Status00 definition uses complete 6-column fields.
+# Why: a mangled Status00 field list is silently accepted by ebusd but decodes
+# the wrong bytes, which is worse than the register being absent. The previous
+# definition had short field rows that shifted every later field.
+async def test_hmux0_status00_definition_has_complete_fields() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        c = VaillantCoordinator(_hass(tmpdir), _entry())
+        c.ebus = MagicMock(spec=EbusService)
+        c.ebus.is_connected = True
+        c.ebus.define_register = AsyncMock(return_value="done")
+        c._graph = DISCOVERY.DiscoveryService.build_device_graph(
+            ["scan.08 = Vaillant;HMUX0;0303;0504", "ctlv3 HwcOpMode = auto"]
+        )
+
+        await c._define_custom_registers()
+
+        definitions = [call.args[0] for call in c.ebus.define_register.await_args_list]
+        definition = next(item for item in definitions if ",B511,00," in item)
+        tokens = definition.split(",B511,00,", 1)[1].split(",")
+        assert len(tokens) == 8 * 6
+        assert tokens[0] == "supplytemp"
+        assert tokens[6] == "waterpressure"
+        assert tokens[42] == "compressorpower"
+        assert tokens[47] == "HMUX0 Status00"
 
 
 # Intent: keep legacy runtime definition templates on their discovered owner.
@@ -755,6 +782,55 @@ async def test_status07_definition_is_gated_to_hm5103() -> None:
         assert "display_b5_noisereduction" in status07
 
 
+# Intent: the BAI boiler switch definitions are emitted on the B509 write message.
+# Why: issue #111 - HeatingSwitch/HwcSwitch are read-only in the generic BAI
+# config, so the integration must redefine them writable for control to work.
+async def test_bai_switch_definitions_use_b509_write_message() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        c = VaillantCoordinator(_hass(tmpdir), _entry())
+        c.ebus = MagicMock(spec=EbusService)
+        c.ebus.is_connected = True
+        c.ebus.define_register = AsyncMock(return_value="done")
+        c._graph = DISCOVERY.DiscoveryService.build_device_graph(["bai FlowTemp = 28.69"])
+
+        await c._define_custom_registers()
+
+        definitions = [call.args[0] for call in c.ebus.define_register.await_args_list]
+        heating = next(item for item in definitions if ",bai,HeatingSwitch," in item)
+        hwc = next(item for item in definitions if ",bai,HwcSwitch," in item)
+        assert ",08,B509,f203," in heating
+        assert ",08,B509,f303," in hwc
+        assert heating.endswith("value,,onoff,,,")
+        assert hwc.endswith("value,,onoff,,,")
+        # The switch definitions must not leak onto a heat-pump alias.
+        assert all(",hmu," not in item for item in definitions)
+
+
+# Intent: the VWZIO/VWZ Status01 definition is emitted passively on address 0x76.
+# Why: upstream PR #598 - the Hydraulikstation flow/storage telemetry must be
+# observed without adding active bus traffic.
+async def test_vwz_status01_definition_is_passive_on_0x76() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        c = VaillantCoordinator(_hass(tmpdir), _entry())
+        c.ebus = MagicMock(spec=EbusService)
+        c.ebus.is_connected = True
+        c.ebus.define_register = AsyncMock(return_value="done")
+        c._graph = DISCOVERY.DiscoveryService.build_device_graph(
+            ["scan.76 = Vaillant;VWZ00;0522;5103", "vwz EnableTestHwcTemp = no data stored"]
+        )
+
+        await c._define_custom_registers()
+
+        definitions = [call.args[0] for call in c.ebus.define_register.await_args_list]
+        status01 = next(item for item in definitions if ",vwz,Status01," in item)
+        assert status01.startswith("u,vwz,Status01,")
+        assert ",31,76,B511,01," in status01
+        tokens = status01.split(",B511,01,", 1)[1].split(",")
+        assert len(tokens) == 36
+        assert tokens[0] == "temp"
+        assert tokens[30] == "pumpstate"
+
+
 # Intent: unproven HMUX0-specific definitions stay disabled for a plain HMU graph.
 # Why: avoids enabling unverified registers (Status00, RunDataElPowerConsumption) on uncaptured hardware.
 async def test_hmux0_unproven_definitions_are_not_enabled() -> None:
@@ -820,11 +896,15 @@ async def test_hmux0_runtime_definitions_use_issue99_fixture_metadata() -> None:
 
         definitions = [call.args[0] for call in c.ebus.define_register.await_args_list]
         hmux0_defs = [definition for definition in definitions if ",hmux0," in definition]
-        assert len(hmux0_defs) == 20
+        assert len(hmux0_defs) == 22
         assert all(",hmu," not in definition for definition in hmux0_defs)
         assert any(",hmux0,RunDataReturnTemp," in definition for definition in hmux0_defs)
         assert any(",hmux0,YieldHc," in definition for definition in hmux0_defs)
         assert any(",hmux0,CopHwcMonth," in definition for definition in hmux0_defs)
+        # Upstream #249 / #522: the 0303/0504 variant keeps the compressor
+        # status block and the electrical-power decode.
+        assert any(",hmux0,Status00," in definition for definition in hmux0_defs)
+        assert any(",hmux0,RunDataElPowerConsumption," in definition for definition in hmux0_defs)
 
 
 # A future HMUX0 firmware (pro7 capture: SW0406/HW0504) must not receive the
@@ -878,7 +958,7 @@ async def test_hmux0_scan_bootstrap_defines_only_confirmed_registers() -> None:
 
         definitions = [call.args[0] for call in c.ebus.define_register.await_args_list]
         hmux0_definitions = [definition for definition in definitions if ",hmux0," in definition]
-        assert len(hmux0_definitions) == 20
+        assert len(hmux0_definitions) == 22
         assert all(definition.split(",", 3)[1] != "hmu" for definition in definitions)
 
 
@@ -917,7 +997,7 @@ async def test_hmux0_scan_bootstrap_rediscovers_defined_registers() -> None:
 
         assert discovery.discover.await_count == 2
         definitions = [call.args[0] for call in mock_ebus.define_register.await_args_list]
-        assert len([definition for definition in definitions if ",hmux0," in definition]) == 20
+        assert len([definition for definition in definitions if ",hmux0," in definition]) == 22
         assert all(definition.split(",", 3)[1] != "hmu" for definition in definitions)
         assert c.heat_pump_circuit == "hmux0"
         assert c.heating_circuit == "ctlv3"
@@ -944,7 +1024,7 @@ async def test_hmux0_scan_bootstrap_ignores_generic_hmu_alias_definitions() -> N
         await c._define_custom_registers()
 
         definitions = [call.args[0] for call in c.ebus.define_register.await_args_list]
-        assert len([definition for definition in definitions if ",hmux0," in definition]) == 20
+        assert len([definition for definition in definitions if ",hmux0," in definition]) == 22
         assert all(definition.split(",", 3)[1] != "hmu" for definition in definitions)
 
 
@@ -1125,7 +1205,7 @@ async def test_transport_reconnect_invalidates_runtime_definitions() -> None:
         assert c._last_energy_poll == datetime.min
         c.ebus.define_register.reset_mock()
         await c._define_custom_registers()
-        assert c.ebus.define_register.await_count == 28
+        assert c.ebus.define_register.await_count == 32
 
 
 # Intent: applying a discovery graph logs the generated entity/platform breakdown.
@@ -1212,7 +1292,7 @@ async def test_define_custom_registers_delegates_to_ebus() -> None:
         c.ebus = mock_ebus
         await c._define_custom_registers()
 
-        assert mock_ebus.define_register.call_count == 28
+        assert mock_ebus.define_register.call_count == 32
         calls = [c.args[0] for c in mock_ebus.define_register.call_args_list]
         assert any("z1RoomHumidity" in d for d in calls)
         assert any("ManualCoolingStartDate" in d and d.startswith("r5") for d in calls)
@@ -1387,6 +1467,28 @@ async def test_async_write_register_rejects_missing_discovered_circuit() -> None
 
         assert await c.async_write_register("hmu", "SetMode", "auto") is False
         mock_ebus.write_register.assert_not_awaited()
+
+
+# Issue #109: on a BAI + CTLV0 boiler bus the BAI burner interface also owns a
+# DHW setpoint, which previously made controller resolution AMBIGUOUS and let
+# the bare runtime ctlv2 probe alias become the write target.
+# Intent: a logical ctlv2 write on the real ecoTEC graph dispatches to ctlv0.
+# Why: issue #109 - HA writes must land on the discovered controller, not ctlv2.
+async def test_ecotec_boiler_write_targets_discovered_ctl0_not_bare_probe() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        c = VaillantCoordinator(_hass(tmpdir), _entry())
+        c._graph = DISCOVERY.DiscoveryService.build_device_graph(
+            load_find_lines("community/ecotec_vrt380_15700_discovery.yaml")
+        )
+        mock_ebus = MagicMock(spec=EbusService)
+        mock_ebus.is_connected = True
+        mock_ebus.write_register = AsyncMock(return_value=WriteResult(success=True, verified_value=None))
+        c.ebus = mock_ebus
+        c.async_request_refresh = AsyncMock()
+
+        assert c.heating_circuit == "ctlv0"
+        assert await c.async_write_register("ctlv2", "Z1DayTemp", "21") is True
+        assert mock_ebus.write_register.await_args.args[0] == "ctlv0"
 
 
 # Intent: an unresolved empty graph makes heating_circuit and heat_pump_circuit return None.


### PR DESCRIPTION
## 1.8.1 - 2026-09-12

### Fixed

- **Malformed HMUX0 `Status00` definition.** The field list contained short
  rows that shifted every later field, so ebusd would have decoded the wrong
  bytes. It is now a complete six-column definition and the field layout is
  regression-tested.
- **ecoTEC/VRT380 write path (#109).** On a bus that exposes both a BAI burner
  interface and a CTLV0 controller, `bai.HwcTempDesired` made controller
  resolution ambiguous. The bare runtime `ctlv2` probe alias was then treated
  as the discovered heating controller, so logical `ctlv2` writes targeted a
  circuit that does not exist and HA changes had no effect. Controller
  resolution now prefers a unique `ctlv*`/`basv*`/`bass*` control-register
  owner over the BAI burner interface, so writes resolve to the discovered
  `ctlv0` controller instead of the probe alias.
- **Phantom heat pump on boiler-only buses (#109).** A boiler bus with no
  heat-pump scan can still report a bare `hmu` circuit made only of runtime
  b516 energy probes. That alias is no longer classified as an aroTHERM heat
  pump when a BAI scan is present and no heat-pump scan exists, so no phantom
  heat-pump device is created. Genuine HMU/HMUX buses and scan-less legacy
  captures are unaffected.

### Added

- **Energy Manager State sensor (#102).** A derived sensor exposes `Heating`,
  `DHW`, `Cooling`, `Standby`, or `Defrost`. It is created for a discovered
  heat pump and maps the compressor status the controller already reports
  (`RunDataStatuscode`, `Status00`, `Status07` heater bits). It reports
  unavailable until a status field carries data, so no state is invented.
- **HMUX0 HW0504 compressor telemetry.** `Status00` and
  `RunDataElPowerConsumption` are defined for the confirmed `0303/0504`
  variant (upstream issues #249 / #522). A double filter had disabled these
  definitions on every bus; the shared b516 energy family and the
  0303/0504-gated yield/COP registers are unchanged, and `SourceTempInput`
  stays off for every HMUX0.
- **eloBLOCK/BAI boiler switches (#111).** `HeatingSwitch` and `HwcSwitch` are
  exposed as switch entities and redefined writable on `B509` (ID `F203` /
  `F303`) for a discovered BAI controller, matching the upstream
  product-specific includes and the community eloBLOCK guide.
- **VWZIO/VWZ Status01 (upstream PR #598).** The Hydraulikstation
  flow/return/outside/storage/pump telemetry is read on address `0x76` and
  exposed when a `vwz`/`vwzio` circuit is discovered, reusing the HMU Status01
  field layout with concrete ebusd types.

### Validation

- 549 pytest tests passing, including fixture-backed regressions for the
  ecoTEC/VRT380 controller resolution, phantom heat-pump suppression, the
  derived operating state, the BAI switch/Status00 wire definitions, and the
  VWZ Status01 field parsing.
- Ruff, scoped format, strict mypy, YAML, compileall, version consistency, and
  whitespace checks passing.
- Live Home Assistant deployment tested.

### Compatibility

- Entity IDs, names, device identities, register names, runtime definitions,
  dump schema, and service behavior remain unchanged except for the additive
  entities above (Energy Manager State, BAI switches, VWZ Status01).