### PR TITLE
release: merge v1.8.3-rc1 write-verification into main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,13 +124,19 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          PRERELEASE=""
+          case "${{ github.ref_name }}" in
+            *-rc*|*rc[0-9]*) PRERELEASE="--prerelease" ;;
+          esac
           if gh release view "${{ github.ref_name }}" >/dev/null 2>&1; then
             gh release upload "${{ github.ref_name }}" /tmp/vaillant_ebus.zip --clobber
             gh release edit "${{ github.ref_name }}" \
               --title "${{ github.ref_name }}" \
+              $PRERELEASE \
               --notes-file /tmp/release_notes.md
           else
             gh release create "${{ github.ref_name }}" /tmp/vaillant_ebus.zip \
               --title "${{ github.ref_name }}" \
+              $PRERELEASE \
               --notes-file /tmp/release_notes.md
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog
 
+## 1.8.3-rc1 - 2026-09-12
+
+### Fixed
+
+- **Write verification bypasses the ebusd cache.** ebusd answers `read` from its
+  cache and stores the written value in that cache during the write itself
+  (`storeLastData`), so a cached read-back always "verified" a write the
+  controller may never have applied. Write verification now re-reads the
+  register from the bus (`read -f`) and retries once after a short delay, so a
+  strict write is only reported as successful when the controller actually
+  reports the new value. A write-only register that has no read-back, or a
+  register whose read-back is still lagging, no longer fails when the caller
+  opted out of strict verification. This is the write path behind the
+  holiday/away dates in issue #99; a controller that accepts but does not apply
+  a write is now surfaced instead of leaving Home Assistant on an optimistic
+  value that later reverts.
+
+### Added
+
+- **Datetime write-contract tests.** The hand-built holiday datetime entities now
+  have regression tests pinning the resolved controller circuit, the register,
+  and the zero-padded `DD.MM.YYYY` serialization.
+- **Cache-vs-device verification tests.** The fake ebusd now models the
+  cache/device boundary, including a controller that accepts but does not apply
+  a write, so the verification contract is covered instead of only the Python
+  call chain.
+
+### Validation
+
+- Full test suite passing, including the new datetime and write-verification
+  regressions.
+- Ruff, scoped format, strict mypy, YAML, compileall, version consistency, and
+  whitespace checks passing.
+
 ## 1.8.2 - 2026-09-12
 
 ### Fixed

--- a/custom_components/vaillant_ebus/backend/ebus_service.py
+++ b/custom_components/vaillant_ebus/backend/ebus_service.py
@@ -16,6 +16,11 @@ MAX_RECONNECT_DELAY = 60
 INITIAL_RECONNECT_DELAY = 1
 READ_TIMEOUT = 10
 DONE_STR = "done"
+# ebusd serves `read` from its cache unless forced; a freshly written value is
+# cached by the write itself. Re-read once from the bus before treating a
+# mismatch as an unapplied write, so a controller that applies the value just
+# after the bus ack is not reported as a failure.
+WRITE_VERIFY_RETRY_DELAY = 0.25
 
 EBUSD_STATUS_SUFFIXES = (";ok", ";err", ";inv", ";too_small", ";too_big", ";nan", ";unknown")
 
@@ -240,13 +245,15 @@ class EbusService:
     async def find_registers(self) -> list[str]:
         return await self._send_find()
 
-    # Read a single register value from ebusd, strip status suffix
-    async def read_register(self, circuit: str, name: str, field: str = "") -> str | None:
+    # Read a single register value from ebusd, strip status suffix. By default
+    # ebusd may answer from its cache; force=True adds "-f" so an active-read
+    # register is queried from the device instead (used to verify writes).
+    async def read_register(self, circuit: str, name: str, field: str = "", force: bool = False) -> str | None:
         _validate_identifier("circuit", circuit)
         _validate_identifier("register name", name)
         if field:
             _validate_identifier("field", field)
-        cmd = f"read -c {circuit} {name}"
+        cmd = f"read -f -c {circuit} {name}" if force else f"read -c {circuit} {name}"
         if field:
             cmd += f" {field}"
         result = await self.send_command(cmd)
@@ -256,11 +263,19 @@ class EbusService:
         raw = result.data.strip()
         return _strip_suffix(raw) if raw else None
 
-    # Write a value to an ebusd register, verify by read-back. When
-    # strict_verify is False a read-back that does not match the written value
-    # is logged but not treated as a failure. This is used for registers whose
-    # physical state lags the accepted write (e.g. HwcSFMode keeps reporting
-    # "load" while the cylinder finishes charging after boost is turned off).
+    # Write a value to an ebusd register, verify by a forced bus read-back.
+    # The read-back bypasses ebusd's cache because ebusd stores the written
+    # value in that cache during the write, which would make a cached read
+    # always "verify" a write the controller never applied. Each failed or
+    # empty read is retried once after a short delay, so a controller that
+    # applies the write just after the bus ack still succeeds.
+    #
+    # strict_verify=True requires the controller to confirm the written value;
+    # an unreadable or mismatching read-back fails the write. strict_verify=False
+    # accepts the write when ebusd acknowledged it, and only warns when the
+    # controller does not confirm it (e.g. HwcSFMode keeps reporting "load"
+    # while the cylinder finishes charging after boost is turned off, or a
+    # write-only register has no read message to verify against).
     async def write_register(self, circuit: str, name: str, value: str, strict_verify: bool = True) -> WriteResult:
         _validate_identifier("circuit", circuit)
         _validate_identifier("register name", name)
@@ -271,14 +286,21 @@ class EbusService:
         data = result.data.strip()
         if data and data != DONE_STR:
             return WriteResult(success=False, error_message=f"Unexpected response: {data}")
-        verified = await self.read_register(circuit, name)
-        if not data and not verified:
-            return WriteResult(success=False, error_message="Write verification returned empty")
-        if verified and verified.startswith("ERR:"):
-            return WriteResult(success=False, error_message=f"Write verification failed: {verified}")
-        if verified and not _values_match(value, verified):
+        verified = await self.read_register(circuit, name, force=True)
+        if strict_verify and (not verified or verified.startswith("ERR:")):
+            # No usable answer on the first post-write read. Retry once; idle
+            # heat-pump registers can return no data on the first attempt. A
+            # non-strict write needs no confirmation, so it skips the retry.
+            await asyncio.sleep(WRITE_VERIFY_RETRY_DELAY)
+            retry = await self.read_register(circuit, name, force=True)
+            if retry and not retry.startswith("ERR:"):
+                verified = retry
+        if not verified or verified.startswith("ERR:"):
+            # A write-only register has no read message, so an unreadable
+            # read-back is not proof the write failed. Only strict callers
+            # require the controller to confirm the value.
             _LOGGER.warning(
-                "Write verification mismatch %s.%s: wrote %r, read back %r",
+                "Write verification unreadable %s.%s: wrote %r, read back %r",
                 circuit,
                 name,
                 value,
@@ -287,8 +309,28 @@ class EbusService:
             if strict_verify:
                 return WriteResult(
                     success=False,
-                    error_message=f"Write verification mismatch: wrote {value!r}, read back {verified!r}",
+                    error_message=f"Write verification failed: wrote {value!r}, read back {verified!r}",
                 )
+            return WriteResult(success=True, verified_value=None)
+        if not _values_match(value, verified):
+            await asyncio.sleep(WRITE_VERIFY_RETRY_DELAY)
+            retry = await self.read_register(circuit, name, force=True)
+            if retry and not retry.startswith("ERR:") and _values_match(value, retry):
+                verified = retry
+            else:
+                _LOGGER.warning(
+                    "Write verification mismatch %s.%s: wrote %r, read back %r",
+                    circuit,
+                    name,
+                    value,
+                    verified,
+                )
+                if strict_verify:
+                    return WriteResult(
+                        success=False,
+                        error_message=f"Write verification mismatch: wrote {value!r}, read back {verified!r}",
+                    )
+        _LOGGER.debug("Write %s.%s=%r acked, verification read-back %r", circuit, name, value, verified)
         return WriteResult(success=True, verified_value=verified)
 
     # Send 'info' command and parse key=value response

--- a/custom_components/vaillant_ebus/manifest.json
+++ b/custom_components/vaillant_ebus/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/MarkBovee/vaillant-ebus/issues",
   "requirements": [],
-  "version": "1.8.2"
+  "version": "1.8.3-rc1"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vaillant-ebus"
-version = "1.8.2"
+version = "1.8.3rc1"
 description = "Home Assistant integration for Vaillant heat pumps via ebusd TCP"
 requires-python = ">=3.14"
 license = { text = "Apache-2.0" }

--- a/tests/fake_ebusd.py
+++ b/tests/fake_ebusd.py
@@ -171,12 +171,21 @@ class FakeEbusdServer:
         fixture: str | list[str] = "arotherm_find.txt",
         host: str = "127.0.0.1",
         port: int = 0,
+        apply_writes: bool = True,
     ) -> None:
         self._host = host
         self._port = port
         self._find_lines = fixture if isinstance(fixture, list) else load_find_lines(fixture)
         self._server: asyncio.AbstractServer | None = None
+        # ebusd keeps a cache separate from the device. A write always updates
+        # the cache (as real ebusd does via storeLastData); the device value
+        # only changes when the controller applies the write. ``read -f``
+        # bypasses the cache and returns the device value, ``read`` returns the
+        # cache. Set apply_writes=False to simulate a controller that accepts
+        # but does not apply a write.
+        self.apply_writes = apply_writes
         self._registers: dict[tuple[str, str], str] = {}
+        self._device_values: dict[tuple[str, str], str] = {}
         self._build_register_db()
 
     def _build_register_db(self) -> None:
@@ -191,6 +200,7 @@ class FakeEbusdServer:
             last_real = _last_real_value(vals)
             if last_real is not None:
                 self._registers[key] = last_real
+        self._device_values = dict(self._registers)
 
     @property
     def host(self) -> str:
@@ -298,15 +308,19 @@ class FakeEbusdServer:
         return "version: ebusd 26.1.p20260503 (fake)"
 
     def _handle_read(self, parts: list[str]) -> str:
-        """Handle ``read [-c circuit] name [field]``."""
+        """Handle ``read [-f] [-c circuit] name [field]``."""
         rest = parts[1:] if len(parts) > 1 else []
         circuit = ""
         name = ""
         field: str | None = None
+        force = False
 
         idx = 0
         while idx < len(rest):
-            if rest[idx] == "-c" and idx + 1 < len(rest):
+            if rest[idx] == "-f":
+                force = True
+                idx += 1
+            elif rest[idx] == "-c" and idx + 1 < len(rest):
                 circuit = rest[idx + 1]
                 idx += 2
             elif field is None and name and not circuit:
@@ -329,13 +343,14 @@ class FakeEbusdServer:
             return "ERR: missing circuit or name"
 
         key = (circuit, name)
-        val = self._registers.get(key)
+        val = (self._device_values if force else self._registers).get(key)
         if val is None:
             return ""
-
-        if field:
-            return self._extract_field(val, circuit, name, field)
-        return val
+        if force:
+            # A bus read updates ebusd's cache (storeLastData), so the next
+            # non-forced read returns the device value instead of a stale write.
+            self._registers[key] = val
+        return self._extract_field(val, circuit, name, field) if field else val
 
     @staticmethod
     def _extract_field(raw_val: str, circuit: str, name: str, field: str) -> str:
@@ -381,7 +396,10 @@ class FakeEbusdServer:
         if not value:
             return "ERR: missing value"
 
-        self._registers[(circuit, name)] = value
+        key = (circuit, name)
+        self._registers[key] = value
+        if self.apply_writes:
+            self._device_values[key] = value
         return "done"
 
     def _handle_find(self, parts: list[str]) -> str:

--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -1,0 +1,161 @@
+"""Tests for the datetime platform write contract.
+
+The holiday datetime entities are hand-built (not generated from the discovery
+graph), so nothing else pins that they address the resolved controller circuit
+with the right register and date serialization. These tests do exactly that,
+using a real discovery graph so the circuit resolution is exercised too.
+
+Reuses the homeassistant mock scaffolding from tests.test_coordinator.
+"""
+
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+from tests import test_coordinator as tc  # noqa: F401 — installs shared HA mocks
+from tests.fake_ebusd import load_find_lines
+
+PROJECT_ROOT = Path(__file__).parents[1]
+COMPONENT_PATH = PROJECT_ROOT / "custom_components/vaillant_ebus"
+
+mock_homeassistant = sys.modules["homeassistant"]
+
+_TZ = timezone(timedelta(hours=2))
+
+
+class _MockBaseEntity:
+    def async_write_ha_state(self) -> None:
+        pass
+
+    def _handle_coordinator_update(self) -> None:
+        pass
+
+    async def async_update(self) -> None:
+        pass
+
+    def __class_getitem__(cls, item):
+        return cls
+
+
+class _MockCoordinatorEntity(_MockBaseEntity):
+    def __init__(self, coordinator) -> None:
+        self.coordinator = coordinator
+
+
+datetime_pkg = importlib.util.module_from_spec(
+    importlib.machinery.ModuleSpec("homeassistant.components.datetime", None)
+)
+datetime_pkg.DateTimeEntity = _MockBaseEntity
+sys.modules["homeassistant.components.datetime"] = datetime_pkg
+mock_homeassistant.helpers.update_coordinator.CoordinatorEntity = _MockCoordinatorEntity
+
+ha_util = importlib.util.module_from_spec(importlib.machinery.ModuleSpec("homeassistant.util", None))
+ha_util.dt = MagicMock()
+ha_util.dt.DEFAULT_TIME_ZONE = _TZ
+sys.modules["homeassistant.util"] = ha_util
+mock_homeassistant.util = ha_util
+
+entity_platform = importlib.util.module_from_spec(
+    importlib.machinery.ModuleSpec("homeassistant.helpers.entity_platform", None)
+)
+entity_platform.AddEntitiesCallback = object
+sys.modules["homeassistant.helpers.entity_platform"] = entity_platform
+
+DATETIME_SPEC = importlib.util.spec_from_file_location("vaillant_ebus.datetime", COMPONENT_PATH / "datetime.py")
+assert DATETIME_SPEC and DATETIME_SPEC.loader
+DATETIME = importlib.util.module_from_spec(DATETIME_SPEC)
+sys.modules["vaillant_ebus.datetime"] = DATETIME
+DATETIME_SPEC.loader.exec_module(DATETIME)
+
+EbusdHolidayEntity = DATETIME.EbusdHolidayEntity
+
+
+def _ebusd_data_from_graph(graph) -> dict[str, str]:
+    data: dict[str, str] = {}
+    for rk, raw in graph.raw_registers.items():
+        circuit, name = rk.split(".", 1)
+        for field, value in tc._register_values(rk, raw).items():
+            if value is not None:
+                data[f"{circuit}.{name}.{field}"] = value
+    return data
+
+
+# Coordinator stub whose heating circuit is resolved from a real discovery
+# graph, mirroring how the live coordinator resolves ctlv2 to the controller.
+class _GraphCoordinator:
+    def __init__(self, graph, data: dict[str, str]) -> None:
+        self._graph = graph
+        self.data = {"ebusd": data}
+        self.ebus = object()
+        self.async_write_register = AsyncMock(return_value=True)
+        self.async_update_listeners = MagicMock()
+
+    @property
+    def heating_circuit(self):
+        return self._graph.resolve_circuit_result("ctlv2").circuit
+
+    def get_device_info(self, *_args):
+        return {"identifiers": {("vaillant_ebus", "dhw")}}
+
+
+def _graph_coordinator(fixture: str = "community/hmux0_issue99_2026-09-10_173229.yaml") -> _GraphCoordinator:
+    graph = tc.DISCOVERY.DiscoveryService.build_device_graph(load_find_lines(fixture, after=True))
+    return _GraphCoordinator(graph, _ebusd_data_from_graph(graph))
+
+
+def _dhw_holiday_entity(coordinator) -> object:
+    entry = MagicMock()
+    entry.entry_id = "entry-1"
+    return EbusdHolidayEntity(
+        coordinator, entry, "DHW Holiday Start", "HwcHolidayStartPeriod", "mdi:calendar-start", "dhw"
+    )
+
+
+# The reporter's HMUX0/CTLV3 bus carries a stray runtime ctlv2 probe node, but
+# HwcHolidayStartPeriod is owned by ctlv3. The entity must resolve to ctlv3.
+# Intent: the DHW holiday entity reads and writes the resolved ctlv3 controller, not the stray ctlv2 node.
+# Why: guards the issue #99 controller-resolution fix on the hand-built datetime entities.
+def test_holiday_entity_targets_resolved_controller_circuit() -> None:
+    coordinator = _graph_coordinator()
+    assert coordinator.heating_circuit == "ctlv3"
+    entity = _dhw_holiday_entity(coordinator)
+    assert entity.native_value is None  # 01.01.2015 is the unset sentinel
+
+
+# A real controller holiday date must surface as a timezone-aware datetime.
+# Intent: a valid ctlv3.HwcHolidayStartPeriod value decodes to a datetime at local midnight.
+# Why: pins the read contract so a future change cannot quietly return unknown for a set date.
+def test_holiday_entity_decodes_configured_date() -> None:
+    coordinator = _graph_coordinator()
+    coordinator.data["ebusd"]["ctlv3.HwcHolidayStartPeriod.value"] = "24.09.2026"
+    entity = _dhw_holiday_entity(coordinator)
+    assert entity.native_value == datetime(2026, 9, 24, tzinfo=_TZ)
+
+
+# The write contract: resolved circuit + register + DD.MM.YYYY serialization.
+# Intent: async_set_value writes ctlv3.HwcHolidayStartPeriod with a zero-padded DD.MM.YYYY date.
+# Why: the DateTimeEntity write path is untested; a wrong circuit, register, or format is the issue #99 failure mode.
+async def test_holiday_entity_write_contract() -> None:
+    coordinator = _graph_coordinator()
+    entity = _dhw_holiday_entity(coordinator)
+
+    await entity.async_set_value(datetime(2026, 9, 24))
+
+    coordinator.async_write_register.assert_awaited_once_with("ctlv3", "HwcHolidayStartPeriod", "24.09.2026")
+
+
+# Single-digit days must be zero-padded so ebusd's date parser accepts them.
+# Intent: 4 September serializes as 04.09.2026.
+# Why: a non-padded day would be rejected by the HDA date decoder.
+async def test_holiday_entity_write_zero_pads_day() -> None:
+    coordinator = _graph_coordinator()
+    entity = _dhw_holiday_entity(coordinator)
+
+    await entity.async_set_value(datetime(2026, 9, 4))
+
+    coordinator.async_write_register.assert_awaited_once_with("ctlv3", "HwcHolidayStartPeriod", "04.09.2026")

--- a/tests/test_ebus_service.py
+++ b/tests/test_ebus_service.py
@@ -165,6 +165,20 @@ async def test_write_register_success() -> None:
     result = await s.write_register("hmu", "SetMode", "auto 17 - - 1 1 1 0 0 1")
     assert result.success
     assert result.verified_value == "auto;17;-;-;1;1;1;0;0;1"
+    # The verification read must bypass ebusd's cache: ebusd caches the written
+    # value during the write, so a cached read would always "verify" it.
+    assert b"read -f -c hmu SetMode" in s._writer.write.call_args_list[1].args[0]
+
+
+# read_register: force=True issues a bus read via the -f flag
+# Intent: a forced read adds -f so ebusd queries the device instead of its cache.
+# Why: the difference between a cached and an applied value is what makes write verification meaningful.
+async def test_read_register_force_adds_f_flag() -> None:
+    s = _service()
+    s._reader.readline = AsyncMock(side_effect=[TimeoutError(), b"auto\n"])
+    val = await s.read_register("ctlv3", "HwcHolidayStartPeriod", force=True)
+    assert val == "auto"
+    assert b"read -f -c ctlv3 HwcHolidayStartPeriod" in s._writer.write.call_args.args[0]
 
 
 # write_register: read-back that does not match the written value fails.
@@ -172,14 +186,17 @@ async def test_write_register_success() -> None:
 # keeps HwcSFMode on "load" while a boost cycle is still running.
 # Intent: a done write whose read-back still reports the old value fails with a verification-mismatch error.
 # Why: ebusd accepts writes it does not apply (DHW HwcSFMode stays load), so trusting done would falsely report success.
-async def test_write_register_readback_mismatch_fails() -> None:
+async def test_write_register_readback_mismatch_fails(monkeypatch) -> None:
+    monkeypatch.setattr(EBUS, "WRITE_VERIFY_RETRY_DELAY", 0)
     s = _service()
     s._reader.readline = AsyncMock(
         side_effect=[
             TimeoutError(),  # drain for write
             b"done\n",  # write response
             TimeoutError(),  # drain for read-back
-            b"load\n",  # read-back: value did not change
+            b"load\n",  # read-back 1: value did not change
+            TimeoutError(),  # drain for retry
+            b"load\n",  # read-back 2: still not applied
         ]
     )
     result = await s.write_register("basv", "HwcSFMode", "auto")
@@ -188,12 +205,35 @@ async def test_write_register_readback_mismatch_fails() -> None:
     assert "load" in result.error_message
 
 
+# write_register: a controller that applies the write just after the bus ack
+# is not reported as a failure because the mismatch is retried once.
+# Intent: first forced read returns the old value, the retry returns the new value, write succeeds.
+# Why: prevents false write failures for controllers with a short apply latency.
+async def test_write_register_retry_recovers_after_controller_lag(monkeypatch) -> None:
+    monkeypatch.setattr(EBUS, "WRITE_VERIFY_RETRY_DELAY", 0)
+    s = _service()
+    s._reader.readline = AsyncMock(
+        side_effect=[
+            TimeoutError(),  # drain for write
+            b"done\n",  # write response
+            TimeoutError(),  # drain for read-back
+            b"load\n",  # read-back 1: not applied yet
+            TimeoutError(),  # drain for retry
+            b"auto\n",  # read-back 2: applied
+        ]
+    )
+    result = await s.write_register("basv", "HwcSFMode", "auto")
+    assert result.success
+    assert result.verified_value == "auto"
+
+
 # write_register: with strict_verify=False a read-back mismatch is logged but
 # not treated as a failure. Used for HwcSFMode, whose physical state lags the
 # accepted write while the cylinder is still charging.
 # Intent: with strict_verify=False a read-back mismatch is reported as success with the observed value.
 # Why: HwcSFMode physical state lags the accepted write, so strict polling would fail valid boost toggles.
-async def test_write_register_readback_mismatch_non_strict() -> None:
+async def test_write_register_readback_mismatch_non_strict(monkeypatch) -> None:
+    monkeypatch.setattr(EBUS, "WRITE_VERIFY_RETRY_DELAY", 0)
     s = _service()
     s._reader.readline = AsyncMock(
         side_effect=[
@@ -201,6 +241,8 @@ async def test_write_register_readback_mismatch_non_strict() -> None:
             b"done\n",  # write response
             TimeoutError(),  # drain for read-back
             b"load\n",  # read-back: value did not change yet
+            TimeoutError(),  # drain for retry
+            b"load\n",  # retry: still not changed
         ]
     )
     result = await s.write_register("basv", "HwcSFMode", "auto", strict_verify=False)
@@ -266,21 +308,32 @@ async def test_write_register_empty_response_verified() -> None:
     assert result.verified_value == "auto;22.0;-;-;1;1;1;0;0;1"
 
 
-# write_register: empty write + empty read-back = failure
-# Intent: an empty write response and empty read-back fails with Write verification returned empty.
+# write_register: empty write + empty read-back = strict failure
+# Intent: an empty write response and an empty verification read fails.
 # Why: prevents a no-op write from being reported as success.
-async def test_write_register_empty_both() -> None:
+async def test_write_register_empty_both(monkeypatch) -> None:
+    monkeypatch.setattr(EBUS, "WRITE_VERIFY_RETRY_DELAY", 0)
     s = _service()
-    s._reader.readline = AsyncMock(side_effect=[TimeoutError(), b"\n", TimeoutError(), b"\n"])
+    s._reader.readline = AsyncMock(
+        side_effect=[
+            TimeoutError(),
+            b"\n",
+            TimeoutError(),
+            b"\n",
+            TimeoutError(),
+            b"\n",  # retry is empty too
+        ]
+    )
     result = await s.write_register("hmu", "SetMode", "auto")
     assert not result.success
-    assert "Write verification returned empty" in result.error_message
+    assert "Write verification failed" in result.error_message
 
 
 # write_register: done response but read-back returns SYN error
-# Intent: a read-back containing ERR: SYN received fails the write with that message.
+# Intent: a read-back containing ERR: SYN received fails the strict write with that message.
 # Why: bus synchronization errors must not be treated as a verified write.
-async def test_write_register_readback_syn_error() -> None:
+async def test_write_register_readback_syn_error(monkeypatch) -> None:
+    monkeypatch.setattr(EBUS, "WRITE_VERIFY_RETRY_DELAY", 0)
     s = _service()
     s._reader.readline = AsyncMock(
         side_effect=[
@@ -288,11 +341,57 @@ async def test_write_register_readback_syn_error() -> None:
             b"done\n",
             TimeoutError(),
             b"ERR: SYN received\n",
+            TimeoutError(),
+            b"ERR: SYN received\n",  # retry errors too
         ]
     )
     result = await s.write_register("ctlv2", "Z1OpMode", "night")
     assert not result.success
-    assert "Write verification failed: ERR: SYN received" in result.error_message
+    assert "Write verification failed" in result.error_message
+    assert "ERR: SYN received" in result.error_message
+
+
+# write_register: an unreadable verification read fails a strict write
+# Intent: write acked, both forced reads return no value -> strict failure, never a false success.
+# Why: the previous shape returned success with verified_value=None when the verification read failed.
+async def test_write_register_unreadable_read_strict_fails(monkeypatch) -> None:
+    monkeypatch.setattr(EBUS, "WRITE_VERIFY_RETRY_DELAY", 0)
+    s = _service()
+    s._reader.readline = AsyncMock(
+        side_effect=[
+            TimeoutError(),
+            b"done\n",
+            TimeoutError(),
+            b"\n",
+            TimeoutError(),
+            b"\n",
+        ]
+    )
+    result = await s.write_register("hmu", "SetMode", "auto")
+    assert not result.success
+    assert "Write verification failed" in result.error_message
+
+
+# write_register: a write-only register (no read message) still succeeds when
+# non-strict, because an unreadable read-back is not proof the write failed.
+# Intent: non-strict write tolerates an ERR: read-back, e.g. bai.SetModeOverride.
+# Why: ebusd exposes no read message for write-only registers, so their forced read always errors.
+async def test_write_register_unreadable_read_non_strict_succeeds(monkeypatch) -> None:
+    monkeypatch.setattr(EBUS, "WRITE_VERIFY_RETRY_DELAY", 0)
+    s = _service()
+    s._reader.readline = AsyncMock(
+        side_effect=[
+            TimeoutError(),
+            b"done\n",
+            TimeoutError(),
+            b"ERR: not found\n",
+            TimeoutError(),
+            b"ERR: not found\n",
+        ]
+    )
+    result = await s.write_register("bai", "SetModeOverride", "load", strict_verify=False)
+    assert result.success
+    assert result.verified_value is None
 
 
 # find_registers: returns raw lines from _send_find
@@ -553,6 +652,45 @@ async def test_integration_define_register() -> None:
         await s.connect()
         resp = await s.define_register("r5,ctlv2,z1RoomHumidity,test")
         assert resp == "done"
+        await s.disconnect()
+
+
+# Integration: a write applied by the controller verifies against the device
+# value via the forced bus read, not ebusd's cache.
+# Intent: write through a real socket succeeds and reports the bus read-back.
+# Why: pins the end-to-end forced read against the cache/device separation.
+async def test_integration_write_verifies_applied_value(monkeypatch) -> None:
+    monkeypatch.setattr(EBUS, "WRITE_VERIFY_RETRY_DELAY", 0)
+    async with FakeEbusdServer("arotherm_find.txt") as fake:
+        s = EbusService(host=fake.host, port=fake.port)
+        await s.connect()
+        result = await s.write_register("ctlv2", "HwcHolidayStartPeriod", "24.09.2026")
+        assert result.success
+        assert result.verified_value == "24.09.2026"
+        await s.disconnect()
+
+
+# Integration: ebusd caches the written value even when the controller does
+# not apply it (storeLastData), so a cached read can falsely verify the write.
+# A forced bus read must return the device value, and a strict write must fail.
+# Intent: with apply_writes=False the write is cached but the device keeps the old value, so a strict write fails.
+# Why: this is the issue #99 write-verification gap: a cached read cannot tell "accepted" from "applied".
+async def test_integration_write_detects_unapplied_write(monkeypatch) -> None:
+    monkeypatch.setattr(EBUS, "WRITE_VERIFY_RETRY_DELAY", 0)
+    async with FakeEbusdServer("arotherm_find.txt", apply_writes=False) as fake:
+        s = EbusService(host=fake.host, port=fake.port)
+        await s.connect()
+        # ebusd accepts and caches the write without the controller applying it.
+        await s.send_command("write -c ctlv2 HwcHolidayStartPeriod 24.09.2026")
+        cached = await s.read_register("ctlv2", "HwcHolidayStartPeriod")
+        assert cached == "24.09.2026"
+        # The forced bus read bypasses the cache and returns the device value.
+        bus_value = await s.read_register("ctlv2", "HwcHolidayStartPeriod", force=True)
+        assert bus_value == "01.01.2015"
+        # A strict write must therefore fail verification.
+        result = await s.write_register("ctlv2", "HwcHolidayStartPeriod", "25.09.2026")
+        assert not result.success
+        assert "Write verification mismatch" in result.error_message
         await s.disconnect()
 
 


### PR DESCRIPTION
Brings the v1.8.3-rc1 changes into main:

- Write verification now bypasses the ebusd cache (`read -f`) with a single retry — a write is only reported successful when the controller actually confirms it.
- CI marks `-rc` tags as prerelease.
- Changelog section for 1.8.3-rc1.

Merged via merge-commit (not squash) so this branch, which does not contain #126/#127, cannot revert them.