### PR TITLE
fix(tools): PEP 440 rc bumps + document ebusd read-back semantics

### DIFF
--- a/docs/developer.md
+++ b/docs/developer.md
@@ -156,6 +156,33 @@ await coordinator.async_write_registers([
 
 For a single write use `coordinator.async_write_register(circuit, name, value)`.
 
+### ebusd read-back semantics
+
+ebusd serves `read` from its cache when the cached value is newer than the
+default max age (300 s). During a `write`, ebusd stores the response into that
+same cache (`storeLastData`), so a plain `read -c <circuit> <name>` right after
+a write returns the just-written value even if the controller never applied it.
+Write verification therefore bypasses the cache:
+
+- `EbusService.read_register(..., force=True)` issues `read -f ...`, a real bus
+  read.
+- `write_register` re-reads from the bus after the write and, on a mismatch,
+  retries once after `WRITE_VERIFY_RETRY_DELAY` so a controller that applies
+  the value just after the bus ack is not reported as failing.
+- With `strict_verify=True` an unreadable or mismatching read-back fails the
+  write. With `strict_verify=False` (e.g. `HwcSFMode`, whose physical state
+  lags the accepted write) the write succeeds on the ebusd ack and a persistent
+  mismatch is only logged. A write-only register has no read message; the
+  verification read then reports `ERR: not found`, which is not a write failure.
+
+On a live bus the equivalent check that cannot be fooled by the cache is:
+
+```bash
+ebusctl read -f -c <circuit> <name>   # NOT read -c ...
+ebusctl write -c <circuit> <name> <value>
+ebusctl read -f -c <circuit> <name>   # immediately after
+```
+
 ## Testing against live ebusd
 
 ```bash

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -70,6 +70,11 @@ To clean manually:
 - Verify `--accesslevel=*` is set in ebusd commandline_options
 - Some registers are read-only by hardware design (eBUS spec limitation)
 - The integration returns a clear error message with the ebusd response
+- The integration verifies writes against the bus, not ebusd's cache. To check
+  whether the controller actually applied a value, use `ebusctl read -f -c
+  <circuit> <name>` — the `-f` forces a real bus read. A plain `read` can
+  return the just-written value from ebusd's cache and hide that the controller
+  reverted it (see `docs/developer.md` "ebusd read-back semantics").
 
 ## HMUX0 heat pump variants (aroTHERM VWL 55/8.2 etc.)
 

--- a/tests/test_version_consistency.py
+++ b/tests/test_version_consistency.py
@@ -8,11 +8,20 @@ normal pytest step. The single source of truth is ``tools/version.py``.
 
 from __future__ import annotations
 
+import importlib.util
 import subprocess
 import sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
+
+
+def _version_tool() -> object:
+    spec = importlib.util.spec_from_file_location("version_tool", ROOT / "tools" / "version.py")
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
 
 
 # Intent: pyproject.toml, manifest.json and the CHANGELOG heading carry one release version.
@@ -25,3 +34,13 @@ def test_release_version_is_consistent() -> None:
         text=True,
     )
     assert result.returncode == 0, result.stdout + result.stderr
+
+
+# Intent: bump keeps pyproject.toml PEP 440 (1.8.0rc2) while manifest keeps the display form (1.8.0-rc2).
+# Why: ``1.8.0-rc2`` is not valid PEP 440; the check-normalizer strips separators,
+# so drift would go unnoticed without this pin.
+def test_pyproject_normalizes_pre_release() -> None:
+    version_tool = _version_tool()
+    assert version_tool.pyproject_version("1.8.3-rc1") == "1.8.3rc1"
+    assert version_tool.pyproject_version("1.8.3") == "1.8.3"
+    assert version_tool.canonical("1.8.3-rc1") == version_tool.canonical("1.8.3rc1") == "183rc1"

--- a/tools/version.py
+++ b/tools/version.py
@@ -7,11 +7,12 @@ The version lives in three places:
 - ``custom_components/vaillant_ebus/manifest.json`` (display: ``1.8.0-rc2``)
 - the top ``## <version>`` heading in ``CHANGELOG.md``
 
-Usage::
+``bump`` converts the input ``X.Y.Z-rcN`` form to the PEP 440 ``X.Y.ZrcN``
+for ``pyproject.toml`` and keeps the display form (hyphen) elsewhere::
 
     python tools/version.py check
     python tools/version.py bump 1.8.0
-    python tools/version.py bump 1.8.0-rc3
+    python tools/version.py bump 1.8.0-rc3  # pyproject gets 1.8.0rc3
 
 ``check`` exits non-zero when the three do not agree. It is enforced by
 ``tests/test_version_consistency.py`` so CI fails on drift. ``bump`` updates
@@ -31,10 +32,18 @@ PYPROJECT = ROOT / "pyproject.toml"
 MANIFEST = ROOT / "custom_components" / "vaillant_ebus" / "manifest.json"
 CHANGELOG = ROOT / "CHANGELOG.md"
 
+# Pre-release suffixes that must lose their hyphen to be valid PEP 440.
+_PRE_RELEASE = r"(rc|alpha|beta|a|b|post|dev)"
+
 
 def canonical(version: str) -> str:
     """Normalize ``1.8.0-rc2`` / ``1.8.0rc2`` / ``1.8.0`` for comparison."""
     return re.sub(r"[^0-9a-z]", "", version.strip().lower())
+
+
+def pyproject_version(version: str) -> str:
+    """PEP 440 form for pyproject: ``1.8.0-rc2`` → ``1.8.0rc2``."""
+    return re.sub(rf"-{_PRE_RELEASE}", r"\1", version, count=1, flags=re.IGNORECASE)
 
 
 def read_pyproject() -> str:
@@ -71,7 +80,7 @@ def bump(new: str) -> int:
     pyproject_text = PYPROJECT.read_text()
     pyproject_new = re.sub(
         r'(^version\s*=\s*")([^"]+)(")',
-        lambda m: f"{m.group(1)}{new}{m.group(3)}",
+        lambda m: f"{m.group(1)}{pyproject_version(new)}{m.group(3)}",
         pyproject_text,
         count=1,
         flags=re.MULTILINE,
@@ -89,10 +98,14 @@ def bump(new: str) -> int:
         count=1,
     )
     if manifest_new == manifest_text:
-        print('version not found in manifest.json', file=sys.stderr)
+        print("version not found in manifest.json", file=sys.stderr)
         return 1
     MANIFEST.write_text(manifest_new)
-    print(f"bumped to {new}; add the matching '## {new}' heading to CHANGELOG.md")
+    message = (
+        f"bumped to {new} (pyproject uses {pyproject_version(new)}); "
+        f"add the matching '## {new}' heading to CHANGELOG.md"
+    )
+    print(message)
     return check()
 
 


### PR DESCRIPTION
Follow-ups from the 1.8.3-rc1 release:

1. **Version tool**: `tools/version.py bump 1.8.3-rc1` wrote `1.8.3-rc1` into `pyproject.toml`, which is not valid PEP 440. The bump now writes `1.8.3rc1` there while `manifest.json` keeps the display form `1.8.3-rc1`. Pinned by a new test in `tests/test_version_consistency.py`.
2. **Docs**: `docs/developer.md` now documents ebusd's read-cache vs forced-read semantics and how write verification works; `docs/troubleshooting.md` points users at `ebusctl read -f` to check whether a write was actually applied.

Local checks: 554 tests pass, ruff clean, version check passes.