### PR TITLE
Release v1.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@
   entity unique IDs, and entity IDs of existing installs are unchanged; only
   the device display name becomes hardware-aware.
 
+### Added
+
+- **Stale device removal.** The integration now supports Home Assistant's
+  device-removal flow for devices that are no longer part of the current
+  discovery graph, so ghost devices (an old runtime alias or a removed
+  circuit) can be deleted from the UI without editing storage by hand.
+
 ### Validation
 
 - Full test suite passing, including regressions for the runtime-only

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## 1.8.2 - 2026-09-12
+
+### Fixed
+
+- **Phantom boiler device on heat-pump buses.** A stale runtime-only controller
+  alias — for example a `bai SetModeOverride` write-only define left on ebusd by
+  an earlier session — is no longer discovered as a physical controller. A
+  scan-less circuit that carries only the integration's own runtime control
+  probes is dropped, so it cannot surface as a phantom `bai` (or similar)
+  device. Real controllers are scan-bound or own native registers and are
+  unaffected.
+
+### Changed
+
+- **Hardware-aware DHW device name.** The logical DHW device is named
+  `Domestic Hot Water` when a heat pump is discovered, and keeps the historical
+  `Boiler (DHW)` name on boiler-only or unresolved buses. Entity names,
+  entity unique IDs, and entity IDs of existing installs are unchanged; only
+  the device display name becomes hardware-aware.
+
+### Validation
+
+- Full test suite passing, including regressions for the runtime-only
+  controller alias and the hardware-aware DHW device name.
+- Ruff, scoped format, strict mypy, YAML, compileall, version consistency, and
+  whitespace checks passing.
+
 ## 1.8.1 - 2026-09-12
 
 ### Fixed

--- a/custom_components/vaillant_ebus/__init__.py
+++ b/custom_components/vaillant_ebus/__init__.py
@@ -9,6 +9,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.device_registry import DeviceEntry
 
 from . import repairs  # noqa: F401 — registers issue translation keys
 from .const import DOMAIN, PLATFORMS
@@ -218,3 +219,19 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         coordinator = hass.data[DOMAIN].pop(entry.entry_id)
         await coordinator.async_stop()
     return True
+
+
+# Allow Home Assistant to delete a device only when it is no longer provided by
+# the current discovery graph. This lets users clear stale/ghost devices (an old
+# runtime alias or a removed circuit) from the UI without touching storage,
+# while still refusing to delete a device that is currently discovered.
+async def async_remove_config_entry_device(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    device_entry: DeviceEntry,
+) -> bool:
+    coordinator: VaillantCoordinator | None = hass.data.get(DOMAIN, {}).get(entry.entry_id)
+    if coordinator is None:
+        return False
+    circuits = {identifier[1] for identifier in device_entry.identifiers if identifier[0] == DOMAIN}
+    return bool(circuits) and not any(coordinator.has_discovered_circuit(circuit) for circuit in circuits)

--- a/custom_components/vaillant_ebus/backend/discovery_service.py
+++ b/custom_components/vaillant_ebus/backend/discovery_service.py
@@ -303,6 +303,13 @@ class DiscoveryService:
                 scan_hw=metadata.scan_hw,
             )
 
+        # A scan-less controller carrying only the integration's own runtime
+        # control probes (e.g. a stale `bai SetModeOverride` write-only define
+        # left behind by an earlier ebusd session) is not a physical device.
+        # Real controllers are scan-bound or own native control/data registers,
+        # so this targeted rule cannot hide a genuine boiler or controller.
+        nodes = {circuit: node for circuit, node in nodes.items() if not _is_runtime_only_controller_alias(node)}
+
         _apply_relationships(nodes, sub_devices)
 
         return DeviceGraph(
@@ -615,6 +622,20 @@ def _is_boiler_without_heat_pump(scan_entries: Sequence[ScanEntry]) -> bool:
     has_bai = any(_name_family(entry.scan_type) == "bai" for entry in scan_entries)
     has_heat_pump = any(_name_family(entry.scan_type) in ("hmu", "hmux") for entry in scan_entries)
     return has_bai and not has_heat_pump
+
+
+# Runtime control-only registers the integration defines itself; a circuit that
+# only carries these and has no scan/data is an alias left by an old ebusd
+# session, not a device.
+_RUNTIME_ONLY_CONTROLLER_REGISTERS = frozenset({"SetModeOverride", "HeatingSwitch", "HwcSwitch"})
+
+
+def _is_runtime_only_controller_alias(node: DeviceNode) -> bool:
+    """Return whether a node is a scan-less runtime-only controller alias."""
+    if node.device_type != DeviceType.HEATING_CONTROLLER or node.scan_type or node.has_data:
+        return False
+    names = {register.rsplit(".", 1)[-1] for register in node.registers}
+    return bool(names) and names <= _RUNTIME_ONLY_CONTROLLER_REGISTERS
 
 
 # Link discovered logical devices to their source circuit and heat-pump parents.

--- a/custom_components/vaillant_ebus/coordinator.py
+++ b/custom_components/vaillant_ebus/coordinator.py
@@ -930,6 +930,14 @@ class VaillantCoordinator(DataUpdateCoordinator[CoordinatorState]):
             _LOGGER.warning("Could not read register cache from %s; using empty cache", self._cache_path, exc_info=True)
             return {}
 
+    # Name the logical DHW device after the hardware that owns it: a heat pump
+    # has a hot-water cylinder, not a boiler. Boiler-only and unresolved buses
+    # keep the historical "Boiler (DHW)" name for stability.
+    def _dhw_device_name(self) -> str:
+        if self._graph is not None and self._graph.heat_pump_result().status == ResolutionStatus.UNIQUE:
+            return "Domestic Hot Water"
+        return CIRCUIT_NAMES.get("dhw", "Boiler (DHW)")
+
     def get_device_info(self, circuit: str) -> DeviceInfo:
         scan_type = ""
         scan_sw = ""
@@ -947,7 +955,9 @@ class VaillantCoordinator(DataUpdateCoordinator[CoordinatorState]):
             parent = node.parent
 
         circuit_lower = circuit.lower()
-        if circuit_lower in CIRCUIT_NAMES:
+        if circuit_lower == "dhw":
+            name = self._dhw_device_name()
+        elif circuit_lower in CIRCUIT_NAMES:
             name = CIRCUIT_NAMES[circuit_lower]
         elif len(circuit_lower) == 5 and circuit_lower.startswith("ctlv") and circuit_lower[-1].isdigit():
             name = "Vaillant sensoCOMFORT Control"

--- a/custom_components/vaillant_ebus/coordinator.py
+++ b/custom_components/vaillant_ebus/coordinator.py
@@ -930,6 +930,12 @@ class VaillantCoordinator(DataUpdateCoordinator[CoordinatorState]):
             _LOGGER.warning("Could not read register cache from %s; using empty cache", self._cache_path, exc_info=True)
             return {}
 
+    # Whether a circuit is present in the current discovery graph. Used to
+    # decide whether a Home Assistant device is still provided by the
+    # integration (and may not be deleted) or is a stale ghost.
+    def has_discovered_circuit(self, circuit: str) -> bool:
+        return self._graph is not None and circuit in self._graph.nodes
+
     # Name the logical DHW device after the hardware that owns it: a heat pump
     # has a hot-water cylinder, not a boiler. Boiler-only and unresolved buses
     # keep the historical "Boiler (DHW)" name for stability.

--- a/custom_components/vaillant_ebus/manifest.json
+++ b/custom_components/vaillant_ebus/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/MarkBovee/vaillant-ebus/issues",
   "requirements": [],
-  "version": "1.8.1"
+  "version": "1.8.2"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vaillant-ebus"
-version = "1.8.1"
+version = "1.8.2"
 description = "Home Assistant integration for Vaillant heat pumps via ebusd TCP"
 requires-python = ">=3.14"
 license = { text = "Apache-2.0" }

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -2544,3 +2544,24 @@ async def test_zone_circuits_keeps_real_idle_zone() -> None:
             placeholder_registers={"ctlv2.Z2RoomTemp", "ctlv2.Z2DayTemp", "ctlv2.Z2OpMode"},
         )
         assert c.zone_circuits() == {"z1": "ctlv2", "z2": "ctlv2"}
+
+
+# Intent: the logical DHW device is named after the hardware that owns it.
+# Why: a heat pump has a hot-water cylinder, not a boiler; a boiler-only bus
+# keeps the historical name so existing installs stay stable.
+async def test_dhw_device_name_is_hardware_aware() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        c = VaillantCoordinator(_hass(tmpdir), _entry())
+
+        c._graph = DISCOVERY.DiscoveryService.build_device_graph(
+            ["scan.08 = Vaillant;HMU00;0522;5103", "hmu FlowTemp = 30", "ctlv2 HwcOpMode = auto"]
+        )
+        assert c._dhw_device_name() == "Domestic Hot Water"
+
+        c._graph = DISCOVERY.DiscoveryService.build_device_graph(
+            ["scan.08 = Vaillant;BAI00;0107;7503", "bai FlowTemp = 30", "ctlv2 HwcOpMode = auto"]
+        )
+        assert c._dhw_device_name() == "Boiler (DHW)"
+
+        c._graph = None
+        assert c._dhw_device_name() == "Boiler (DHW)"

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -2565,3 +2565,17 @@ async def test_dhw_device_name_is_hardware_aware() -> None:
 
         c._graph = None
         assert c._dhw_device_name() == "Boiler (DHW)"
+
+
+# Intent: has_discovered_circuit reflects the current graph and a cleared graph.
+# Why: HA device removal must only be allowed for circuits no longer discovered.
+async def test_has_discovered_circuit_matches_graph() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        c = VaillantCoordinator(_hass(tmpdir), _entry())
+        c._graph = DISCOVERY.DiscoveryService.build_device_graph(["ctlv2 HwcOpMode = auto"])
+
+        assert c.has_discovered_circuit("ctlv2")
+        assert not c.has_discovered_circuit("bai")
+
+        c._graph = None
+        assert not c.has_discovered_circuit("ctlv2")

--- a/tests/test_discovery_service.py
+++ b/tests/test_discovery_service.py
@@ -1570,3 +1570,20 @@ async def test_discover_logs_per_device_and_type_summary(caplog) -> None:
     assert "Discovered device ctlv2" in messages
     assert "Device graph:" in messages
     assert graph.nodes["hmu"].device_type == DeviceType.HEAT_PUMP
+
+
+# Intent: a scan-less, data-less runtime-only controller alias is not a device.
+# Why: a stale `bai SetModeOverride` define left on ebusd by an old session must
+# not create a phantom boiler device.
+def test_runtime_only_controller_alias_is_not_a_device() -> None:
+    graph = DiscoveryService.build_device_graph(["bai SetModeOverride = no data stored"])
+
+    assert "bai" not in graph.nodes
+
+
+# Intent: a BAI with native registers is still discovered as a controller.
+# Why: the phantom-alias rule must never hide real boiler hardware.
+def test_bai_with_native_registers_is_kept() -> None:
+    graph = DiscoveryService.build_device_graph(["bai FlowTemp = 28.69", "bai StorageTemp = 56.12"])
+
+    assert graph.nodes["bai"].device_type.name == "HEATING_CONTROLLER"


### PR DESCRIPTION
## 1.8.2 - 2026-09-12

### Fixed

- **Phantom boiler device on heat-pump buses.** A stale runtime-only controller
  alias — for example a `bai SetModeOverride` write-only define left on ebusd by
  an earlier session — is no longer discovered as a physical controller. A
  scan-less circuit that carries only the integration's own runtime control
  probes is dropped, so it cannot surface as a phantom `bai` (or similar)
  device. Real controllers are scan-bound or own native registers and are
  unaffected.

### Changed

- **Hardware-aware DHW device name.** The logical DHW device is named
  `Domestic Hot Water` when a heat pump is discovered, and keeps the historical
  `Boiler (DHW)` name on boiler-only or unresolved buses. Entity names,
  entity unique IDs, and entity IDs of existing installs are unchanged; only
  the device display name becomes hardware-aware.

### Added

- **Stale device removal.** The integration now supports Home Assistant's
  device-removal flow for devices that are no longer part of the current
  discovery graph, so ghost devices (an old runtime alias or a removed
  circuit) can be deleted from the UI without editing storage by hand.

### Validation

- Full test suite passing, including regressions for the runtime-only
  controller alias and the hardware-aware DHW device name.
- Ruff, scoped format, strict mypy, YAML, compileall, version consistency, and
  whitespace checks passing.